### PR TITLE
FIX: Improve tests that check warnings.

### DIFF
--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -86,7 +86,9 @@ def test_incompatible_db_warns_by_default():
     test_dbf = Database.from_string(INVALID_TDB_STR, fmt='tdb')
     with warnings.catch_warnings(record=True) as w:
         invalid_dbf = test_dbf.to_string(fmt='tdb')
-        assert len(w) == 1
+        assert len(w) >= 1
+        expected_string_fragment = 'Ignoring that the following function names are beyond the 8 character TDB limit'
+        assert any([expected_string_fragment in str(warning.message) for warning in w])
     assert test_dbf == Database.from_string(invalid_dbf, fmt='tdb')
 
 @nose.tools.raises(DatabaseExportError)
@@ -100,7 +102,9 @@ def test_incompatible_db_warns_with_kwarg_warn():
     test_dbf = Database.from_string(INVALID_TDB_STR, fmt='tdb')
     with warnings.catch_warnings(record=True) as w:
         invalid_dbf = test_dbf.to_string(fmt='tdb', if_incompatible='warn')
-        assert len(w) == 1
+        assert len(w) >= 1
+        expected_string_fragment = 'Ignoring that the following function names are beyond the 8 character TDB limit'
+        assert any([expected_string_fragment in str(warning.message) for warning in w])
     assert test_dbf == Database.from_string(invalid_dbf, fmt='tdb')
 
 def test_incompatible_db_ignores_with_kwarg_ignore():
@@ -108,7 +112,8 @@ def test_incompatible_db_ignores_with_kwarg_ignore():
     test_dbf = Database.from_string(INVALID_TDB_STR, fmt='tdb')
     with warnings.catch_warnings(record=True) as w:
         invalid_dbf = test_dbf.to_string(fmt='tdb', if_incompatible='ignore')
-        assert len(w) == 0
+        not_expected_string_fragment = 'Ignoring that the following function names are beyond the 8 character TDB limit'
+        assert all([not_expected_string_fragment not in str(warning.message) for warning in w])
     assert test_dbf == Database.from_string(invalid_dbf, fmt='tdb')
 
 def test_incompatible_db_mangles_names_with_kwarg_fix():

--- a/pycalphad/tests/test_equilibrium.py
+++ b/pycalphad/tests/test_equilibrium.py
@@ -288,9 +288,11 @@ def test_unused_equilibrium_kwarg_warns():
     "Check that an unused keyword argument raises a warning"
     with warnings.catch_warnings(record=True) as w:
         equilibrium(ALFE_DBF, ['AL', 'FE', 'VA'], 'FCC_A1', {v.T: 1300, v.P: 101325, v.X('AL'): 0}, unused_kwarg='should raise a warning')
+        assert len(w) >= 1
         categories = [warning.__dict__['_category_name'] for warning in w]
         assert 'UserWarning' in categories
-        assert len(w) == 1 # make sure we don't raise other warnings later that make this test falsely pass
+        expected_string_fragment = 'keyword arguments were passed, but unused'
+        assert any([expected_string_fragment in str(warning.message) for warning in w])
 
 def test_eq_unary_issue78():
     "Unary equilibrium calculations work with property calculations."


### PR DESCRIPTION
Warning testing is independent of the number of warnings raised and depends instead on specific string fragments.