### PR TITLE
ENH: Optimize calculate

### DIFF
--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -180,10 +180,10 @@ def _compute_phase_values(components, statevar_dict,
     # we need to force broadcasting and flatten the result before calling
     t = time.time()
     bc_statevars = np.ascontiguousarray([broadcast_to(x, points.shape[:-1]).reshape(-1) for x in statevars])
-    pts = points.reshape(-1, points.shape[-1]).T
-    dof = np.concatenate((bc_statevars.T, pts.T), axis=1)
-    phase_output = np.ascontiguousarray(np.zeros(dof.shape[0]))
-    phase_compositions = np.asfortranarray(np.zeros((dof.shape[0], len(pure_elements))))
+    pts = points.reshape(-1, points.shape[-1])
+    dof = np.concatenate((bc_statevars.T, pts), axis=1)
+    phase_output = np.zeros(dof.shape[0], order='C')
+    phase_compositions = np.zeros((dof.shape[0], len(pure_elements)), order='F')
     print('obj setup time', time.time() - t)
     t = time.time()
     phase_record.obj(phase_output, dof)
@@ -220,8 +220,10 @@ def _compute_phase_values(components, statevar_dict,
     else:
         t = time.time()
         expanded_points = np.full(points.shape[:-1] + (maximum_internal_dof,), np.nan)
+        print('expand points creation of full time', time.time() - t)
+        t = time.time()
         expanded_points[..., :points.shape[-1]] = points
-        print('expand points time', time.time() - t)
+        print('expand points assignment time', time.time() - t)
     if broadcast:
         coordinate_dict.update({key: np.atleast_1d(value) for key, value in statevar_dict.items()})
         output_columns = [str(x) for x in statevar_dict.keys()] + ['points']

--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -180,7 +180,7 @@ def _compute_phase_values(components, statevar_dict,
     # we need to force broadcasting and flatten the result before calling
     bc_statevars = np.ascontiguousarray([broadcast_to(x, points.shape[:-1]).reshape(-1) for x in statevars])
     pts = points.reshape(-1, points.shape[-1])
-    dof = np.concatenate((bc_statevars.T, pts), axis=1)
+    dof = np.ascontiguousarray(np.concatenate((bc_statevars.T, pts), axis=1))
     phase_output = np.zeros(dof.shape[0], order='C')
     phase_compositions = np.zeros((dof.shape[0], len(pure_elements)), order='F')
     phase_record.obj(phase_output, dof)

--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -21,6 +21,7 @@ import warnings
 from xarray import Dataset, concat
 from collections import OrderedDict
 
+
 def _generate_fake_points(components, statevar_dict, energy_limit, output, maximum_internal_dof, broadcast):
     """
     Generate points for a fictitious hyperplane used as a starting point for energy minimization.

--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -214,11 +214,8 @@ def _compute_phase_values(components, statevar_dict,
     # It can be expensive for many points (~14s for 500M points)
     if fake_points:
         desired_shape = points.shape[:-2] + (max_tieline_vertices + points.shape[-2], maximum_internal_dof)
-        if points.shape == desired_shape:
-            expanded_points = points
-        else:
-            expanded_points = np.full(desired_shape, np.nan)
-            expanded_points[..., len(pure_elements):, :points.shape[-1]] = points
+        expanded_points = np.full(desired_shape, np.nan)
+        expanded_points[..., len(pure_elements):, :points.shape[-1]] = points
     else:
         desired_shape = points.shape[:-1] + (maximum_internal_dof,)
         if points.shape == desired_shape:

--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -178,9 +178,9 @@ def _compute_phase_values(components, statevar_dict,
     pure_elements = sorted(set([el.upper() for constituents in pure_elements for el in constituents]))
     # func may only have support for vectorization along a single axis (no broadcasting)
     # we need to force broadcasting and flatten the result before calling
-    bc_statevars = [np.ascontiguousarray(broadcast_to(x, points.shape[:-1]).reshape(-1)) for x in statevars]
+    bc_statevars = np.ascontiguousarray([broadcast_to(x, points.shape[:-1]).reshape(-1) for x in statevars])
     pts = points.reshape(-1, points.shape[-1]).T
-    dof = np.ascontiguousarray(np.concatenate((bc_statevars, pts), axis=0).T)
+    dof = np.concatenate((bc_statevars.T, pts.T), axis=1)
     phase_output = np.ascontiguousarray(np.zeros(dof.shape[0]))
     phase_compositions = np.asfortranarray(np.zeros((dof.shape[0], len(pure_elements))))
     phase_record.obj(phase_output, dof)
@@ -202,7 +202,6 @@ def _compute_phase_values(components, statevar_dict,
                                       np.full(points.shape[:-1], phase_record.phase_name, dtype='U' + str(len(phase_record.phase_name)))), axis=-1)
     else:
         phase_names = np.full(points.shape[:-1], phase_record.phase_name, dtype='U'+str(len(phase_record.phase_name)))
-
     if fake_points:
         phase_compositions = np.concatenate((np.broadcast_to(np.eye(len(pure_elements)), points.shape[:-2] + (max_tieline_vertices, len(pure_elements))), phase_compositions), axis=-2)
 


### PR DESCRIPTION
### Summary

For a set of 30M points (x16 DOF = 500M array elements), `calculate` had an overhead of ~35s beyond calling the objective function. These changes optimize that down to ~13s in the general case and ~5s in special cases.

### Problem

When working with a large (8 sublattice) binary system, which results in points arrays of approximately 500M points at a point density of 1000. calling calculate was very slow.

This PR introduces some optimizations to speed up calculate.

For reference, here is the script that was run:

```python
from pycalphad import calculate, Database

dbf = Database('/Users/brandon/Projects/notebooks/pycalphad/AB8SL_v4.TDB')

from pycalphad import Model
mod = Model(dbf, ['A', 'B'], 'FCC')  # save time initializing models on each call
# warm the cache
calc_res = calculate(dbf, ['A', 'B'], 'FCC', pdens=1000, model=mod)
% timeit calc_res = calculate(dbf, ['A', 'B'], 'FCC', pdens=1000, model=mod)
```

### Details

Running this on develop master gives:

`1min 15s ± 783 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)`, where ~40s comes from calling the `obj` method of a PhaseRecord. Here I am assuming that this cannot be changed.

The main changes are 

1. Update `dof` array to tranpose before, rather than after, where the concatenated arrays line up better in memory. Leads to 

    `58.7 s ± 2.74 s per loop (mean ± std. dev. of 7 runs, 1 loop each)`

2. Changing to append the NaNs to extend the points array, rather than preallocate a whole array of them and then copy the points over. Both methods have to copy the points, so it's not the most efficient, but this is a little faster because it saves from allocating `np.size(points)` of `np.nan`. The ideal situation (as commented) would be to give `_compute_phase_values` the NaN-padded points array in the first place, then slice that up (if possible) inside the function, preventing any copying of memory. This optimization gives

    `53.1 s ± 4.65 s per loop (mean ± std. dev. of 7 runs, 1 loop each)`

3. For the hot path, such as single phase calculations and other special cases, where the current internal degrees of freedom is the same as the maximum degrees of freedom, we can avoid any extending/copying completely. Gives

    `46.6 s ± 884 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)`

    which is close to the objective function time. 

Except for the additional overhead of the if statement checking the array shapes, this should across the board be cheaper, even for small points arrays, and should allow us to handle more sublattice and multicomponent systems more gracefully.

