### PR TITLE
MAINT: Relax dask requirements

### DIFF
--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - pyparsing
     - tinydb >=3.8
     - scipy
-    - dask >=1.2.0
+    - dask >=0.18.0
     - distributed
     - numpy >=1.13
     - dill
@@ -54,7 +54,7 @@ requirements:
     - pyparsing
     - tinydb >=3.8
     - scipy
-    - dask >=1.2.0
+    - dask >=0.18.0
     - distributed
     - numpy >=1.13
     - cython >=0.24

--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ setup(
     long_description=read('README.rst'),
     url='https://pycalphad.org/',
     install_requires=['matplotlib', 'pandas', 'xarray>=0.11.2', 'sympy==1.4', 'pyparsing', 'Cython>=0.24',
-                      'tinydb>=3.8', 'scipy', 'numpy>=1.13', 'dask[complete]>=1.2', 'dill', 'ipopt', 'symengine'],
+                      'tinydb>=3.8', 'scipy', 'numpy>=1.13', 'dask[complete]>=0.18.0', 'dill', 'ipopt', 'symengine'],
     classifiers=[
         # How mature is this project? Common values are
         #   3 - Alpha


### PR DESCRIPTION
Relax dask requirements to the minimum required for `scheduler=` syntax