### PR TITLE
MAINT: Refactor build_callables

### DIFF
--- a/pycalphad/codegen/callables.py
+++ b/pycalphad/codegen/callables.py
@@ -5,6 +5,7 @@ from pycalphad.core.utils import get_pure_elements, unpack_components, \
 from pycalphad.core.phase_rec import PhaseRecord
 from pycalphad.core.constraints import build_constraints
 from itertools import repeat
+import warnings
 
 
 def build_callables(dbf, comps, phases, models, parameter_symbols=None,
@@ -88,6 +89,11 @@ def build_callables(dbf, comps, phases, models, parameter_symbols=None,
 
     state_variables = get_state_variables(models=models)
     state_variables |= additional_statevars
+    if state_variables != {v.T, v.P, v.N}:
+        warnings.warn("State variables in `build_callables` are not {{N, P, T}}, "
+                      "but {}. Be sure you know what you are doing. "
+                      "State variables can be added with the `additional_statevars` "
+                      "argument.".format(state_variables))
     state_variables = sorted(state_variables, key=str)
 
     for name in phases:

--- a/pycalphad/codegen/callables.py
+++ b/pycalphad/codegen/callables.py
@@ -1,16 +1,17 @@
 import pycalphad.variables as v
 from pycalphad.codegen.sympydiff_utils import build_functions
-from pycalphad.core.utils import get_pure_elements, unpack_components, extract_parameters, get_state_variables
+from pycalphad.core.utils import get_pure_elements, unpack_components, \
+    extract_parameters, get_state_variables, wrap_symbol
 from pycalphad.core.phase_rec import PhaseRecord
 from pycalphad.core.constraints import build_constraints
 from itertools import repeat
 
 
-def build_callables(dbf, comps, phases, models, conds, parameters=None, callables=None,
+def build_callables(dbf, comps, phases, models, parameter_symbols=None,
                     output='GM', build_gradients=True, build_hessians=False,
-                    additional_statevars=None, verbose=False):
+                    additional_statevars=None):
     """
-    Create dictionaries of callable dictionaries and PhaseRecords.
+    Create a compiled callables dictionary.
 
     Parameters
     ----------
@@ -20,46 +21,57 @@ def build_callables(dbf, comps, phases, models, conds, parameters=None, callable
         List of component names
     phases : list
         List of phase names
-    conds : dict or None
-        Conditions for calculation
     models : dict
         Dictionary of {phase_name: Model subclass}
-    parameters : dict, optional
-        Maps SymPy Symbol to numbers, for overriding the values of parameters in the Database.
-    callables : dict, optional
-        Pre-computed callables
-    output : str
-        Output property of the particular Model to sample
-    build_gradients : bool
+    parameter_symbols : list, optional
+        List of string or SymPy Symbols that will be overridden in the callables.
+    output : str, optional
+        Output property of the particular Model to sample. Defaults to 'GM'
+    build_gradients : bool, optional
         Whether or not to build gradient functions. Defaults to True.
-    build_hessians : bool
+    build_hessians : bool, optional
         Whether or not to build Hessian functions. Defaults to False.
-    additional_statevars : set or None
-        State variables to include in the callables that may not be in the models
-
-    verbose : bool
+    additional_statevars : set, optional
+        State variables to include in the callables that may not be in the models (e.g. from conditions)
+    verbose : bool, optional
         Print the name of the phase when its callables are built
 
     Returns
     -------
     callables : dict
         Dictionary of keyword argument callables to pass to equilibrium.
+        Maps {'output' -> {'function' -> {'phase_name' -> AutowrapFunction()}}.
 
-    Example
-    -------
+    Notes
+    -----
+    *All* the state variables used in calculations must be specified.
+    If these are not specified as state variables of the models (e.g. often the
+    case for v.N), then it must be supplied by the additional_statevars keyword
+    argument.
+
+    Examples
+    --------
+    >>> from pycalphad import Database, equilibrium, variables as v
+    >>> from pycalphad.codegen.callables import build_callables
+    >>> from pycalphad.core.utils import instantiate_models
     >>> dbf = Database('AL-NI.tdb')
     >>> comps = ['AL', 'NI', 'VA']
-    >>> phases = ['FCC_L12', 'BCC_B2', 'LIQUID', 'AL3NI5', 'AL3NI2', 'AL3NI']
-    >>> callables = build_callables(dbf, comps, phases)
-    >>> equilibrium(dbf, comps, phases, conditions, **callables)
+    >>> phases = ['LIQUID', 'AL3NI5', 'AL3NI2', 'AL3NI']
+    >>> models = instantiate_models(dbf, comps, phases)
+    >>> callables = build_callables(dbf, comps, phases, models, additional_statevars={v.P, v.T, v.N})
+    >>> 'GM' in callables.keys()
+    True
+    >>> 'massfuncs' in callables['GM']
+    True
+    >>> conditions = {v.P: 101325, v.T: 2500, v.X('AL'): 0.2}
+    >>> equilibrium(dbf, comps, phases, conditions, callables=callables)
     """
-    additional_statevars = additional_statevars if additional_statevars is not None else set()
-    parameters = parameters if parameters is not None else {}
-    param_symbols, param_values = extract_parameters(parameters)
+    additional_statevars = set(additional_statevars) if additional_statevars is not None else set()
+    parameter_symbols = parameter_symbols if parameter_symbols is not None else []
+    parameter_symbols = sorted([wrap_symbol(x) for x in parameter_symbols], key=str)
     comps = sorted(unpack_components(dbf, comps))
     pure_elements = get_pure_elements(dbf, comps)
 
-    callables = callables if callables is not None else {}
     _callables = {
         'massfuncs': {},
         'massgradfuncs': {},
@@ -74,8 +86,6 @@ def build_callables(dbf, comps, phases, models, conds, parameters=None, callable
         'mp_jac': {},
     }
 
-    phase_records = {}
-
     state_variables = get_state_variables(models=models)
     state_variables |= additional_statevars
     state_variables = sorted(state_variables, key=str)
@@ -89,85 +99,145 @@ def build_callables(dbf, comps, phases, models, conds, parameters=None, callable
             raise AttributeError('Missing Model attribute {0} specified for {1}'
                                  .format(output, mod.__class__))
 
-        if callables.get('callables', {}).get(name, False) and \
-                ((not build_gradients) or callables.get('grad_callables', {}).get(name, False)) and \
-                ((not build_hessians) or callables.get('hess_callables', {}).get(name, False)):
-            _callables['callables'][name] = callables['callables'][name]
-            _callables['grad_callables'][name] = callables['grad_callables'].get(name, None)
-            _callables['hess_callables'][name] = callables['hess_callables'].get(name, None)
-        else:
-            # Build the callables of the output
-            # Only force undefineds to zero if we're not overriding them
-            undefs = {x for x in out.free_symbols if not isinstance(x, v.StateVariable)} - set(param_symbols)
-            undef_vals = repeat(0., len(undefs))
-            out = out.xreplace(dict(zip(undefs, undef_vals)))
-            build_output = build_functions(out, tuple(state_variables + site_fracs), parameters=param_symbols,
-                                           include_grad=build_gradients, include_hess=build_hessians)
-            cf, gf, hf = build_output.func, build_output.grad, build_output.hess
-            _callables['callables'][name] = cf
-            _callables['grad_callables'][name] = gf
-            _callables['hess_callables'][name] = hf
+        # Build the callables of the output
+        # Only force undefineds to zero if we're not overriding them
+        undefs = {x for x in out.free_symbols if not isinstance(x, v.StateVariable)} - set(parameter_symbols)
+        undef_vals = repeat(0., len(undefs))
+        out = out.xreplace(dict(zip(undefs, undef_vals)))
+        build_output = build_functions(out, tuple(state_variables + site_fracs), parameters=parameter_symbols,
+                                       include_grad=build_gradients, include_hess=build_hessians)
+        cf, gf, hf = build_output.func, build_output.grad, build_output.hess
+        # trigger the JIT
+        cf.kernel
+        if gf is not None:
+            gf.kernel
+        if hf is not None:
+            hf.kernel
+        _callables['callables'][name] = cf
+        _callables['grad_callables'][name] = gf
+        _callables['hess_callables'][name] = hf
 
-        if callables.get('massfuncs', {}).get(name, False) and \
-                ((not build_gradients) or callables.get('massgradfuncs', {}).get(name, False)) and \
-                ((not build_hessians) or callables.get('masshessfuncs', {}).get(name, False)):
-            _callables['massfuncs'][name] = callables['massfuncs'][name]
-            _callables['massgradfuncs'][name] = callables['massgradfuncs'].get(name, None)
-            _callables['masshessfuncs'][name] = callables['masshessfuncs'].get(name, None)
+        # Build the callables for mass
+        # TODO: In principle, we should also check for undefs in mod.moles()
+        mcf, mgf, mhf = zip(*[build_functions(mod.moles(el), state_variables + site_fracs,
+                                              include_obj=True,
+                                              include_grad=build_gradients,
+                                              include_hess=build_hessians,
+                                              parameters=parameter_symbols)
+                              for el in pure_elements])
+        # Compile and/or set the gradients and hessians to None
+        [x.kernel for x in mcf]
+        if all(x is None for x in mgf):
+            mgf = None
         else:
-            # Build the callables for mass
-            # TODO: In principle, we should also check for undefs in mod.moles()
-            mcf, mgf, mhf = zip(*[build_functions(mod.moles(el), state_variables + site_fracs,
-                                                  include_obj=True,
-                                                  include_grad=build_gradients,
-                                                  include_hess=build_hessians,
-                                                  parameters=param_symbols)
-                                  for el in pure_elements])
-            if all(x is None for x in mgf):
-                mgf = None
-            if all(x is None for x in mhf):
-                mhf = None
-            _callables['massfuncs'][name] = mcf
-            _callables['massgradfuncs'][name] = mgf
-            _callables['masshessfuncs'][name] = mhf
-        if not callables.get('phase_records', {}).get(name, False):
-            pv = param_values
+            [x.kernel for x in mgf if x is not None]
+        if all(x is None for x in mhf):
+            mhf = None
         else:
-            # Copy parameter values from old PhaseRecord, if it exists
-            pv = callables['phase_records'][name].parameters
+            [x.kernel for x in mhf if x is not None]
+        _callables['massfuncs'][name] = mcf
+        _callables['massgradfuncs'][name] = mgf
+        _callables['masshessfuncs'][name] = mhf
+    return {output: _callables}
 
+
+def build_phase_records(dbf, comps, phases, conds, models, output='GM',
+                        callables=None, parameters=None, verbose=False,
+                        build_gradients=False, build_hessians=False
+                        ):
+    """
+    Combine compiled callables and callables from conditions into PhaseRecords.
+
+    Parameters
+    ----------
+    dbf : Database
+        A Database object
+    comps : list
+        List of component names
+    phases : list
+        List of phase names
+    conds : dict or None
+        Conditions for calculation
+    models : dict
+        Dictionary of {'phase_name': Model()}
+    parameters : dict, optional
+        Maps SymPy Symbol to numbers, for overriding the values of parameters in the Database.
+    callables : dict, optional
+        Pre-computed callables. If None are passed, they will be built.
+        Maps {'output' -> {'function' -> {'phase_name' -> AutowrapFunction()}}
+    output : str
+        Output property of the particular Model to sample
+    verbose : bool, optional
+        Print the name of the phase when its callables are built
+    build_gradients : bool
+        Whether or not to build gradient functions. Defaults to False. Only
+        takes effect if callables are not passed.
+    build_hessians : bool
+        Whether or not to build Hessian functions. Defaults to False. Only
+        takes effect if callables are not passed.
+
+    Returns
+    -------
+    dict
+        Dictionary mapping phase names to PhaseRecord instances.
+
+    Notes
+    -----
+    If callables are passed, don't rebuild them. This means that the callables
+    are not checked for incompatibility. Users of build_callables are
+    responsible for ensuring that the state variables, parameters and models
+    used to construct the callables are compatible with the ones used to
+    build the constraints and phase records.
+
+    """
+    parameters = parameters if parameters is not None else {}
+    callables = callables if callables is not None else {}
+    _constraints = {
+        'internal_cons': {},
+        'internal_jac': {},
+        'internal_cons_hess': {},
+        'mp_cons': {},
+        'mp_jac': {},
+    }
+    phase_records = {}
+    state_variables = sorted(get_state_variables(models=models, conds=conds), key=str)
+    param_symbols, param_values = extract_parameters(parameters)
+
+    if callables.get(output) is None:
+        callables = build_callables(dbf, comps, phases, models,
+                                    parameter_symbols=parameters.keys(), output=output,
+                                    additional_statevars=state_variables,
+                                    build_gradients=build_gradients,
+                                    build_hessians=build_hessians)
+
+    for name in phases:
+        mod = models[name]
+        site_fracs = mod.site_fractions
+        # build constraint functions
         cfuncs = build_constraints(mod, state_variables + site_fracs, conds, parameters=param_symbols)
-        _callables['internal_cons'][name] = cfuncs.internal_cons
-        _callables['internal_jac'][name] = cfuncs.internal_jac
-        _callables['internal_cons_hess'][name] = cfuncs.internal_cons_hess
-        _callables['mp_cons'][name] = cfuncs.multiphase_cons
-        _callables['mp_jac'][name] = cfuncs.multiphase_jac
+        _constraints['internal_cons'][name] = cfuncs.internal_cons
+        _constraints['internal_jac'][name] = cfuncs.internal_jac
+        _constraints['internal_cons_hess'][name] = cfuncs.internal_cons_hess
+        _constraints['mp_cons'][name] = cfuncs.multiphase_cons
+        _constraints['mp_jac'][name] = cfuncs.multiphase_jac
         num_internal_cons = cfuncs.num_internal_cons
         num_multiphase_cons = cfuncs.num_multiphase_cons
 
-        phase_records[name.upper()] = PhaseRecord(comps, state_variables, site_fracs, pv,
-                                                  _callables['callables'][name],
-                                                  _callables['grad_callables'][name],
-                                                  _callables['hess_callables'][name],
-                                                  _callables['massfuncs'][name],
-                                                  _callables['massgradfuncs'][name],
-                                                  _callables['masshessfuncs'][name],
-                                                  _callables['internal_cons'][name],
-                                                  _callables['internal_jac'][name],
-                                                  _callables['internal_cons_hess'][name],
-                                                  _callables['mp_cons'][name],
-                                                  _callables['mp_jac'][name],
+        phase_records[name.upper()] = PhaseRecord(comps, state_variables, site_fracs, param_values,
+                                                  callables[output]['callables'][name],
+                                                  callables[output]['grad_callables'][name],
+                                                  callables[output]['hess_callables'][name],
+                                                  callables[output]['massfuncs'][name],
+                                                  callables[output]['massgradfuncs'][name],
+                                                  callables[output]['masshessfuncs'][name],
+                                                  _constraints['internal_cons'][name],
+                                                  _constraints['internal_jac'][name],
+                                                  _constraints['internal_cons_hess'][name],
+                                                  _constraints['mp_cons'][name],
+                                                  _constraints['mp_jac'][name],
                                                   num_internal_cons,
                                                   num_multiphase_cons)
+
         if verbose:
             print(name + ' ')
-
-    # Update PhaseRecords with any user-specified parameter values, in case we skipped the build phase
-    # We assume here that users know what they are doing, and pass compatible combinations of callables and parameters
-    # See discussion in gh-192 for details
-    if len(param_values) > 0:
-        for prx_name in phase_records:
-            if len(phase_records[prx_name].parameters) != len(param_values):
-                raise ValueError('User-specified callables and parameters are incompatible')
-            phase_records[prx_name].parameters = param_values
-    return phase_records, state_variables
+    return phase_records

--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -311,7 +311,6 @@ def calculate(dbf, comps, phases, mode=None, output='GM', fake_points=False, bro
     if points_dict is None and broadcast is False:
         raise ValueError('The \'points\' keyword argument must be specified if broadcast=False is also given.')
     nonvacant_components = [x for x in sorted(comps) if x.number_of_atoms > 0]
-    # TODO: check unspecified state variables
 
     all_phase_data = []
     largest_energy = 1e10

--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -325,7 +325,7 @@ def calculate(dbf, comps, phases, mode=None, output='GM', fake_points=False, bro
         raise ConditionError('None of the passed phases ({0}) are active. List of possible phases: {1}.'
                              .format(phases, list_of_possible_phases))
 
-    models = instantiate_models(dbf, comps, active_phases, model=kwargs.pop('model', None), parameters=parameters)
+    models = instantiate_models(dbf, comps, list(active_phases.keys()), model=kwargs.pop('model', None), parameters=parameters)
 
     if isinstance(output, (list, tuple, set)):
         raise NotImplementedError('Only one property can be specified in calculate() at a time')

--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -4,12 +4,12 @@ property surface of a system.
 """
 
 from __future__ import division
-from pycalphad import Model
-from pycalphad.codegen.callables import build_callables
+from pycalphad.codegen.callables import build_phase_records
 from pycalphad import ConditionError
 from pycalphad.core.utils import point_sample, generate_dof
 from pycalphad.core.utils import endmember_matrix, unpack_kwarg
-from pycalphad.core.utils import broadcast_to, filter_phases, unpack_condition, unpack_components
+from pycalphad.core.utils import broadcast_to, filter_phases, unpack_condition,\
+    unpack_components, get_state_variables, instantiate_models
 from pycalphad.core.cache import cacheit
 from pycalphad.core.phase_rec import PhaseRecord
 import pycalphad.variables as v
@@ -297,8 +297,7 @@ def calculate(dbf, comps, phases, mode=None, output='GM', fake_points=False, bro
     # there may be keyword arguments that aren't state variables
     pdens_dict = unpack_kwarg(kwargs.pop('pdens', 2000), default_arg=2000)
     points_dict = unpack_kwarg(kwargs.pop('points', None), default_arg=None)
-    model_dict = unpack_kwarg(kwargs.pop('model', Model), default_arg=Model)
-    callables_dict = kwargs.pop('callables', {})
+    callables = kwargs.pop('callables', {})
     sampler_dict = unpack_kwarg(kwargs.pop('sampler', None), default_arg=None)
     fixedgrid_dict = unpack_kwarg(kwargs.pop('grid_points', True), default_arg=True)
     parameters = parameters or dict()
@@ -327,33 +326,31 @@ def calculate(dbf, comps, phases, mode=None, output='GM', fake_points=False, bro
         raise ConditionError('None of the passed phases ({0}) are active. List of possible phases: {1}.'
                              .format(phases, list_of_possible_phases))
 
+    models = instantiate_models(dbf, comps, active_phases, model=kwargs.pop('model', None), parameters=parameters)
 
     if isinstance(output, (list, tuple, set)):
         raise NotImplementedError('Only one property can be specified in calculate() at a time')
     output = output if output is not None else 'GM'
 
-    conds = {getattr(v, str(key)): value for key, value in kwargs.items() if getattr(v, str(key), None) is not None}
-    eq_callables = build_callables(dbf, comps, active_phases, conds=conds,
-                                   model=model_dict,
-                                   parameters=parameters,
-                                   output=output, callables=callables_dict, build_gradients=False,
-                                   verbose=False)
+    # Implicitly add 'N' state variable as a string to keyword arguements if it's not passed
+    if kwargs.get('N') is None:
+        kwargs['N'] = 1
+    if np.any(np.array(kwargs['N']) != 1):
+        raise ConditionError('N!=1 is not yet supported, got N={}'.format(kwargs['N']))
 
-    phase_records = eq_callables['phase_records']
-    state_variables = eq_callables['state_variables']
-    models = eq_callables['model']
-    maximum_internal_dof = max(len(mod.site_fractions) for mod in models.values())
-
-    # Convert keyword strings to proper state variable objects
+    # TODO: conditions dict of StateVariable instances should become part of the calculate API
+    statevar_strings = [sv for sv in kwargs.keys() if getattr(v, sv) is not None]
     # If we don't do this, sympy will get confused during substitution
-    statevar_dict = dict((v.StateVariable(key), unpack_condition(value)) for (key, value) in kwargs.items()
-                         if str(key) in [str(x) for x in state_variables])
-
+    statevar_dict = dict((v.StateVariable(key), unpack_condition(value)) for key, value in kwargs.items() if key in statevar_strings)
     # Sort after default state variable check to fix gh-116
     statevar_dict = collections.OrderedDict(sorted(statevar_dict.items(), key=lambda x: str(x[0])))
+    phase_records = build_phase_records(dbf, comps, active_phases, statevar_dict,
+                                   models=models, parameters=parameters,
+                                   output=output, callables=callables,
+                                   verbose=kwargs.pop('verbose', False))
     str_statevar_dict = collections.OrderedDict((str(key), unpack_condition(value)) \
                                                 for (key, value) in statevar_dict.items())
-
+    maximum_internal_dof = max(len(mod.site_fractions) for mod in models.values())
     for phase_name, phase_obj in sorted(active_phases.items()):
         mod = models[phase_name]
         phase_record = phase_records[phase_name]

--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -312,6 +312,7 @@ def calculate(dbf, comps, phases, mode=None, output='GM', fake_points=False, bro
     if points_dict is None and broadcast is False:
         raise ValueError('The \'points\' keyword argument must be specified if broadcast=False is also given.')
     nonvacant_components = [x for x in sorted(comps) if x.number_of_atoms > 0]
+    # TODO: check unspecified state variables
 
     all_phase_data = []
     largest_energy = 1e10

--- a/pycalphad/core/constraints.py
+++ b/pycalphad/core/constraints.py
@@ -1,6 +1,7 @@
 from sympy import ImmutableMatrix, MatrixSymbol, Symbol
 from pycalphad.codegen.sympydiff_utils import AutowrapFunction, CompileLock
 from pycalphad.core.cache import cacheit
+from pycalphad import variables as v
 from pycalphad.core.constants import INTERNAL_CONSTRAINT_SCALING, MULTIPHASE_CONSTRAINT_SCALING
 from collections import namedtuple
 
@@ -70,9 +71,9 @@ def build_constraints(mod, variables, conds, parameters=None):
     multiphase_constraints = mod.get_multiphase_constraints(conds)
     multiphase_constraints = [MULTIPHASE_CONSTRAINT_SCALING*x for x in multiphase_constraints]
     # TODO: Conditions needing Hessians should probably have a 'second-order' tag or something
-    has_chempots = any(str(cond).startswith('MU') for cond in conds.keys())
+    need_hess = any(type(c) in v.CONDITIONS_REQUIRING_HESSIANS for c in conds.keys())
     cf_output = _build_constraint_functions(variables, internal_constraints,
-                                            include_hess=has_chempots, parameters=parameters)
+                                            include_hess=need_hess, parameters=parameters)
     internal_cons = cf_output.cons_func
     internal_jac = cf_output.cons_jac
     internal_cons_hess = cf_output.cons_hess

--- a/pycalphad/core/equilibrium.py
+++ b/pycalphad/core/equilibrium.py
@@ -192,7 +192,6 @@ def equilibrium(dbf, comps, phases, conditions, output=None, model=None,
     --------
     None yet.
     """
-    from pycalphad import __version__ as pycalphad_version
     if not broadcast:
         raise NotImplementedError('Broadcasting cannot yet be disabled')
     comps = sorted(unpack_components(dbf, comps))
@@ -209,7 +208,8 @@ def equilibrium(dbf, comps, phases, conditions, output=None, model=None,
     if len(set(comps) - set(dbf.species)) > 0:
         raise EquilibriumError('Components not found in database: {}'
                                .format(','.join([c.name for c in (set(comps) - set(dbf.species))])))
-
+    # TODO: check unspecified state variables
+    # TODO: determine whether to build Hessians (MU and NP conditions)
     calc_opts = calc_opts if calc_opts is not None else dict()
     model = model if model is not None else Model
     solver = solver if solver is not None else InteriorPointSolver(verbose=verbose)

--- a/pycalphad/core/equilibrium.py
+++ b/pycalphad/core/equilibrium.py
@@ -5,11 +5,11 @@ calculated phase equilibria.
 from __future__ import print_function
 import warnings
 import pycalphad.variables as v
-from pycalphad.core.utils import unpack_components, unpack_condition, unpack_phases, filter_phases
-from pycalphad import calculate, Model
+from pycalphad.core.utils import unpack_components, unpack_condition, unpack_phases, filter_phases, instantiate_models, get_state_variables
+from pycalphad import calculate
 from pycalphad.core.errors import EquilibriumError, ConditionError
 from pycalphad.core.starting_point import starting_point
-from pycalphad.codegen.callables import build_callables
+from pycalphad.codegen.callables import build_phase_records
 from pycalphad.core.constants import MIN_SITE_FRACTION
 from pycalphad.core.eqsolver import _solve_eq_at_conditions
 from pycalphad.core.solver import InteriorPointSolver
@@ -141,10 +141,11 @@ def _eqcalculate(dbf, comps, phases, conditions, output, data=None, per_phase=Fa
         result['NP'] = data['NP'].copy()
     return result
 
+
 def equilibrium(dbf, comps, phases, conditions, output=None, model=None,
                 verbose=False, broadcast=True, calc_opts=None,
-                scheduler='sync',
-                parameters=None, solver=None, callables=None, **kwargs):
+                scheduler='sync', parameters=None, solver=None, callables=None,
+                **kwargs):
     """
     Calculate the equilibrium state of a system containing the specified
     components and phases, under the specified conditions.
@@ -208,19 +209,17 @@ def equilibrium(dbf, comps, phases, conditions, output=None, model=None,
     if len(set(comps) - set(dbf.species)) > 0:
         raise EquilibriumError('Components not found in database: {}'
                                .format(','.join([c.name for c in (set(comps) - set(dbf.species))])))
-    # TODO: check unspecified state variables
-    # TODO: determine whether to build Hessians (MU and NP conditions)
     calc_opts = calc_opts if calc_opts is not None else dict()
-    model = model if model is not None else Model
     solver = solver if solver is not None else InteriorPointSolver(verbose=verbose)
     parameters = parameters if parameters is not None else dict()
     if isinstance(parameters, dict):
         parameters = OrderedDict(sorted(parameters.items(), key=str))
+    models = instantiate_models(dbf, comps, active_phases, model=model, parameters=parameters)
     # Temporary solution until constraint system improves
-    if not conditions.get(v.N, False):
+    if conditions.get(v.N) is None:
         conditions[v.N] = 1
-    if conditions[v.N] != 1:
-        raise ConditionError('N!=1 is not yet supported')
+    if np.any(np.array(conditions[v.N]) != 1):
+        raise ConditionError('N!=1 is not yet supported, got N={}'.format(conditions[v.N]))
     # Modify conditions values to be within numerical limits, e.g., X(AL)=0
     # Also wrap single-valued conditions with lists
     conds = _adjust_conditions(conditions)
@@ -228,13 +227,13 @@ def equilibrium(dbf, comps, phases, conditions, output=None, model=None,
     for cond in conds.keys():
         if isinstance(cond, (v.Composition, v.ChemicalPotential)) and cond.species not in comps:
             raise ConditionError('{} refers to non-existent component'.format(cond))
+    state_variables = sorted(get_state_variables(models=models, conds=conds), key=str)
     str_conds = OrderedDict((str(key), value) for key, value in conds.items())
     num_calcs = np.prod([len(i) for i in str_conds.values()])
     components = [x for x in sorted(comps)]
     desired_active_pure_elements = [list(x.constituents.keys()) for x in components]
     desired_active_pure_elements = [el.upper() for constituents in desired_active_pure_elements for el in constituents]
     pure_elements = sorted(set([x for x in desired_active_pure_elements if x != 'VA']))
-    other_output_callables = {}
     if verbose:
         print('Components:', ' '.join([str(x) for x in comps]))
         print('Phases:', end=' ')
@@ -243,41 +242,29 @@ def equilibrium(dbf, comps, phases, conditions, output=None, model=None,
     output = set(output)
     output |= {'GM'}
     output = sorted(output)
-    for o in output:
-        if o == 'GM':
-            eq_callables = build_callables(dbf, comps, active_phases, conds=conds,
-                                           model=model,
-                                           parameters=parameters,
-                                           output=o, build_gradients=True, callables=callables,
-                                           verbose=verbose)
-        else:
-            other_output_callables[o] = build_callables(dbf, comps, active_phases, conds=conds,
-                                                        model=model,
-                                                        parameters=parameters,
-                                                        output=o, build_gradients=False,
-                                                        verbose=False)
-
-    phase_records = eq_callables['phase_records']
-    state_variables = eq_callables['state_variables']
-    models = eq_callables['model']
-
+    need_hessians = any(type(c) in v.CONDITIONS_REQUIRING_HESSIANS for c in conds.keys())
+    phase_records = build_phase_records(dbf, comps, active_phases, conds, models,
+                                        output='GM', callables=callables,
+                                        parameters=parameters, verbose=verbose,
+                                        build_gradients=True, build_hessians=need_hessians)
     if verbose:
         print('[done]', end='\n')
 
     # 'calculate' accepts conditions through its keyword arguments
     grid_opts = calc_opts.copy()
-    grid_opts.update({key: value for key, value in str_conds.items() if key in [str(x) for x in state_variables]})
+    statevar_strings = [str(x) for x in state_variables]
+    grid_opts.update({key: value for key, value in str_conds.items() if key in statevar_strings})
     if 'pdens' not in grid_opts:
         grid_opts['pdens'] = 500
-    grid = delayed(calculate, pure=False)(dbf, comps, active_phases, output='GM',
-                                          model=models, fake_points=True, callables=eq_callables,
+    grid = delayed(calculate, pure=False)(dbf, comps, active_phases,
+                                          model=models, fake_points=True,
+                                          callables=callables, output='GM',
                                           parameters=parameters, **grid_opts)
-    nonvacant_elements = phase_records[active_phases[0]].nonvacant_elements
     coord_dict = str_conds.copy()
     coord_dict['vertex'] = np.arange(
         len(pure_elements) + 1)  # +1 is to accommodate the degenerate degree of freedom at the invariant reactions
-    coord_dict['component'] = nonvacant_elements
-    grid_shape = tuple(len(x) for x in conds.values()) + (len(nonvacant_elements)+1,)
+    coord_dict['component'] = pure_elements
+    grid_shape = tuple(len(x) for x in conds.values()) + (len(pure_elements)+1,)
     properties = delayed(starting_point, pure=False)(conds, state_variables, phase_records, grid)
     conditions_per_chunk_per_axis = 2
     if num_calcs > 1:
@@ -320,7 +307,7 @@ def equilibrium(dbf, comps, phases, conditions, output=None, model=None,
             per_phase = False
         eqcal = delayed(_eqcalculate, pure=False)(dbf, comps, active_phases, conditions, out,
                                                   data=properties, per_phase=per_phase,
-                                                  callables=other_output_callables[out],
+                                                  callables=callables,
                                                   parameters=parameters,
                                                   model=models, **calc_opts)
         properties = delayed(properties.merge, pure=False)(eqcal, compat='equals')

--- a/pycalphad/core/utils.py
+++ b/pycalphad/core/utils.py
@@ -398,10 +398,16 @@ def instantiate_models(dbf, comps, phases, model=None, parameters=None, symbols_
     -------
 
     """
-    from pycalphad import Model
+    from pycalphad import Model  # avoid cyclic imports
     parameters = parameters if parameters is not None else {}
     if symbols_only:
         parameters, _ = extract_parameters(parameters)
+    if isinstance(model, Model):  # Check that this instance is compatible with phases
+        if len(phases) > 1:
+            raise ValueError("Cannot instantiate models for multiple phases ({}) using a Model instance ({}, phase: {})".format(phases, model, model.phase_name))
+        else:
+            if phases[0] != model.phase_name:
+                raise ValueError("Cannot instantiate models because the desired {} phase does not match the Model instance () {} phase.".format(phases[0], model.phase_name, model))
     models_dict = unpack_kwarg(model, Model)
     for name in phases:
         mod = models_dict[name]

--- a/pycalphad/core/utils.py
+++ b/pycalphad/core/utils.py
@@ -3,7 +3,6 @@ The utils module handles helper routines for equilibrium calculation.
 """
 from __future__ import division
 import pycalphad.variables as v
-from pycalphad import Model
 from pycalphad.core.halton import halton
 from pycalphad.core.constants import MIN_SITE_FRACTION
 from sympy.utilities.lambdify import lambdify
@@ -375,7 +374,7 @@ def extract_parameters(parameters):
     return param_symbols, param_values
 
 
-def instantiate_models(dbf, comps, phases, models, parameters=None, symbols_only=True):
+def instantiate_models(dbf, comps, phases, model=None, parameters=None, symbols_only=True):
     """
 
     Parameters
@@ -386,22 +385,24 @@ def instantiate_models(dbf, comps, phases, models, parameters=None, symbols_only
         Names of components to consider in the calculation.
     phases : Iterable
         Names of phases to consider in the calculation.
-    models : Model class, a dict of phase names to Model, or a Iterable of both
+    model : Model class, a dict of phase names to Model, or a Iterable of both
         Model class to use for each phase.
     parameters : dict, optional
         Maps SymPy Symbol to numbers, for overriding the values of parameters in
         the Database.
     symbols_only : bool
-        If True, symbols will be extracted from the parameters dict as used to
+        If True, symbols will be extracted from the parameters dict and used to
         construct the Model instances.
 
     Returns
     -------
 
     """
+    from pycalphad import Model
+    parameters = parameters if parameters is not None else {}
     if symbols_only:
         parameters, _ = extract_parameters(parameters)
-    models_dict = unpack_kwarg(models, Model)
+    models_dict = unpack_kwarg(model, Model)
     for name in phases:
         mod = models_dict[name]
         if isinstance(mod, type):
@@ -424,6 +425,13 @@ def get_state_variables(models=None, conds=None):
     -------
     set
         State variables that are defined in the models and or conditions.
+
+    Examples
+    --------
+    >>> from pycalphad import variables as v
+    >>> from pycalphad.core.utils import get_state_variables
+    >>> get_state_variables(conds={v.P: 101325, v.N: 1, v.X('AL'): 0.2}) == {v.P, v.N, v.T}
+    True
     """
     state_vars = set()
     if models is not None:

--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -9,7 +9,7 @@ from tinydb import where
 import pycalphad.variables as v
 from pycalphad.core.errors import DofError
 from pycalphad.core.constants import MIN_SITE_FRACTION
-from pycalphad.core.utils import unpack_components, get_pure_elements
+from pycalphad.core.utils import unpack_components, get_pure_elements, wrap_symbol
 from pycalphad.core.constraints import is_multiphase_constraint
 import numpy as np
 from collections import OrderedDict
@@ -155,11 +155,6 @@ class Model(object):
         # This makes xreplace work with the symbols dict
         symbols = {Symbol(s): val for s, val in dbe.symbols.items()}
 
-        def wrap_symbol(obj):
-            if isinstance(obj, Symbol):
-                return obj
-            else:
-                return Symbol(obj)
         if parameters is not None:
             self._parameters_arg = parameters
             if isinstance(parameters, dict):

--- a/pycalphad/tests/test_calculate.py
+++ b/pycalphad/tests/test_calculate.py
@@ -46,11 +46,17 @@ def test_issue116():
     result_one_values = result_one.GM.values
     result_two = calculate(DBF, ['AL', 'CR', 'NI'], 'LIQUID', T=400, P=101325)
     result_two_values = result_two.GM.values
+    result_three = calculate(DBF, ['AL', 'CR', 'NI'], 'LIQUID', T=400, P=101325, N=1)
+    result_three_values = result_three.GM.values
     np.testing.assert_array_equal(np.squeeze(result_one_values), np.squeeze(result_two_values))
-    assert len(result_one_values.shape) == 2
+    np.testing.assert_array_equal(np.squeeze(result_one_values), np.squeeze(result_three_values))
+    # N is added automatically
+    assert len(result_one_values.shape) == 3  # N, T, points
     assert result_one_values.shape[0] == 1
-    assert len(result_two_values.shape) == 3
-    assert result_two_values.shape[:2] == (1, 1)
+    assert len(result_two_values.shape) == 4  # N, P, T, points
+    assert result_two_values.shape[:3] == (1, 1, 1)
+    assert len(result_three_values.shape) == 4  # N, P, T, points
+    assert result_three_values.shape[:3] == (1, 1, 1)
 
 
 def test_calculate_some_phases_filtered():

--- a/pycalphad/tests/test_calculate.py
+++ b/pycalphad/tests/test_calculate.py
@@ -4,7 +4,7 @@ Model quantities correctly.
 """
 
 import nose.tools
-from pycalphad import Database, calculate
+from pycalphad import Database, calculate, Model
 import numpy as np
 try:
     # Python 2
@@ -72,6 +72,24 @@ def test_calculate_raises_with_no_active_phases_passed():
     """Passing inactive phases to calculate() raises a ConditionError."""
     # Phase cannot be built without FE
     calculate(ALFE_DBF, ['AL', 'VA'], ['AL13FE4'], T=1200, P=101325)
+
+
+@nose.tools.raises(ValueError)
+def test_incompatible_model_instance_raises():
+    "Calculate raises when an incompatible Model instance built with a different phase is passed."
+    comps = ['AL', 'CR', 'NI']
+    phase_name = 'L12_FCC'
+    mod = Model(DBF, comps, 'LIQUID')  # Model instance does not match the phase
+    calculate(DBF, comps, phase_name, T=1400.0, output='_fail_', model=mod)
+
+
+@nose.tools.raises(ValueError)
+def test_single_model_instance_raises():
+    "Calculate raises when a single Model instance is passed with multiple phases."
+    comps = ['AL', 'CR', 'NI']
+    phase_name = 'L12_FCC'
+    mod = Model(DBF, comps, 'L12_FCC')  # Model instance does not match the phase
+    calculate(DBF, comps, ['LIQUID', 'L12_FCC'], T=1400.0, output='_fail_', model=mod)
 
 
 if __name__ == '__main__':

--- a/pycalphad/tests/test_equilibrium.py
+++ b/pycalphad/tests/test_equilibrium.py
@@ -13,6 +13,7 @@ import numpy as np
 from pycalphad import Database, Model, calculate, equilibrium, EquilibriumError, ConditionError
 from pycalphad.codegen.callables import build_callables
 from pycalphad.core.solver import SolverBase, InteriorPointSolver
+from pycalphad.core.utils import get_state_variables
 import pycalphad.variables as v
 from pycalphad.tests.datasets import *
 
@@ -357,12 +358,10 @@ def test_eq_build_callables_with_parameters():
     dbf = AL_PARAMETER_DBF
     phases = ['FCC_A1']
     conds = {v.P: 101325, v.T: 500, v.N: 1}
+    conds_statevars = get_state_variables(conds=conds)
+    models = {'FCC_A1': Model(dbf, comps, 'FCC_A1', parameters=['VV0000'])}
     # build callables with a parameter of 20000.0
-    callables = build_callables(dbf, comps, phases, conds=conds, parameters={'VV0000': 20000})
-
-    # Check that passing callables should skip the build phase, but use the values from 'VV0000' saved in callables
-    eq_res = equilibrium(dbf, comps, phases, conds, callables=callables)
-    np.testing.assert_allclose(eq_res.GM.values.squeeze(), 20000.0)
+    callables = build_callables(dbf, comps, phases, models=models, parameter_symbols=['VV0000'], additional_statevars=conds_statevars)
 
     # Check that passing callables should skip the build phase, but use the values from 'VV0000' as passed in parameters
     eq_res = equilibrium(dbf, comps, phases, conds, callables=callables, parameters={'VV0000': 10000})

--- a/pycalphad/variables.py
+++ b/pycalphad/variables.py
@@ -252,3 +252,5 @@ site_fraction = Y = SiteFraction
 X = Composition
 MU = ChemicalPotential
 si_gas_constant = R = Float(8.3145) # ideal gas constant
+
+CONDITIONS_REQUIRING_HESSIANS = {ChemicalPotential, PhaseFraction}


### PR DESCRIPTION
The following changes are made:

1. `build_callables` now becomes `build_callables` and `build_phase_records`. 
    - Both require that correctly instantated model dicts, i.e. {'PHASE_NAME': Model()}
    - `build_callables` should be called by users and just builds the callable functions and JIT compiles them. It returns a dict of `{'output': {'callables': {'PHASE_NAME': AutowrapFunc()}, 'massfuncs': {'PHASE_NAME': AutowrapFunc()}, ...}}`. These callables are passed to equilibrium and calculate.
    - Calculate and equilibrium should be calling `build_phase_records`, which optionally take `callables`. If callables are provided for the output, they are not recomputed (if users pass callables, they are responsible for determine if they are compatible). If no callables are passed, compatible ones will be built automatically.
    - `equilibrium` should not be building callables or phase records for other outputs. It just passes along the user callables (if they are provided) and `calculate` handles building the phase records for the particular outputs in `_eqcalculate`.
   - It is the responsibility of the caller of `build_callables` to know whether gradients and Hessians are required. This means two cases can exist. Either the user calls `build_callables` (the user is responsible) or `build_callables` is called by `build_phase_records` (`calculate`/`equilibrium` are responsible for propagating the correct settings). For `calculate`, no gradients or Hessians are built. For `equilibrium`, gradients are always built, and Hessians are built if any of the conditions are instances of the classes in `pycalphad.variables.CONDITIONS_REQUIRING_HESSIANS`.
2. This also refactors all the code where state variables and models were retrieved from the result of the old `build_callables`. Getting these additional outputs violates single the responsibility principle. A convenience function for getting state variables from models and or conditions now exists for `calculate`, `equilibrium`, and `build_callables`/`build_phase_records` to use.
3. The following code in the test `test_eq_build_callables_with_parameters` was removed, because this is not valid - parameters are not added automatically through build callables because `PhaseRecords` are no longer built in `build_callables`.
```python
    # Check that passing callables should skip the build phase, but use the values from 'VV0000' saved in callables
    eq_res = equilibrium(dbf, comps, phases, conds, callables=callables)
    np.testing.assert_allclose(eq_res.GM.values.squeeze(), 20000.0)
```
4. v.N now gets specified automatically in calculate. Previously, it was automatically specified in equilibrium, but not calculate. When `calculate` was called from `equilibrium` that there was an extra dimension for `v.N` that is not present when `calculate` alone was called. A user-friendly alternative to the ConditionError error message is written if `v.N` is not in the equilibrium or calculate conditions. This would cause the `callables` to give incorrect answers in either `calculate` or `equilibrium` if called separately. All callables should be built with the `v.N` statevariable (while v.N=1 is a required condition internally) so that the behavior is constistent with both. Users building callables by hand should be aware that they may need to add `v.N` to the callables by the `additional_statevars` argument of `build_callables`. `test_issue116` was updated to reflect that N is added automatically. As much as possible, we should try to progressively expose pycalphad variables objects to the end user - IMO we state variables should be part of a state variables dict to calculate.
