### PR TITLE
ENH: Species support in Database and TDB read/write

### DIFF
--- a/pycalphad/io/database.py
+++ b/pycalphad/io/database.py
@@ -43,10 +43,13 @@ class Specie(object):
         Name of the specie
     constituents : dict
         Dictionary of {element: quantity} where the element is a string and the quantity a float.
+    charge : int
+        Integer charge. Can be positive or negative.
     """
-    def __init__(self, name, constituents):
+    def __init__(self, name, constituents, charge):
         self.name = name
         self.constituents = constituents
+        self.charge = charge
 
     def __eq__(self, other):
         """Two species are the same if their names and constituents are the same."""

--- a/pycalphad/io/database.py
+++ b/pycalphad/io/database.py
@@ -33,6 +33,31 @@ def _to_tuple(lst):
     return tuple(_to_tuple(i) if isinstance(i, list) else i for i in lst)
 
 
+class Specie(object):
+    """
+    A specie in the database.
+
+    Attributes
+    ----------
+    name : string
+        Name of the specie
+    constituents : dict
+        Dictionary of {element: quantity} where the element is a string and the quantity a float.
+    """
+    def __init__(self, name, constituents):
+        self.name = name
+        self.constituents = constituents
+
+    def __eq__(self, other):
+        """Two species are the same if their names and constituents are the same."""
+        if isinstance(other, self.__class__):
+            return (self.name == other.name) and (self.constituents == other.constituents)
+        else:
+            return False
+
+    def __hash__(self):
+        return hash(self.name)
+
 class Phase(object): #pylint: disable=R0903
     """
     Phase in the database.
@@ -320,7 +345,7 @@ class Database(object): #pylint: disable=R0902
 
     def __str__(self):
         result = 'Elements: {0}\n'.format(sorted(self.elements))
-        result += 'Species: {0}\n'.format(sorted(self.species))
+        result += 'Species: {0}\n'.format(sorted(self.species, key=lambda s: s.name))
         for name, phase in sorted(self.phases.items()):
             result += str(phase)+'\n'
         result += '{0} symbols in database\n'.format(len(self.symbols))

--- a/pycalphad/io/database.py
+++ b/pycalphad/io/database.py
@@ -33,9 +33,9 @@ def _to_tuple(lst):
     return tuple(_to_tuple(i) if isinstance(i, list) else i for i in lst)
 
 
-class Specie(object):
+class Species(object):
     """
-    A specie in the database.
+    A species in the database.
 
     Attributes
     ----------

--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -329,8 +329,8 @@ def _setitem_raise_duplicates(dictionary, key, value):
     dictionary[key] = value
 
 _TDB_PROCESSOR = {
-    'ELEMENT': lambda db, el: db.elements.add(el),
-    'SPECIES': _unimplemented,
+    'ELEMENT': lambda db, el: (db.elements.add(el), db.species.add(el)),
+    'SPECIES': lambda db, sp_name, sp_comp: db.species.add(sp_name),
     'TYPE_DEFINITION': _process_typedef,
     'FUNCTION': lambda db, name, sym: _setitem_raise_duplicates(db.symbols, name, sym),
     'DEFINE_SYSTEM_DEFAULT': _unimplemented,

--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -15,7 +15,7 @@ from sympy.printing.str import StrPrinter
 from sympy.core.mul import _keep_coeff
 from sympy.printing.precedence import precedence
 from pycalphad import Database
-from pycalphad.io.database import DatabaseExportError, Specie
+from pycalphad.io.database import DatabaseExportError, Species
 import pycalphad.variables as v
 from pycalphad.io.tdb_keywords import expand_keyword, TDB_PARAM_TYPES
 from collections import defaultdict, namedtuple
@@ -324,11 +324,11 @@ def _unimplemented(*args, **kwargs): #pylint: disable=W0613
     """
     pass
 
