### PR TITLE
TC TDB Compatibility (symbol length)

### DIFF
--- a/pycalphad/io/database.py
+++ b/pycalphad/io/database.py
@@ -15,9 +15,16 @@ except ImportError:
     from io import StringIO
 
 
+
+class DatabaseExportError(Exception):
+    """Raised when a database cannot be written."""
+    pass
+
+
 def _to_tuple(lst):
     "Convert nested list to nested tuple. Source: Martijn Pieters on StackOverflow"
     return tuple(_to_tuple(i) if isinstance(i, list) else i for i in lst)
+
 
 class Phase(object): #pylint: disable=R0903
     """

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -2,9 +2,14 @@
 The test_database module contains tests for the Database object.
 """
 from __future__ import print_function
+import warnings
+import hashlib
+from copy import deepcopy
 from pyparsing import ParseException
-from pycalphad import Database, Model
+from sympy import Symbol, Piecewise, And
+from pycalphad import Database, Model, variables as v
 from pycalphad.io.tdb import expand_keyword
+from pycalphad.io.tdb import _apply_new_symbol_names, DatabaseExportError
 from pycalphad.tests.datasets import ALCRNI_TDB, ALFE_TDB, ALNIPT_TDB, ROSE_TDB, DIFFUSION_TDB
 import nose.tools
 try:
@@ -13,6 +18,8 @@ try:
 except ImportError:
     # Python 3
     from io import StringIO
+
+warnings.simplefilter("always", UserWarning) # so we can test warnings
 
 #
 # DATABASE LOADING TESTS
@@ -24,6 +31,12 @@ except ImportError:
 # We're only checking consistency and exercising error checking here.
 REFERENCE_DBF = Database(ALCRNI_TDB)
 REFERENCE_MOD = Model(REFERENCE_DBF, ['CR', 'NI'], 'L12_FCC')
+
+INVALID_TDB_STR="""$ Note: database that invalidates the minimum compatibility subset for TDBs in different softwares
+$ functions names must be <=8 characters (Thermo-Calc)
+FUNCTION A_VERY_LONG_FUNCTION_NAME  298.15 -42; 6000 N !
+FUNCTION COMPAT 298.15 +9001; 6000 N !
+"""
 
 def test_database_eq():
     "Database equality comparison."
@@ -64,9 +77,67 @@ def test_load_from_string():
 def test_export_import():
     "Equivalence of re-imported database to original."
     test_dbf = Database(ALNIPT_TDB)
-    assert Database.from_string(test_dbf.to_string(fmt='tdb'), fmt='tdb') == test_dbf
+    assert Database.from_string(test_dbf.to_string(fmt='tdb', if_incompatible='ignore'), fmt='tdb') == test_dbf
     test_dbf = Database(ALFE_TDB)
     assert Database.from_string(test_dbf.to_string(fmt='tdb'), fmt='tdb') == test_dbf
