### PR TITLE
FIX: future sympy version compatibility issue with gmpy2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     license='MIT',
     long_description=read('README.rst'),
     url='https://pycalphad.org/',
-    install_requires=['matplotlib', 'pandas', 'xarray!=0.8', 'sympy', 'pyparsing', 'Cython>=0.24',
+    install_requires=['matplotlib', 'pandas', 'xarray!=0.8', 'sympy>1.1', 'pyparsing', 'Cython>=0.24',
                       'tinydb', 'scipy', 'numpy>=1.9', 'dask[complete]>=0.10', 'dill'],
     classifiers=[
         # How mature is this project? Common values are


### PR DESCRIPTION
Once sympy/sympy#12895 is merged and makes it into a release, we should merge this PR and release. We should also update the pycalphad feedstock repository on conda-forge.
This will address an issue where some users with gmpy2 installed (an optional sympy dependency) will experience errors.