-def _process_specie(db, sp_name, sp_comp, charge=0, *args):
-    """Add a species to the Database. If charge not specified, the Specie will be neutral."""
+def _process_species(db, sp_name, sp_comp, charge=0, *args):
+    """Add a species to the Database. If charge not specified, the Species will be neutral."""
     # process the species composition list of [element1, ratio1, element2, ratio2, ..., elementN, ratioN]
     constituents = {sp_comp[i]: sp_comp[i+1] for i in range(0, len(sp_comp), 2)}
-    db.species.add(Specie(sp_name, constituents, charge=charge))
+    db.species.add(Species(sp_name, constituents, charge=charge))
 
 def _setitem_raise_duplicates(dictionary, key, value):
     if key in dictionary:
@@ -336,8 +336,8 @@ def _setitem_raise_duplicates(dictionary, key, value):
     dictionary[key] = value
 
 _TDB_PROCESSOR = {
-    'ELEMENT': lambda db, el: (db.elements.add(el), _process_specie(db, el, [el, 1], 0)),
-    'SPECIES': _process_specie,
+    'ELEMENT': lambda db, el: (db.elements.add(el), _process_species(db, el, [el, 1], 0)),
+    'SPECIES': _process_species,
     'TYPE_DEFINITION': _process_typedef,
     'FUNCTION': lambda db, name, sym: _setitem_raise_duplicates(db.symbols, name, sym),
     'DEFINE_SYSTEM_DEFAULT': _unimplemented,
@@ -681,8 +681,8 @@ def write_tdb(dbf, fd, groupby='subsystem', if_incompatible='warn'):
                 charge = '/{}{}'.format(charge_sign, species.charge)
             else:
                 charge = ''
-            specie_constituents = ''.join(['{}{}'.format(el, val) for el, val in sorted(species.constituents.items(), key=lambda t: t[0])])
-            output += "SPECIES {0} {1}{2} !\n".format(species.name.upper(), specie_constituents, charge)
+            species_constituents = ''.join(['{}{}'.format(el, val) for el, val in sorted(species.constituents.items(), key=lambda t: t[0])])
+            output += "SPECIES {0} {1}{2} !\n".format(species.name.upper(), species_constituents, charge)
     if len(dbf.species) > 0:
         output += "\n"
     # Write FUNCTION block

--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -672,7 +672,17 @@ def write_tdb(dbf, fd, groupby='subsystem', if_incompatible='warn'):
         output += "\n"
     for species in sorted(dbf.species, key=lambda s: s.name):
         if species.name not in dbf.elements:
-            output += "SPECIES {0} {1}!\n".format(species.name.upper(), ''.join(['{}{}'.format(el, val) for el, val in species.constituents.items()]))
+            # construct the charge part of the specie
+            if species.charge != 0:
+                if species.charge >0:
+                    charge_sign = '+'
+                else:
+                    charge_sign = ''
+                charge = '/{}{}'.format(charge_sign, species.charge)
+            else:
+                charge = ''
+            specie_constituents = ''.join(['{}{}'.format(el, val) for el, val in species.constituents.items()])
+            output += "SPECIES {0} {1}{2} !\n".format(species.name.upper(), specie_constituents, charge)
     if len(dbf.species) > 0:
         output += "\n"
     # Write FUNCTION block

--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -793,8 +793,8 @@ def write_tdb(dbf, fd, groupby='subsystem', if_incompatible='warn'):
                                                         param_to_write.parameter_order,
                                                         exprx)
     if groupby == 'subsystem':
-        for num_elements in range(1, 5):
-            subsystems = list(itertools.combinations(sorted([i.upper() for i in dbf.elements]), num_elements))
+        for num_species in range(1, 5):
+            subsystems = list(itertools.combinations(sorted([i.name.upper() for i in dbf.species]), num_species))
             for subsystem in subsystems:
                 parameters = sorted(param_sorted[subsystem])
                 if len(parameters) > 0:
@@ -806,7 +806,7 @@ def write_tdb(dbf, fd, groupby='subsystem', if_incompatible='warn'):
                     for parameter in parameters:
                         output += write_parameter(parameter)
         # Don't generate combinatorics for multi-component subsystems or we'll run out of memory
