### PR TITLE
FIX: Fix compiling+autowrapping of Model callables

### DIFF
--- a/pycalphad/core/custom_autowrap.py
+++ b/pycalphad/core/custom_autowrap.py
@@ -533,19 +533,18 @@ class ThreadSafeCythonCodeWrapper(CythonCodeWrapper):
             return str(arg.name)
 
     def wrap_code(self, routine, helpers=None):
+        self._module_id = str(uuid.uuid4()).replace('-', '_')
         helpers = helpers if helpers is not None else []
         workdir = self.filepath
         if not os.access(workdir, os.F_OK):
             os.mkdir(workdir)
-        try:
-            self.generator.write(
-                [routine]+helpers, str(os.path.join(workdir, self.filename)).replace(os.sep, '/'), True, self.include_header,
-                self.include_empty)
-            self._prepare_files(routine)
-            self._process_files(routine)
-            mod = import_extension(workdir, self.module_name)
-        finally:
-            self._module_id = str(uuid.uuid4()).replace('-', '_')
+        self.generator.write(
+            [routine]+helpers, str(os.path.join(workdir, self.filename)).replace(os.sep, '/'), True, self.include_header,
+            self.include_empty)
+        self._prepare_files(routine)
+        self._process_files(routine)
+        mod = import_extension(workdir, self.module_name)
+
         return self._get_wrapped_function(mod, routine.name), self._get_wrapped_function(mod, 'get_pointer')(), str(self.module_name), str(routine.name)
 
 

--- a/pycalphad/core/sympydiff_utils.py
+++ b/pycalphad/core/sympydiff_utils.py
@@ -45,7 +45,8 @@ class PickleableFunction(object):
                     while mod is None:
                         try:
                             mod = import_extension(self._workdir, self._module_name)
-                            self._kernel = getattr(mod, self._routine_name)
+                            self._kernel = getattr(mod, self._routine_name + '_c')
+                            self._cpointer = getattr(mod, 'get_pointer_c')()
                         except ImportError:
                             if start + 60 > time.time():
                                 raise


### PR DESCRIPTION
- Callable module names/ids were modified in custom_autowrap.wrap_code function.
- sympydiff_utils was not properly getting a pointer to the name of the C routine