### PR TITLE
BLD/TST: Add support for Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ matrix:
         - python: 3.4
           env: DOCKER_TAG=linux-python34
         - python: 3.5
-          env: DEPLOY_ENC_LABEL=e64cfe3b4e81 DOCKER_TAG=linux-python35
+          env: DOCKER_TAG=linux-python35
+        - python: 3.6
+          env: DEPLOY_ENC_LABEL=e64cfe3b4e81 DOCKER_TAG=linux-python36
         - language: generic
           os: osx
           env: TRAVIS_PYTHON_VERSION=2.7
@@ -23,6 +25,9 @@ matrix:
         - language: generic
           os: osx
           env: TRAVIS_PYTHON_VERSION=3.5
+        - language: generic
+          os: osx
+          env: TRAVIS_PYTHON_VERSION=3.6
 
 # Setup anaconda
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,10 @@ environment:
       PYTHON_VERSION: "3.4"
       PYTHON_ARCH: "64"
 
+    - PYTHON: "C:\\Python36-conda64"
+      PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "64"
+
 install:
   # Install miniconda Python
   - "powershell ./ci/install_python.ps1"

--- a/pycalphad/io/database.py
+++ b/pycalphad/io/database.py
@@ -104,7 +104,7 @@ class Database(object): #pylint: disable=R0902
                 path, ext = os.path.splitext(fname)
                 if '.' in ext and ext[1:].lower() in format_registry:
                     fmt = ext[1:].lower()
-            except AttributeError:
+            except (AttributeError, TypeError):
                 pass
             if hasattr(fname, 'read'):
                 # File descriptor
@@ -184,7 +184,7 @@ class Database(object): #pylint: disable=R0902
             # Attempt to auto-detect the correct format based on the file extension
             try:
                 path, ext = os.path.splitext(fname)
-            except AttributeError:
+            except (AttributeError, TypeError):
                 # fname isn't actually a path, so we don't know the correct format
                 raise ValueError('\'fmt\' keyword argument must be specified when passing a file descriptor.')
             if '.' in ext and ext[1:].lower() in format_registry:
@@ -260,7 +260,7 @@ class Database(object): #pylint: disable=R0902
             # Attempt to auto-detect the correct format based on the file extension
             try:
                 path, ext = os.path.splitext(fname)
-            except AttributeError:
+            except (AttributeError, TypeError):
                 # fname isn't actually a path, so we don't know the correct format
                 raise ValueError('\'fmt\' keyword argument must be specified when passing a file descriptor.')
             if '.' in ext and ext[1:].lower() in format_registry:

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -85,6 +85,11 @@ def test_unknown_format_to_string():
 
 def test_load_from_stringio():
     "Test database loading from a file-like object."
+    test_tdb = Database(StringIO(ALCRNI_TDB))
+    assert test_tdb == REFERENCE_DBF
+
+def test_load_from_stringio_from_file():
+    "Test database loading from a file-like object with the from_file method."
     test_tdb = Database.from_file(StringIO(ALCRNI_TDB), fmt='tdb')
     assert test_tdb == REFERENCE_DBF
 


### PR DESCRIPTION
**Please check that I updated the Travis and Appveyor files correctly.** 

Closes gh-66.

Add Python 3.6 to Travis and Appveyor

Python 3.6 changed `splitext` to support path-like objects, so passing a StringIO
(file-like) now throws a `TypeError` instead of an `AttributeError`. This was
changed at 3 instances in the format determination.

A test was also written to check that passing a StringIO directly to the Database
constructor (e.g. not using the static method constructors) will proceed
correctly through the try-except block. It's the same test as from_file, it just
did not exist for the direct __new__ constructor.