### PR TITLE
Fix filtering of phases with composition >1

### DIFF
--- a/pycalphad/core/eqsolver.pyx
+++ b/pycalphad/core/eqsolver.pyx
@@ -413,9 +413,9 @@ def _solve_eq_at_conditions(dbf, comps, properties, phase_records, conds_keys, v
             # Skip this condition set
             # We silently allow this to make 2-D composition mapping easier
             prop_MU_values[it.multi_index] = np.nan
-            prop_NP_values[it.multi_index + np.index_exp[:len(phases)]] = np.nan
-            prop_Phase_values[it.multi_index + np.index_exp[:len(phases)]] = ''
-            prop_X_values[it.multi_index + np.index_exp[:len(phases)]] = np.nan
+            prop_NP_values[it.multi_index + np.index_exp[:]] = np.nan
+            prop_Phase_values[it.multi_index + np.index_exp[:]] = ''
+            prop_X_values[it.multi_index + np.index_exp[:]] = np.nan
             prop_Y_values[it.multi_index] = np.nan
             prop_GM_values[it.multi_index] = np.nan
             it.iternext()

--- a/pycalphad/plot/eqplot.py
+++ b/pycalphad/plot/eqplot.py
@@ -95,8 +95,6 @@ def eqplot(eq, ax=None, x=None, y=None, z=None, phases=None, **kwargs):
         raise NotImplementedError('Plotting {} is not yet implemented'.format(x))
     # Have to do some extra work to get all potential values for the given tie lines
     temps = np.take(eq[str(y)].values, two_phase_indices[list(str(i) for i in conds.keys()).index(str(y))])
-    if ax is None:
-        ax = plt.gca()
     # Draw zero phase-fraction lines
     ax.scatter(compositions[..., 0], temps, s=3, c=plotcolors[..., 0], edgecolors='None', zorder=2, **kwargs)
     ax.scatter(compositions[..., 1], temps, s=3, c=plotcolors[..., 1], edgecolors='None', zorder=2, **kwargs)


### PR DESCRIPTION
As discussed in #4, conditions where the total composition is > 1 should be skipped, but instead were referencing the `phases` variable which does not exist.

Also a small fix some duplicate code in `eqplot` is included because line 58 ensures that `ax` will never be `None` here. 