-        if len(dbf.elements) > 4:
+        if len(dbf.species) > 4:
             subsystems = [k for k in param_sorted.keys() if len(k) > 4]
             for subsystem in subsystems:
                 parameters = sorted(param_sorted[subsystem])

--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -681,7 +681,7 @@ def write_tdb(dbf, fd, groupby='subsystem', if_incompatible='warn'):
                 charge = '/{}{}'.format(charge_sign, species.charge)
             else:
                 charge = ''
-            specie_constituents = ''.join(['{}{}'.format(el, val) for el, val in species.constituents.items()])
+            specie_constituents = ''.join(['{}{}'.format(el, val) for el, val in sorted(species.constituents.items(), key=lambda t: t[0])])
             output += "SPECIES {0} {1}{2} !\n".format(species.name.upper(), specie_constituents, charge)
     if len(dbf.species) > 0:
         output += "\n"

--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -200,7 +200,7 @@ def _tdb_grammar(): #pylint: disable=R0914
     cmd_element = TCCommand('ELEMENT') + Word(alphas+'/-', min=1, max=2) + Optional(Suppress(ref_phase_name)) + \
         Optional(Suppress(OneOrMore(float_number))) + LineEnd()
     # SPECIES
-    cmd_species = TCCommand('SPECIES') + species_name + Group(OneOrMore(Word(alphas, min=1, max=2) + float_number)) + Optional(Suppress('/') + pos_neg_int_number) + LineEnd()
+    cmd_species = TCCommand('SPECIES') + species_name + Group(OneOrMore(Word(alphas, min=1, max=2) + Optional(float_number, default=1.0))) + Optional(Suppress('/') + pos_neg_int_number) + LineEnd()
     # TYPE_DEFINITION
     cmd_typedef = TCCommand('TYPE_DEFINITION') + \
         Suppress(White()) + CharsNotIn(' !', exact=1) + SkipTo(LineEnd())

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -308,6 +308,33 @@ SPECIES ALO3/2                      AL1O1.5!
     """
     test_dbf = Database.from_string(tdb_specie_str, fmt='tdb')
     assert len(test_dbf.species) == 18
+    specie_dict = {sp.name: sp for sp in test_dbf.species}
+    assert specie_dict['AL'].charge == 0
+    assert specie_dict['O2'].constituents['O'] == 2
+    assert specie_dict['AL1O2'].constituents['AL'] == 1
+    assert specie_dict['AL1O2'].constituents['O'] == 2
+    assert specie_dict['ALO3/2'].constituents['O'] == 1.5
+
+
+def test_tdb_species_with_charge_are_parsed_correctly():
+    """The TDB species that have a charge should be properly parsed."""
+    tdb_specie_str = """
+ELEMENT /-   ELECTRON_GAS              0.0000E+00  0.0000E+00  0.0000E+00!
+ELEMENT VA   VACUUM                    0.0000E+00  0.0000E+00  0.0000E+00!
+ELEMENT AL   FCC_A1                    2.6982E+01  4.5773E+03  2.8321E+01!
+ELEMENT O    1/2_MOLE_O2(G)            1.5999E+01  4.3410E+03  1.0252E+02!
+
+SPECIES AL+3                        AL1/+3!
+SPECIES O-2                         O1/-2!
+SPECIES O2                          O2!
+SPECIES AL2                         AL2!
+    """
+    test_dbf = Database.from_string(tdb_specie_str, fmt='tdb')
+    assert len(test_dbf.species) == 8
+    specie_dict = {sp.name: sp for sp in test_dbf.species}
+    assert specie_dict['AL'].charge == 0
+    assert specie_dict['AL+3'].charge == 3
+    assert specie_dict['O-2'].charge == -2
 
 
 @nose.tools.raises(ParseException)

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -284,8 +284,8 @@ def test_expand_keyword():
 
 
 def test_tdb_species_are_parsed_correctly():
-    """The TDB species command should be properly parsed."""
-    tdb_specie_str = """
+    """The TDB speciescommand should be properly parsed."""
+    tdb_species_str = """
 ELEMENT /-   ELECTRON_GAS              0.0000E+00  0.0000E+00  0.0000E+00!
 ELEMENT VA   VACUUM                    0.0000E+00  0.0000E+00  0.0000E+00!
 ELEMENT AL   FCC_A1                    2.6982E+01  4.5773E+03  2.8321E+01!
@@ -307,20 +307,20 @@ SPECIES ALO                         AL1O1!
 SPECIES ALO2                        AL1O2!
 SPECIES ALO3/2                      AL1O1.5!
     """
