### PR TITLE
ENH: Add a function to filter inactive phases

### DIFF
--- a/pycalphad/core/equilibrium.py
+++ b/pycalphad/core/equilibrium.py
@@ -205,7 +205,7 @@ def equilibrium(dbf, comps, phases, conditions, output=None, model=None,
     if len(list_of_possible_phases) == 0:
         raise ConditionError('There are no phases in the Database that can be active with components {0}'.format(comps))
     if len(active_phases) == 0:
-        raise ConditionError('None of the passed phases ({0}) are active. List of active phases: {1}.'.format(phases, list_of_possible_phases))
+        raise ConditionError('None of the passed phases ({0}) are active. List of possible phases: {1}.'.format(phases, list_of_possible_phases))
     comps = sorted(comps)
     if len(set(comps) - set(dbf.elements)) > 0:
         raise EquilibriumError('Components not found in database: {}'.format(','.join(set(comps) - set(dbf.elements))))

--- a/pycalphad/core/equilibrium.py
+++ b/pycalphad/core/equilibrium.py
@@ -200,12 +200,12 @@ def equilibrium(dbf, comps, phases, conditions, output=None, model=None,
     from pycalphad import __version__ as pycalphad_version
     phases = unpack_phases(phases) or sorted(dbf.phases.keys())
     # remove phases that cannot be active
-    possible_active_phases = filter_phases(dbf, comps)
-    active_phases = sorted(set(possible_active_phases).intersection(set(phases)))
-    if len(possible_active_phases) == 0:
+    list_of_possible_phases = filter_phases(dbf, comps)
+    active_phases = sorted(set(list_of_possible_phases).intersection(set(phases)))
+    if len(list_of_possible_phases) == 0:
         raise ConditionError('There are no phases in the Database that can be active with components {0}'.format(comps))
     if len(active_phases) == 0:
-        raise ConditionError('None of the passed phases ({0}) are active. List of active phases: {1}.'.format(phases, possible_active_phases))
+        raise ConditionError('None of the passed phases ({0}) are active. List of active phases: {1}.'.format(phases, list_of_possible_phases))
     comps = sorted(comps)
     if len(set(comps) - set(dbf.elements)) > 0:
         raise EquilibriumError('Components not found in database: {}'.format(','.join(set(comps) - set(dbf.elements))))

--- a/pycalphad/core/utils.py
+++ b/pycalphad/core/utils.py
@@ -260,3 +260,36 @@ def unpack_kwarg(kwarg_obj, default_arg=None):
 
     return new_dict
 
+
+def filter_phases(dbf, comps):
+    """Return phases that are valid for equilibrium calculations for the given database and components
+
+    Filters out phases that
+    * Have no active components in any sublattice of a phase
+    * Are disordered phases in an order-disorder model
+
+    Parameters
+    ----------
+    dbf : Database
+        Thermodynamic database containing the relevant parameters.
+    comps : list
+        Names of components to consider in the calculation.
+
+    Returns
+    -------
+    list
+        Sorted list of phases that are valid for the Database and components
+    """
+    # TODO: filter phases that can not charge balance
+
+    def all_sublattices_active(comps, phase):
+        active_sublattices = [len(set(comps).intersection(subl)) > 0 for
+                              subl in phase.constituents]
+        return all(active_sublattices)
+
+    candidate_phases = dbf.phases.keys()
+    disordered_phases = [dbf.phases[phase].model_hints.get('disordered_phase') for phase in candidate_phases]
+    phases = [phase for phase in candidate_phases if
+                all_sublattices_active(comps, dbf.phases[phase]) and
+                phase not in disordered_phases]
+    return sorted(phases)

--- a/pycalphad/tests/test_equilibrium.py
+++ b/pycalphad/tests/test_equilibrium.py
@@ -318,3 +318,17 @@ def test_equilibrium_result_dataset_can_serialize_to_netcdf():
     eq = equilibrium(ALFE_DBF, ['AL', 'VA'], 'FCC_A1', {v.T: 1200, v.P: 101325})
     eq.to_netcdf(fname)
     os.remove(fname)  # cleanup
+
+
+@raises(ConditionError)
+def test_equilibrium_raises_with_no_active_phases_passed():
+    """Passing inactive phases to equilibrium raises a ConditionError."""
+    # the only phases passed are the disordered phases, which are inactive
+    equilibrium(ALNIFCC4SL_DBF, ['AL', 'NI', 'VA'], ['FCC_A1', 'BCC_A2'], {v.T: 300, v.P: 101325})
+
+
+@raises(ConditionError)
+def test_equilibrium_raises_when_no_phases_can_be_active():
+    """Equliibrium raises when the components passed cannot give any active phases"""
+    # all phases contain AL and/or FE in a sublattice, so no phases can be active
+    equilibrium(ALFE_DBF, ['VA'], list(ALFE_DBF.phases.keys()), {v.T: 300, v.P: 101325})

--- a/pycalphad/tests/test_utils.py
+++ b/pycalphad/tests/test_utils.py
@@ -1,0 +1,23 @@
+"""
+The utils test module contains tests for pycalphad utilities.
+"""
+
+from pycalphad import Database
+from pycalphad.core.utils import filter_phases
+
+from pycalphad.tests.datasets import ALNIPT_TDB
+
+ALNIPT_DBF = Database(ALNIPT_TDB)
+
+def test_filter_phases_removes_disordered_phases_from_order_disorder():
+    """Databases with order-disorder models should have the disordered phases be filtered."""
+    all_phases = set(ALNIPT_DBF.phases.keys())
+    filtered_phases = set(filter_phases(ALNIPT_DBF, ['AL', 'NI', 'PT', 'VA']))
+    assert all_phases.difference(filtered_phases) == {'FCC_A1'}
+
+def test_filter_phases_removes_phases_with_inactive_sublattices():
+    """Phases that have no active components in any sublattice should be filtered"""
+    all_phases = set(ALNIPT_DBF.phases.keys())
+    filtered_phases = set(filter_phases(ALNIPT_DBF, ['AL', 'NI', 'VA']))
+    assert all_phases.difference(filtered_phases) == {'FCC_A1', 'PT8AL21', 'PT5AL21', 'PT2AL', 'PT2AL3', 'PT5AL3', 'ALPT2'}
+


### PR DESCRIPTION
Closes #100 and closes #129

I use this all the time. @richardotis what do you think about including this in pycalphad proper?

Any thoughts on doing this automatically in equilibrium calculations? That way users could always pass in phases=dbf.phases.keys() without getting any error messages. In large databases, your only other choice is to tediously select phases in the system you want to calculate.