### PR TITLE
BLD/FIX: use `set -e` to to exit on failure of any command in travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ matrix:
 
 # Setup anaconda
 before_install:
+  - set -e # Exit immediately if a command exits with a non-zero status
   - |
       if [ -z "$DOCKER_TAG" ]; then
         ./ci/travis_legacy_deps.sh


### PR DESCRIPTION
See http://steven.casagrande.io/articles/travis-ci-and-if-statements/ and https://github.com/travis-ci/travis-ci/issues/1066

Since we currently don't have anything that would warrant continuing after a non-zero exit code, this solution is the simplest.

Closes #107