-    test_dbf = Database.from_string(tdb_specie_str, fmt='tdb')
+    test_dbf = Database.from_string(tdb_species_str, fmt='tdb')
     assert len(test_dbf.species) == 19
-    specie_dict = {sp.name: sp for sp in test_dbf.species}
-    assert specie_dict['AL'].charge == 0
-    assert specie_dict['O2'].constituents['O'] == 2
-    assert specie_dict['O1'].constituents['O'] == 1
-    assert specie_dict['AL1O2'].constituents['AL'] == 1
-    assert specie_dict['AL1O2'].constituents['O'] == 2
-    assert specie_dict['ALO3/2'].constituents['O'] == 1.5
+    species_dict = {sp.name: sp for sp in test_dbf.species}
+    assert species_dict['AL'].charge == 0
+    assert species_dict['O2'].constituents['O'] == 2
+    assert species_dict['O1'].constituents['O'] == 1
+    assert species_dict['AL1O2'].constituents['AL'] == 1
+    assert species_dict['AL1O2'].constituents['O'] == 2
+    assert species_dict['ALO3/2'].constituents['O'] == 1.5
 
 
 def test_tdb_species_with_charge_are_parsed_correctly():
     """The TDB species that have a charge should be properly parsed."""
-    tdb_specie_str = """
+    tdb_species_str = """
 ELEMENT /-   ELECTRON_GAS              0.0000E+00  0.0000E+00  0.0000E+00!
 ELEMENT VA   VACUUM                    0.0000E+00  0.0000E+00  0.0000E+00!
 ELEMENT AL   FCC_A1                    2.6982E+01  4.5773E+03  2.8321E+01!
@@ -331,17 +331,17 @@ SPECIES O-2                         O1/-2!
 SPECIES O2                          O2!
 SPECIES AL2                         AL2!
     """
-    test_dbf = Database.from_string(tdb_specie_str, fmt='tdb')
+    test_dbf = Database.from_string(tdb_species_str, fmt='tdb')
     assert len(test_dbf.species) == 8
-    specie_dict = {sp.name: sp for sp in test_dbf.species}
-    assert specie_dict['AL'].charge == 0
-    assert specie_dict['AL+3'].charge == 3
-    assert specie_dict['O-2'].charge == -2
+    species_dict = {sp.name: sp for sp in test_dbf.species}
+    assert species_dict['AL'].charge == 0
+    assert species_dict['AL+3'].charge == 3
+    assert species_dict['O-2'].charge == -2
 
 
 def test_writing_tdb_with_species_gives_same_result():
     """Species defined in the tdb should be written back to the TDB correctly"""
-    tdb_specie_str = """
+    tdb_species_str = """
 ELEMENT /-   ELECTRON_GAS              0.0000E+00  0.0000E+00  0.0000E+00!
 ELEMENT VA   VACUUM                    0.0000E+00  0.0000E+00  0.0000E+00!
 ELEMENT AL   FCC_A1                    2.6982E+01  4.5773E+03  2.8321E+01!
@@ -352,14 +352,14 @@ SPECIES O-2                         O1/-2!
 SPECIES O2                          O2!
 SPECIES AL2                         AL2!
     """
-    test_dbf = Database.from_string(tdb_specie_str, fmt='tdb')
+    test_dbf = Database.from_string(tdb_species_str, fmt='tdb')
     written_tdb_str = test_dbf.to_string(fmt='tdb')
     test_dbf_reread = Database.from_string(written_tdb_str, fmt='tdb')
     assert len(test_dbf_reread.species) == 8
