### PR TITLE
FIX: Create a blacklist for compiler files

### DIFF
--- a/pycalphad/core/custom_autowrap.py
+++ b/pycalphad/core/custom_autowrap.py
@@ -99,6 +99,11 @@ def _infer_language(backend):
 def import_extension(path, modname):
     import glob
     npath = glob.glob(os.path.join(path, modname+'.*'))
+    # Blacklist fixes gh-65.
+    # We filter out any files that can be created by compilers which are not our actual compiled file.
+    # We cannot more directly search for our files because of differing platforms.
+    blacklist = ['dSYM']
+    npath = [x for x in npath if x.split('.')[-1] not in blacklist]
     if len(npath) == 1:
         npath = npath[0]
     else:


### PR DESCRIPTION
Compiler settings on certain machines can create files such as debug
symbols. This commit creates a blacklist for filtering those files out,
leaving only the compiled file. We cannot more directly find the compiled
file because only the extensions differ (e.g. '*.so' and '*.so.dysm') and
the extensions of the compiled files change on different platforms.

Fixes gh-65