### PR TITLE
ENH: JIT performance improvement

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,6 @@
 # This file was based on Olivier Grisel's python-appveyor-demo
 
 environment:
-  global:
-    WITH_COMPILER: "cmd /E:ON /V:ON /C ci\\with-compiler.cmd"
   matrix:
     - PYTHON: "C:\\Python27-conda32"
       PYTHON_VERSION: "2.7"
@@ -46,4 +44,4 @@ install:
 build: false
 
 test_script:
-  - "%WITH_COMPILER% python -c \"import nose ; nose.main()\" -s -v pycalphad"
+  - "python -c \"import nose ; nose.main()\" -s -v pycalphad"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ install:
   # Check that we have the expected version and architecture for Python
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
-  - "conda install --yes --quiet conda"
+  - "conda install --yes --quiet conda=4.3"
   - "conda config --system --add pinned_packages defaults::conda"
   - "conda -V"
   - "conda create --yes -n condaenv python=%PYTHON_VERSION%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ install:
   # Check that we have the expected version and architecture for Python
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
-  - "conda install --yes --quiet conda=4.3"
+  - "conda install --yes --quiet conda=4.3.30"
   - "conda config --system --add pinned_packages defaults::conda"
   - "conda -V"
   - "conda create --yes -n condaenv python=%PYTHON_VERSION%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,8 @@ install:
   # Check that we have the expected version and architecture for Python
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
-  - "conda update --yes --quiet conda"
+  - "conda install --yes --quiet conda"
+  - "conda config --system --add pinned_packages defaults::conda"
   - "conda -V"
   - "conda create --yes -n condaenv python=%PYTHON_VERSION%"
   - "activate condaenv"

--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -412,7 +412,7 @@ def calculate(dbf, comps, phases, mode=None, output='GM', fake_points=False, bro
                     out = out.xreplace({undef: float(0)})
                     warnings.warn('Setting undefined symbol {0} for phase {1} to zero'.format(undef, phase_name))
                 comp_sets[phase_name] = build_functions(out, list(statevar_dict.keys()) + variables,
-                                                        include_obj=True, include_grad=False, include_hess=False,
+                                                        include_obj=True, include_grad=False,
                                                         parameters=param_symbols)
             else:
                 comp_sets[phase_name] = callable_dict[phase_name]

--- a/pycalphad/core/custom_autowrap.py
+++ b/pycalphad/core/custom_autowrap.py
@@ -160,6 +160,8 @@ class C89CodePrinter(CCodePrinter):
             close_lines.append("}")
         return open_lines, close_lines
 
+    _print_ComplexInfinity = CCodePrinter._print_Infinity
+
 
 class CustomCCodeGen(CCodeGen):
     def get_prototype(self, routine):

--- a/pycalphad/core/custom_autowrap.py
+++ b/pycalphad/core/custom_autowrap.py
@@ -161,6 +161,7 @@ class C89CodePrinter(CCodePrinter):
         return open_lines, close_lines
 
     _print_ComplexInfinity = CCodePrinter._print_Infinity
+    _print_NegativeComplexInfinity = CCodePrinter._print_NegativeInfinity
 
 
 class CustomCCodeGen(CCodeGen):

--- a/pycalphad/core/custom_autowrap.py
+++ b/pycalphad/core/custom_autowrap.py
@@ -73,6 +73,8 @@ except ImportError:
 from sympy.utilities.codegen import (AssignmentError, InOutArgument, InputArgument, OutputArgument,
                                      ResultBase, Result, CodeGenArgumentListError,
                                      CCodeGen, CodeGenError, Routine, Variable)
+from sympy.codegen.ast import Assignment
+from sympy.printing.precedence import precedence
 from sympy.core import Symbol, S, Tuple, Equality
 from sympy.core.compatibility import is_sequence
 from sympy.tensor import Idx, Indexed, IndexedBase
@@ -142,6 +144,8 @@ class C89CodePrinter(CCodePrinter):
     C89-compatible code printing allows for Windows compatibility.
     (MSVC 14 and newer support C99, but we are going for broad compatibility.)
     """
+    order = 'none'
+
     def _get_loop_opening_ending(self, indices):
         # The purpose is to enable C89-compliant loops (indices are pre-declared)
         open_lines = []
@@ -155,6 +159,7 @@ class C89CodePrinter(CCodePrinter):
                 'end': self._print(i.upper + 1)})
             close_lines.append("}")
         return open_lines, close_lines
+
 
 class CustomCCodeGen(CCodeGen):
     def get_prototype(self, routine):

--- a/pycalphad/core/custom_autowrap.py
+++ b/pycalphad/core/custom_autowrap.py
@@ -302,6 +302,10 @@ class CustomCCodeGen(CCodeGen):
         be ordered alphabetically, but with all InputArguments first, and then
         OutputArgument and InOutArguments.
 
+        This implementation is almost the same as the CodeGen class, but
+        expensive calls to Basic.atoms() have been replaced with
+        cheaper equivalents.
+
         """
 
         if is_sequence(expr) and not isinstance(expr, (MatrixBase, MatrixExpr)):

--- a/pycalphad/core/equilibrium.py
+++ b/pycalphad/core/equilibrium.py
@@ -268,7 +268,7 @@ def equilibrium(dbf, comps, phases, conditions, output=None, model=None,
                 for undef in undefs:
                     out = out.xreplace({undef: float(0)})
                 cf, gf = build_functions(out, tuple([v.P, v.T] + site_fracs),
-                                         parameters=param_symbols, include_hess=False)
+                                         parameters=param_symbols)
                 hf = None
                 if callable_dict.get(name, None) is None:
                     callable_dict[name] = cf

--- a/pycalphad/core/equilibrium.py
+++ b/pycalphad/core/equilibrium.py
@@ -267,7 +267,9 @@ def equilibrium(dbf, comps, phases, conditions, output=None, model=None,
                 undefs = list(out.atoms(Symbol) - out.atoms(v.StateVariable) - set(param_symbols))
                 for undef in undefs:
                     out = out.xreplace({undef: float(0)})
-                cf, gf, hf = build_functions(out, tuple([v.P, v.T] + site_fracs), parameters=param_symbols)
+                cf, gf = build_functions(out, tuple([v.P, v.T] + site_fracs),
+                                         parameters=param_symbols, include_hess=False)
+                hf = None
                 if callable_dict.get(name, None) is None:
                     callable_dict[name] = cf
                 if grad_callable_dict.get(name, None) is None:

--- a/pycalphad/core/phase_rec.pyx
+++ b/pycalphad/core/phase_rec.pyx
@@ -48,7 +48,8 @@ cdef public class PhaseRecord(object)[type PhaseRecordType, object PhaseRecordOb
         if self._hess != NULL:
             self._hess(&dof[0], &self.parameters[0], &out[0,0])
         else:
-            self.cmpmdl.eval_energy_hessian(out, dof, self.parameters)
+            if self.cmpmdl is not None:
+                self.cmpmdl.eval_energy_hessian(out, dof, self.parameters)
 
     @cython.boundscheck(False)
     @cython.wraparound(False)


### PR DESCRIPTION
The `Model` class is JIT-compiled by an autowrap-based utility, which is primarily located in `core\sympydiff_utils.py` and `core\custom_autowrap.py`. A substantial portion of the startup time for a new `Model` used in a calculation is in the JIT. Here the performance is improved via profiling, where redundant or unnecessary computations are eliminated. In particular, since the new IPOPT-based solver does not require direct Hessian computation, Hessian codegen is disabled. This, and a few other tweaks,lead to a 50-70% reduction in the first-run time for `Model`-based computations.