-    specie_dict = {sp.name: sp for sp in test_dbf_reread.species}
-    assert specie_dict['AL'].charge == 0
-    assert specie_dict['AL+3'].charge == 3
-    assert specie_dict['O-2'].charge == -2
+    species_dict = {sp.name: sp for sp in test_dbf_reread.species}
+    assert species_dict['AL'].charge == 0
+    assert species_dict['AL+3'].charge == 3
+    assert species_dict['O-2'].charge == -2
 
 
 def test_species_are_parsed_in_tdb_phases_and_parameters():

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -382,16 +382,22 @@ SPECIES AL2                         AL2!
  PARA G(TEST_PH,AL2;0) 298.15          +100; 6000 N !
  PARA G(TEST_PH,O-2;0) 298.15          +1000; 6000 N !
 
+ PHASE T2SL % 2 1 1 !
+  CONSTITUENT T2SL :AL+3:O-2: !
+  PARA L(T2SL,AL+3:O-2;0) 298.15 +2; 6000 N !
     """
     from tinydb import where
     test_dbf = Database.from_string(tdb_str, fmt='tdb')
     written_tdb_str = test_dbf.to_string(fmt='tdb')
     test_dbf_reread = Database.from_string(written_tdb_str, fmt='tdb')
-    assert set(test_dbf_reread.phases.keys()) == {'TEST_PH'}
+    assert set(test_dbf_reread.phases.keys()) == {'TEST_PH', 'T2SL'}
     assert test_dbf_reread.phases['TEST_PH'].constituents[0] == {'AL', 'AL2', 'O-2'}
-    assert len(test_dbf._parameters.search(where('constituent_array') == (('AL',),))) == 1
-    assert len(test_dbf._parameters.search(where('constituent_array') == (('AL2',),))) == 1
-    assert len(test_dbf._parameters.search(where('constituent_array') == (('O-2',),))) == 1
+    assert len(test_dbf_reread._parameters.search(where('constituent_array') == (('AL',),))) == 1
+    assert len(test_dbf_reread._parameters.search(where('constituent_array') == (('AL2',),))) == 1
+    assert len(test_dbf_reread._parameters.search(where('constituent_array') == (('O-2',),))) == 1
+
+    assert test_dbf_reread.phases['T2SL'].constituents == ({'AL+3'}, {'O-2'})
+    assert len(test_dbf_reread._parameters.search(where('constituent_array') == (('AL+3',),('O-2',)))) == 1
 
 @nose.tools.raises(ParseException)
 def test_tdb_missing_terminator_element():

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -337,6 +337,29 @@ SPECIES AL2                         AL2!
     assert specie_dict['O-2'].charge == -2
 
 
+def test_writing_tdb_with_species_gives_same_result():
+    """Species defined in the tdb should be written back to the TDB correctly"""
+    tdb_specie_str = """
+ELEMENT /-   ELECTRON_GAS              0.0000E+00  0.0000E+00  0.0000E+00!
+ELEMENT VA   VACUUM                    0.0000E+00  0.0000E+00  0.0000E+00!
+ELEMENT AL   FCC_A1                    2.6982E+01  4.5773E+03  2.8321E+01!
+ELEMENT O    1/2_MOLE_O2(G)            1.5999E+01  4.3410E+03  1.0252E+02!
+
+SPECIES AL+3                        AL1/+3!
+SPECIES O-2                         O1/-2!
+SPECIES O2                          O2!
+SPECIES AL2                         AL2!
+    """
+    test_dbf = Database.from_string(tdb_specie_str, fmt='tdb')
+    written_tdb_str = test_dbf.to_string(fmt='tdb')
+    test_dbf_reread = Database.from_string(written_tdb_str, fmt='tdb')
+    assert len(test_dbf_reread.species) == 8
+    specie_dict = {sp.name: sp for sp in test_dbf_reread.species}
+    assert specie_dict['AL'].charge == 0
+    assert specie_dict['AL+3'].charge == 3
+    assert specie_dict['O-2'].charge == -2
+
+
 @nose.tools.raises(ParseException)
 def test_tdb_missing_terminator_element():
     tdb_str = """$ Note missing '!' in next line

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -283,9 +283,37 @@ def test_expand_keyword():
     assert all([full == expand_keyword(test_list, abbrev) for abbrev, full in test_input])
 
 