+
+def test_incompatible_db_warns_by_default():
+    "Symbol names too long for Thermo-Calc warn and write the database as given by default."
+    test_dbf = Database.from_string(INVALID_TDB_STR, fmt='tdb')
+    with warnings.catch_warnings(record=True) as w:
+        invalid_dbf = test_dbf.to_string(fmt='tdb')
+        assert len(w) > 0
+    assert test_dbf == Database.from_string(invalid_dbf, fmt='tdb')
+
+@nose.tools.raises(DatabaseExportError)
+def test_incompatible_db_raises_error_with_kwarg_raise():
+    "Symbol names too long for Thermo-Calc raise error on write with kwarg raise."
+    test_dbf = Database.from_string(INVALID_TDB_STR, fmt='tdb')
+    test_dbf.to_string(fmt='tdb', if_incompatible='raise')
+
+def test_incompatible_db_warns_with_kwarg_warn():
+    "Symbol names too long for Thermo-Calc warn and write the database as given."
+    test_dbf = Database.from_string(INVALID_TDB_STR, fmt='tdb')
+    with warnings.catch_warnings(record=True) as w:
+        invalid_dbf = test_dbf.to_string(fmt='tdb', if_incompatible='warn')
+        assert len(w) > 0
+    assert test_dbf == Database.from_string(invalid_dbf, fmt='tdb')
+
+def test_incompatible_db_ignores_with_kwarg_ignore():
+    "Symbol names too long for Thermo-Calc are ignored the database written as given."
+    test_dbf = Database.from_string(INVALID_TDB_STR, fmt='tdb')
+    with warnings.catch_warnings(record=True) as w:
+        invalid_dbf = test_dbf.to_string(fmt='tdb', if_incompatible='ignore')
+        assert len(w) == 0
+    assert test_dbf == Database.from_string(invalid_dbf, fmt='tdb')
+
+def test_incompatible_db_mangles_names_with_kwarg_fix():
+    "Symbol names too long for Thermo-Calc are mangled and replaced in symbol names, symbol expressions, and parameter expressions."
+    test_dbf = Database.from_string(INVALID_TDB_STR, fmt='tdb')
+    test_dbf_copy = deepcopy(test_dbf)
+    mangled_dbf = Database.from_string(test_dbf.to_string(fmt='tdb', if_incompatible='fix'), fmt='tdb')
+    # check that the long function name was hashed correctly
+    a_very_long_function_name_hash_symbol = 'F' + str(hashlib.md5('A_VERY_LONG_FUNCTION_NAME'.encode('UTF-8')).hexdigest()).upper()[:7]
+    assert a_very_long_function_name_hash_symbol in mangled_dbf.symbols.keys()
+    assert 'COMPAT' in mangled_dbf.symbols.keys() # test that compatible keys are not removed
+    assert test_dbf_copy == test_dbf # make sure test_dbf has not mutated
+    assert test_dbf != mangled_dbf # also make sure test_dbf has not mutated
+
+def test_symbol_names_are_propagated_through_symbols_and_parameters():
+    """A map of old symbol names to new symbol names should propagate through symbol and parameter SymPy expressions"""
+    tdb_propagate_str = """$ Mangled function names should propagate through other symbols and parameters
+    ELEMENT A PH 0 0 0 !
+    FUNCTION FN1  298.15 -42; 6000 N !
+    FUNCTION FN2 298.15 FN1#; 6000 N !
+    PARAMETER G(PH,A;0) 298.15 FN1# + FN2#; 6000 N !
+    """
+    test_dbf = Database.from_string(tdb_propagate_str, fmt='tdb')
+    rename_map = {'FN1': 'RENAMED_FN1', 'FN2': 'RENAMED_FN2'}
+    _apply_new_symbol_names(test_dbf, rename_map)
+    assert 'RENAMED_FN1' in test_dbf.symbols
+    assert 'FN1' not in test_dbf.symbols # check that the old key was removed
+    assert test_dbf.symbols['RENAMED_FN2'] == Piecewise((Symbol('RENAMED_FN1'), And(v.T < 6000.0, v.T >= 298.15)), (0, True))
+    assert test_dbf._parameters.all()[0]['parameter'] == Piecewise((Symbol('RENAMED_FN1')+Symbol('RENAMED_FN2'), And(v.T < 6000.0, v.T >= 298.15)), (0, True))
 
 @nose.tools.raises(ValueError)
 def test_unspecified_format_from_string():

--- a/pycalphad/tests/test_model.py
+++ b/pycalphad/tests/test_model.py
@@ -35,7 +35,7 @@ def test_model_ne():
 
 def test_export_import():
     "Equivalence of Model using re-imported database."
-    test_model = Model(Database.from_string(ALNIPT_DBF.to_string(fmt='tdb'), fmt='tdb'), ['PT', 'NI', 'VA'], 'FCC_L12')
+    test_model = Model(Database.from_string(ALNIPT_DBF.to_string(fmt='tdb', if_incompatible='ignore'), fmt='tdb'), ['PT', 'NI', 'VA'], 'FCC_L12')
     ref_model = Model(ALNIPT_DBF, ['NI', 'PT', 'VA'], 'FCC_L12')
     assert test_model == ref_model
 


### PR DESCRIPTION
This limitation and other limitations as a subset of the different TDB implementations should be handled by pycalphad so that any output database can work on any thermodynamics software. Some of these limitations can be handled automatically, as in the case of line length limits, others cannot. These changes typically break `DB == DB.read(DB.write())`, so they require explicit handling from the user. 

Here, Thermo-Calc TDBs require symbols to be <= 8 characters

This PR:
- Provides a reasonably scalable (rough) framework to optionally sanitize TDBs for compatibility with the following options in the case of an invalid database
    - 'raise' (default): raise an error if the TDB is invalid and cannot be automatically compatible 
    - 'warn': Issue a warning that the database is invalid and write it as is
    - 'ignore': Silently write the invalid database as is
    - 'fix': Make any changes required for compatibility
- Implement optional name mangling of long symbol names to 8 characters using md5 hashing
- Adds documentation to `io.tdb.write_tdb` to clarify the goals and functionality
- Includes tests for the newly added documentation and updates old tests to conform.

Future features:
- Use and improve the framework to add more compatibility fixes (listed in the docstring)
- (Possibly) Add the ability to reconstitute the original database in cases where names have been mangled