### PR TITLE
Add Binder link to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,10 @@ pycalphad, a library for the CALculation of PHAse Diagrams
 .. image:: http://img.shields.io/badge/benchmarked%20by-asv-green.svg
     :target: https://github.com/spacetelescope/asv
 
+.. image:: http://mybinder.org/badge.svg 
+    :target: http://mybinder.org:/repo/pycalphad/pycalphad
+    :alt: Binder
+
 **Note**: Unsolicited pull requests are _happily_ accepted!
 
 pycalphad is a free and open-source Python library for 


### PR DESCRIPTION
I was able to go into the examples and run the BinaryExamples in Binder, but it was not picking up and installing pycalphad correctly. There are probably better ways to fix this so that docker detects and installs correctly, but running the following command in the Jupyter Notebook to install it worked fine.
`! conda install -y -p /home/main/anaconda2/envs/python3 -c conda-forge pycalphad`

The performance isn't bad either. I was able to run the Al-Zn example in about 2 minutes on my i7 MacBook and it took about 5 to run in the Docker instance.