+def test_tdb_species_are_parsed_correctly():
+    """The TDB species command should be properly parsed."""
+    tdb_specie_str = """
+ELEMENT /-   ELECTRON_GAS              0.0000E+00  0.0000E+00  0.0000E+00!
+ELEMENT VA   VACUUM                    0.0000E+00  0.0000E+00  0.0000E+00!
+ELEMENT AL   FCC_A1                    2.6982E+01  4.5773E+03  2.8321E+01!
+ELEMENT O    1/2_MOLE_O2(G)            1.5999E+01  4.3410E+03  1.0252E+02!
+
+SPECIES AL+3                        AL1/+3!
+SPECIES O-2                         O1/-2!
+SPECIES O2                          O2!
+SPECIES O3                          O3!
+SPECIES AL1O1                       AL1O1!
+SPECIES AL1O2                       AL1O2!
+SPECIES AL2                         AL2!
+SPECIES AL2O                        AL2O1!
+SPECIES AL2O1                       AL2O1!
+SPECIES AL2O2                       AL2O2!
+SPECIES AL2O3                       AL2O3!
+SPECIES ALO                         AL1O1!
+SPECIES ALO2                        AL1O2!
+SPECIES ALO3/2                      AL1O1.5!
+    """
+    test_dbf = Database.from_string(tdb_specie_str, fmt='tdb')
+    assert len(test_dbf.species) == 18
+
+
 @nose.tools.raises(ParseException)
 def test_tdb_missing_terminator_element():
     tdb_str = """$ Note missing '!' in next line
                ELEMENT ZR   BCT_A5
                FUNCTION EMBCCTI    298.15 -39.72; 6000 N !"""
     Database(tdb_str)
+

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -293,6 +293,7 @@ ELEMENT O    1/2_MOLE_O2(G)            1.5999E+01  4.3410E+03  1.0252E+02!
 
 SPECIES AL+3                        AL1/+3!
 SPECIES O-2                         O1/-2!
+SPECIES O1                          O!
 SPECIES O2                          O2!
 SPECIES O3                          O3!
 SPECIES AL1O1                       AL1O1!
@@ -307,10 +308,11 @@ SPECIES ALO2                        AL1O2!
 SPECIES ALO3/2                      AL1O1.5!
     """
     test_dbf = Database.from_string(tdb_specie_str, fmt='tdb')
-    assert len(test_dbf.species) == 18
+    assert len(test_dbf.species) == 19
     specie_dict = {sp.name: sp for sp in test_dbf.species}
     assert specie_dict['AL'].charge == 0
     assert specie_dict['O2'].constituents['O'] == 2
+    assert specie_dict['O1'].constituents['O'] == 1
     assert specie_dict['AL1O2'].constituents['AL'] == 1
     assert specie_dict['AL1O2'].constituents['O'] == 2
     assert specie_dict['ALO3/2'].constituents['O'] == 1.5


### PR DESCRIPTION
Species in a TDB are parsed in the `Specie` class and added to the `species` set attribute of the Database.

The Specie class has several attributes:

- `name`: the name of the specie
- `constituents`: a dictionary of `{element: composition}` of the specie
- `charge`: integer charge. Defaults to zero if none specified.

As discussed in the Thermo-Calc database manager guide, elements entered via the ELEMENT command are automatically entered as species. We match that behavior here. The constituents of an element are just that element with a fraction of 1 and the charge is 0.

In principle, the constituents dictionary will be used in the solver to link the specie to how it contributes to the overall mass balance conditions.

Tests are included that test the basic functionality. I think the examples I chose were representative, and I'm unaware of any edge cases that I missed.

This could be merged immediately to better support parsing of species, but no changes were made to the solver and the species defined here should not affect calculations in any way.

@richardotis comments? suggestions?