### PR TITLE
ENH: TDB compatibility: all chars after command delimiters should be neglected

### DIFF
--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -826,13 +826,12 @@ def read_tdb(dbf, fd):
     splitlines = [' '.join(k.split()) for k in splitlines]
     # Remove comments
     splitlines = [k.strip().split('$', 1)[0] for k in splitlines]
+    # Remove everything after command delimiter, but keep the delimiter so we can split later
+    splitlines = [k.split('!')[0] + ('!' if len(k.split('!')) > 1 else '') for k in splitlines]
     # Combine everything back together
     lines = ' '.join(splitlines)
     # Now split by the command delimeter
     commands = lines.split('!')
-    # Filter out comments one more time
-    # It's possible they were at the end of a command
-    commands = [k.strip() for k in commands if not k.startswith("$")]
 
     # Temporary storage while we process type definitions
     dbf.tdbtypedefs = {}

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -139,6 +139,17 @@ def test_symbol_names_are_propagated_through_symbols_and_parameters():
     assert test_dbf.symbols['RENAMED_FN2'] == Piecewise((Symbol('RENAMED_FN1'), And(v.T < 6000.0, v.T >= 298.15)), (0, True))
     assert test_dbf._parameters.all()[0]['parameter'] == Piecewise((Symbol('RENAMED_FN1')+Symbol('RENAMED_FN2'), And(v.T < 6000.0, v.T >= 298.15)), (0, True))
 
+def test_tdb_content_after_line_end_is_neglected():
+    """Any characters after the line ending '!' are neglected as in commercial software."""
+    tdb_line_ending_str = """$ Characters after line endings should be discarded.
+    PARAMETER G(PH,A;0) 298.15 +42; 6000 N ! SHOULD_NOT_RAISE_ERROR
+    $ G(PH,C;0) should not parse
+    PARAMETER G(PH,B;0) 298.15 +9001; 6000 N ! PARAMETER G(PH,C;0) 298.15 +2; 600 N !
+    PARAMETER G(PH,D;0) 298.15 -42; 6000 N !
+    """
+    test_dbf = Database.from_string(tdb_line_ending_str, fmt='tdb')
+    assert len(test_dbf._parameters) == 3
+
 @nose.tools.raises(ValueError)
 def test_unspecified_format_from_string():
     "from_string: Unspecified string format raises ValueError."


### PR DESCRIPTION
Thermo-Calc will not parse commands or other strings after the command delimiter. Previously pycalphad only removed comments after command delimiters. This commit makes pycalphad conform  to the behavior of parsing out everything on the line after the delimiter and includes a test for this behavior.

Another approach might be to only strip characters after the last delimiter on a line, which would be an overall improved approach in the case that multiple commands were on a single line (or an entire TDB on a single line) even though I have never encountered such a case in the wild. I'm not sure how other commercial software handles multiple commands per line.