### PR TITLE
FIX: calculate: Maintain sorted state variable ordering

### DIFF
--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -422,13 +422,14 @@ def calculate(dbf, comps, phases, mode=None, output='GM', fake_points=False, bro
 
     # Convert keyword strings to proper state variable objects
     # If we don't do this, sympy will get confused during substitution
-    statevar_dict = collections.OrderedDict((v.StateVariable(key), unpack_condition(value)) \
-                                            for (key, value) in sorted(kwargs.items()))
+    statevar_dict = dict((v.StateVariable(key), unpack_condition(value)) for (key, value) in kwargs.items())
     # XXX: CompiledModel assumes P, T are the only state variables
     if statevar_dict.get(v.P, None) is None:
         statevar_dict[v.P] = 101325
     if statevar_dict.get(v.T, None) is None:
         statevar_dict[v.T] = 300
+    # Sort after default state variable check to fix gh-116
+    statevar_dict = collections.OrderedDict(sorted(statevar_dict.items(), key=lambda x: str(x[0])))
     str_statevar_dict = collections.OrderedDict((str(key), unpack_condition(value)) \
                                                 for (key, value) in statevar_dict.items())
     all_phase_data = []

--- a/pycalphad/tests/test_calculate.py
+++ b/pycalphad/tests/test_calculate.py
@@ -5,6 +5,7 @@ Model quantities correctly.
 
 import nose.tools
 from pycalphad import Database, calculate
+import numpy as np
 try:
     # Python 2
     from StringIO import StringIO
@@ -37,3 +38,9 @@ def test_points_kwarg_multi_phase():
     "Multi-phase calculation works when internal dof differ (gh-41)."
     calculate(DBF, ['AL', 'CR', 'NI'], ['L12_FCC', 'LIQUID'],
                 T=1273, points={'L12_FCC': [0.20, 0.05, 0.75, 0.05, 0.20, 0.75]}, mode='numpy')
+
+def test_issue116():
+    "Calculate gives correct result when a state variable is left as default (gh-116)."
+    result_one = calculate(DBF, ['AL', 'CR', 'NI'], 'LIQUID', T=400)
+    result_two = calculate(DBF, ['AL', 'CR', 'NI'], 'LIQUID', T=400, P=101325)
+    np.testing.assert_array_equal(result_one.GM.values, result_two.GM.values)


### PR DESCRIPTION
Maintain sorted state variable ordering when one or more state variables is left as default. Fixes gh-116.