### PR TITLE
FIX: Improve Model instantiation

### DIFF
--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -349,7 +349,7 @@ def calculate(dbf, comps, phases, mode=None, output='GM', fake_points=False, bro
                                    verbose=kwargs.pop('verbose', False))
     str_statevar_dict = collections.OrderedDict((str(key), unpack_condition(value)) \
                                                 for (key, value) in statevar_dict.items())
-    maximum_internal_dof = max(len(mod.site_fractions) for mod in models.values())
+    maximum_internal_dof = max(len(models[phase_name].site_fractions) for phase_name in active_phases)
     for phase_name, phase_obj in sorted(active_phases.items()):
         mod = models[phase_name]
         phase_record = phase_records[phase_name]

--- a/pycalphad/core/utils.py
+++ b/pycalphad/core/utils.py
@@ -396,7 +396,8 @@ def instantiate_models(dbf, comps, phases, model=None, parameters=None, symbols_
 
     Returns
     -------
-
+    dict
+        Dictionary of Model instances corresponding to the passed phases.
     """
     from pycalphad import Model  # avoid cyclic imports
     parameters = parameters if parameters is not None else {}
@@ -408,11 +409,14 @@ def instantiate_models(dbf, comps, phases, model=None, parameters=None, symbols_
         else:
             if phases[0] != model.phase_name:
                 raise ValueError("Cannot instantiate models because the desired {} phase does not match the Model instance () {} phase.".format(phases[0], model.phase_name, model))
-    models_dict = unpack_kwarg(model, Model)
+    models_defaultdict = unpack_kwarg(model, Model)
+    models_dict = {}
     for name in phases:
-        mod = models_dict[name]
+        mod = models_defaultdict[name]
         if isinstance(mod, type):
             models_dict[name] = mod(dbf, comps, name, parameters=parameters)
+        else:
+            models_dict[name] = mod
     return models_dict
 
 

--- a/pycalphad/tests/test_utils.py
+++ b/pycalphad/tests/test_utils.py
@@ -35,7 +35,7 @@ def test_instantiate_models_only_returns_desired_phases():
     assert len(inst_mods) == len(phases)
 
     # models are underspecified w.r.t. phases
-    too_few_phases = ['FCC_A1', 'LIQUID', 'AL3NI1']
-    too_few_models = {phase: Model(ALNIPT_DBF, comps, phase) for phase in too_many_phases}
+    too_few_phases = ['FCC_A1']
+    too_few_models = {phase: Model(ALNIPT_DBF, comps, phase) for phase in too_few_phases}
     inst_mods = instantiate_models(ALNIPT_DBF, comps, phases, model=too_few_models)
     assert len(inst_mods) == len(phases)

--- a/pycalphad/tests/test_utils.py
+++ b/pycalphad/tests/test_utils.py
@@ -2,8 +2,8 @@
 The utils test module contains tests for pycalphad utilities.
 """
 
-from pycalphad import Database
-from pycalphad.core.utils import filter_phases, unpack_components
+from pycalphad import Database, Model
+from pycalphad.core.utils import filter_phases, unpack_components, instantiate_models
 
 from pycalphad.tests.datasets import ALNIPT_TDB
 
@@ -15,9 +15,27 @@ def test_filter_phases_removes_disordered_phases_from_order_disorder():
     filtered_phases = set(filter_phases(ALNIPT_DBF, unpack_components(ALNIPT_DBF, ['AL', 'NI', 'PT', 'VA'])))
     assert all_phases.difference(filtered_phases) == {'FCC_A1'}
 
+
 def test_filter_phases_removes_phases_with_inactive_sublattices():
     """Phases that have no active components in any sublattice should be filtered"""
     all_phases = set(ALNIPT_DBF.phases.keys())
     filtered_phases = set(filter_phases(ALNIPT_DBF, unpack_components(ALNIPT_DBF, ['AL', 'NI', 'VA'])))
     assert all_phases.difference(filtered_phases) == {'FCC_A1', 'PT8AL21', 'PT5AL21', 'PT2AL', 'PT2AL3', 'PT5AL3', 'ALPT2'}
 
+
+def test_instantiate_models_only_returns_desired_phases():
+    """instantiate_models should only return phases passed"""
+    comps = ['AL', 'NI', 'VA']
+    phases = ['FCC_A1', 'LIQUID']
+
+    # models are overspecified w.r.t. phases
+    too_many_phases = ['FCC_A1', 'LIQUID', 'AL3NI1']
+    too_many_models = {phase: Model(ALNIPT_DBF, comps, phase) for phase in too_many_phases}
+    inst_mods = instantiate_models(ALNIPT_DBF, comps, phases, model=too_many_models)
+    assert len(inst_mods) == len(phases)
+
+    # models are underspecified w.r.t. phases
+    too_few_phases = ['FCC_A1', 'LIQUID', 'AL3NI1']
+    too_few_models = {phase: Model(ALNIPT_DBF, comps, phase) for phase in too_many_phases}
+    inst_mods = instantiate_models(ALNIPT_DBF, comps, phases, model=too_few_models)
+    assert len(inst_mods) == len(phases)


### PR DESCRIPTION
Two changes here:

1. `instantiate_models` now returns a dict instead of a default dict to be more explicit. Only phases passed to `instantiate_models` are included.
2. Fixed a subtle bug in calculate where over-specified models could have led to inconsistent maximum internal degree of freedom between `calculate` and `starting_point` because `calculate` based the internal dof size on all the model instances, while starting_point used the phase records (active phases only).