### PR TITLE
FIX: Database.write should raise if one of the specified values is not entered.

### DIFF
--- a/pycalphad/io/database.py
+++ b/pycalphad/io/database.py
@@ -284,12 +284,13 @@ class Database(object): #pylint: disable=R0902
             format_registry[fmt].write(self, fname, **write_kwargs)
         else:
             if os.path.exists(fname) and if_exists != 'overwrite':
-                if if_exists == 'raise':
-                    raise FileExistsError('File {} already exists'.format(fname))
-                elif if_exists == 'rename':
+                if if_exists == 'rename':
                     writetime = datetime.now()
                     fname = os.path.splitext(fname)
                     fname = fname[0] + "." + writetime.strftime("%Y-%m-%d-%H-%M") + fname[1]
+                else:
+                    # equivalent to 'raise'
+                    raise FileExistsError('File {} already exists'.format(fname))
             with open(fname, mode='w') as fd:
                 format_registry[fmt].write(self, fd, **write_kwargs)
 

--- a/pycalphad/io/database.py
+++ b/pycalphad/io/database.py
@@ -15,7 +15,13 @@ except ImportError:
     # Python 3
     from io import StringIO
 
-
+# handle missing FileExistsError in Python2
+try:
+    FileExistsError = FileExistsError
+except NameError:
+    class FileExistsError(OSError):
+        """Python 2 backported FileExistsError wrapping OSError"""
+        pass
 
 class DatabaseExportError(Exception):
     """Raised when a database cannot be written."""

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -4,6 +4,7 @@ The test_database module contains tests for the Database object.
 from __future__ import print_function
 import warnings
 import hashlib
+import os
 from copy import deepcopy
 from pyparsing import ParseException
 from sympy import Symbol, Piecewise, And
@@ -154,6 +155,39 @@ def test_tdb_content_after_line_end_is_neglected():
     """
     test_dbf = Database.from_string(tdb_line_ending_str, fmt='tdb')
     assert len(test_dbf._parameters) == 3
+
+def _remove_file_with_name_testwritedb():
+    fname = 'testwritedb.tdb'
+    os.remove(fname)
+
+@nose.tools.with_setup(None, _remove_file_with_name_testwritedb)
+@nose.tools.raises(FileExistsError)
+def test_to_file_defaults_to_raise_if_exists():
+    "Attempting to use Database.to_file should raise by default if it exists"
+    fname = 'testwritedb.tdb'
+    test_dbf = Database(ALNIPT_TDB)
+    test_dbf.to_file(fname)  # establish the initial file
+    test_dbf.to_file(fname)  # test if_exists behavior
+
+@nose.tools.with_setup(None, _remove_file_with_name_testwritedb)
+@nose.tools.raises(FileExistsError)
+def test_to_file_raises_with_bad_if_exists_argument():
+    "Database.to_file should raise if a bad behavior string is passed to if_exists"
+    fname = 'testwritedb.tdb'
+    test_dbf = Database(ALNIPT_TDB)
+    test_dbf.to_file(fname)  # establish the initial file
+    test_dbf.to_file(fname, if_exists='TEST_BAD_ARGUMENT')  # test if_exists behavior
+
+@nose.tools.with_setup(None, _remove_file_with_name_testwritedb)
+def test_to_file_overwrites_with_if_exists_argument():
+    "Database.to_file should overwrite if 'overwrite' is passed to if_exists"
+    fname = 'testwritedb.tdb'
+    test_dbf = Database(ALNIPT_TDB)
+    test_dbf.to_file(fname)  # establish the initial file
+    inital_modification_time = os.path.getmtime(fname)
+    test_dbf.to_file(fname, if_exists='overwrite')  # test if_exists behavior
+    overwrite_modification_time = os.path.getmtime(fname)
+    assert overwrite_modification_time > inital_modification_time
 
 @nose.tools.raises(ValueError)
 def test_unspecified_format_from_string():

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 from pyparsing import ParseException
 from sympy import Symbol, Piecewise, And
 from pycalphad import Database, Model, variables as v
+from pycalphad.io.database import FileExistsError
 from pycalphad.io.tdb import expand_keyword
 from pycalphad.io.tdb import _apply_new_symbol_names, DatabaseExportError
 from pycalphad.tests.datasets import ALCRNI_TDB, ALFE_TDB, ALNIPT_TDB, ROSE_TDB, DIFFUSION_TDB


### PR DESCRIPTION
Closes #94.

This handles cases where `if_exists` is passed a string that is not in ['raise', 'overwrite', 'rename']. In that case, we should raise rather than overwrite.