### PR TITLE
FIX: equilibrium: Unary calculation and property calculation

### DIFF
--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -461,7 +461,7 @@ def calculate(dbf, comps, phases, mode=None, output='GM', fake_points=False, bro
             continue
         if (not isinstance(mod, CompiledModel)) or (output != 'GM'):
             if isinstance(mod, CompiledModel):
-                mod = Model(dbf, comps, phase_name)
+                mod = Model(dbf, comps, phase_name, parameters=parameters)
             # Construct an ordered list of the variables
             variables, sublattice_dof = generate_dof(phase_obj, mod.components)
             # Build the "fast" representation of that model

--- a/pycalphad/core/compiled_model.pyx
+++ b/pycalphad/core/compiled_model.pyx
@@ -73,13 +73,20 @@ cdef public class CompiledModel(object)[type CompiledModelType, object CompiledM
             for comp in sublattice:
                 self.variables.append(v.Y(phase_name, idx, comp))
         parameters = parameters if parameters is not None else {}
+        renamed_params = []
+        for param, val in parameters.items():
+            if not isinstance(param, Symbol):
+                parameters[Symbol(param)] = val
+                renamed_params.append(param)
+        for param in renamed_params:
+            parameters.pop(param)
+        if isinstance(parameters, dict):
+            parameters = OrderedDict(sorted(parameters.items(), key=str))
+        param_symbols = tuple(parameters.keys())
         self._debug = _debug
         if _debug:
             debugmodel = Model(dbe, comps, phase_name, parameters)
             out = debugmodel.energy
-            if isinstance(parameters, dict):
-                parameters = OrderedDict(sorted(parameters.items(), key=str))
-            param_symbols = tuple(parameters.keys())
             undefs = list(out.atoms(Symbol) - out.atoms(v.StateVariable) - set(param_symbols))
             for undef in undefs:
                 out = out.xreplace({undef: float(0)})

--- a/pycalphad/core/eqsolver.pyx
+++ b/pycalphad/core/eqsolver.pyx
@@ -394,8 +394,7 @@ def _solve_eq_at_conditions(comps, properties, phase_records, grid, conds_keys, 
             if (num_phases == 1) and np.all(np.asarray(composition_sets[0].dof[2:]) == 1.):
                 # Single phase with zero internal degrees of freedom, can't do any refinement
                 # TODO: In the future we may be able to refine other degrees of freedom like temperature
-                # Chemical potentials have no meaning for this case
-                chemical_potentials[:] = np.nan
+                chemical_potentials[:] = energy
                 converged = True
                 break
 

--- a/pycalphad/core/lower_convex_hull.py
+++ b/pycalphad/core/lower_convex_hull.py
@@ -419,10 +419,13 @@ def lower_convex_hull(global_grid, result_array, verbose=False):
     comp_coord_shape = tuple(len(result_array.coords[cond]) for cond in comp_conds)
     while not it.finished:
         indep_idx = it.multi_index[:len(indep_conds)]
-        comp_idx = np.ravel_multi_index(it.multi_index[len(indep_conds):], comp_coord_shape)
+        if len(comp_conds) > 0:
+            comp_idx = np.ravel_multi_index(it.multi_index[len(indep_conds):], comp_coord_shape)
+            idx_comp_values = comp_values[comp_idx]
+        else:
+            idx_comp_values = np.atleast_1d(1.)
         idx_global_grid_X_values = global_grid_X_values[indep_idx]
         idx_global_grid_GM_values = global_grid_GM_values[indep_idx]
-        idx_comp_values = comp_values[comp_idx]
         idx_result_array_MU_values = result_array_MU_values[it.multi_index]
         idx_result_array_NP_values = result_array_NP_values[it.multi_index]
         idx_result_array_GM_values = result_array_GM_values[it.multi_index]

--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -83,13 +83,13 @@ class Model(object):
         # This makes xreplace work with the symbols dict
         symbols = {Symbol(s): val for s, val in dbe.symbols.items()}
 
-        if parameters is not None:
-            symbols.update([(Symbol(s), val) for s, val in parameters.items()])
         def wrap_symbol(obj):
             if isinstance(obj, Symbol):
                 return obj
             else:
                 return Symbol(obj)
+        if parameters is not None:
+            symbols.update([(wrap_symbol(s), val) for s, val in parameters.items()])
         self._symbols = {wrap_symbol(key): value for key, value in symbols.items()}
 
         self.models = OrderedDict()

--- a/pycalphad/tests/test_equilibrium.py
+++ b/pycalphad/tests/test_equilibrium.py
@@ -291,3 +291,10 @@ def test_unused_equilibrium_kwarg_warns():
         categories = [warning.__dict__['_category_name'] for warning in w]
         assert 'UserWarning' in categories
         assert len(w) == 1 # make sure we don't raise other warnings later that make this test falsely pass
+
+def test_eq_unary_issue78():
+    "Unary equilibrium calculations work with property calculations."
+    eq = equilibrium(ALFE_DBF, ['AL', 'VA'], 'FCC_A1', {v.T: 1200, v.P: 101325}, output='SM')
+    np.testing.assert_allclose(eq.SM, 68.143273)
+    eq = equilibrium(ALFE_DBF, ['AL', 'VA'], 'FCC_A1', {v.T: 1200, v.P: 101325}, parameters={'GHSERAL': 1000})
+    np.testing.assert_allclose(eq.GM, 1000)

--- a/pycalphad/tests/test_equilibrium.py
+++ b/pycalphad/tests/test_equilibrium.py
@@ -296,5 +296,6 @@ def test_eq_unary_issue78():
     "Unary equilibrium calculations work with property calculations."
     eq = equilibrium(ALFE_DBF, ['AL', 'VA'], 'FCC_A1', {v.T: 1200, v.P: 101325}, output='SM')
     np.testing.assert_allclose(eq.SM, 68.143273)
-    eq = equilibrium(ALFE_DBF, ['AL', 'VA'], 'FCC_A1', {v.T: 1200, v.P: 101325}, parameters={'GHSERAL': 1000})
+    eq = equilibrium(ALFE_DBF, ['AL', 'VA'], 'FCC_A1', {v.T: 1200, v.P: 101325}, output='SM', parameters={'GHSERAL': 1000})
     np.testing.assert_allclose(eq.GM, 1000)
+    np.testing.assert_allclose(eq.SM, 0)


### PR DESCRIPTION
This PR does the following:

- Fixes #78 
- Fixes the `output` keyword argument so it actually works again (this was a gap in the test suite)
- Fixes the `parameters` keyword argument so it works with `CompiledModel` and is propagated everywhere. Also a `str` to `sympy.Symbol` conversion issue is properly handled now.

There is still a bug where undefined FUNCTIONs in PARAMETERs will raise an error for `CompiledModel` instead of just setting to zero and warning the user like `Model` does. There's some additional work in figuring out missing parameters for `CompiledModel` since `sympy.atoms` is unavailable in that mode, so I'm not sure the best way yet.