### PR TITLE
FIX: SymPy namespace clash with TDBs, and other deprecation fixes

### DIFF
--- a/pycalphad/core/cache.py
+++ b/pycalphad/core/cache.py
@@ -6,7 +6,11 @@ The difference is _HashedSeq has been modified to use a custom hash function.
 http://code.activestate.com/recipes/578078-py26-and-py30-backport-of-python-33s-lru-cache/
 """
 
-from collections import Iterable, Mapping, namedtuple
+try:
+    from collections.abc import Iterable, Mapping
+except ImportError:
+    from collections import Iterable, Mapping
+from collections import namedtuple
 from threading import RLock
 from functools import update_wrapper
 

--- a/pycalphad/core/utils.py
+++ b/pycalphad/core/utils.py
@@ -6,13 +6,16 @@ import pycalphad.variables as v
 from pycalphad.core.halton import halton
 from pycalphad.core.constants import MIN_SITE_FRACTION
 from sympy.utilities.lambdify import lambdify
-from sympy.printing.lambdarepr import LambdaPrinter
 from sympy import Symbol
 import numpy as np
 import operator
 import functools
 import itertools
 import collections
+try:
+    from collections.abc import Iterable, Mapping
+except ImportError:
+    from collections import Iterable, Mapping
 
 try:
     # Only available in numpy 1.10 and newer
@@ -137,7 +140,7 @@ def unpack_condition(tup):
             return np.arange(tup[0], tup[1], tup[2], dtype=np.float)
         else:
             raise ValueError('Condition tuple is length {}'.format(len(tup)))
-    elif isinstance(tup, collections.Iterable):
+    elif isinstance(tup, Iterable):
         return [float(x) for x in tup]
     else:
         return [float(tup)]
@@ -242,14 +245,14 @@ def unpack_kwarg(kwarg_obj, default_arg=None):
     """
     new_dict = collections.defaultdict(lambda: default_arg)
 
-    if isinstance(kwarg_obj, collections.Mapping):
+    if isinstance(kwarg_obj, Mapping):
         new_dict.update(kwarg_obj)
     # kwarg_obj is a list containing a dict and a default
     # For now at least, we don't treat ndarrays the same as other iterables
     # ndarrays are assumed to be numeric arrays containing "default values", so don't match here
-    elif isinstance(kwarg_obj, collections.Iterable) and not isinstance(kwarg_obj, np.ndarray):
+    elif isinstance(kwarg_obj, Iterable) and not isinstance(kwarg_obj, np.ndarray):
         for element in kwarg_obj:
-            if isinstance(element, collections.Mapping):
+            if isinstance(element, Mapping):
                 new_dict.update(element)
             else:
                 # element=element syntax to silence var-from-loop warning

--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -96,7 +96,13 @@ def _parse_action(func):
     Source: Florian Brucker on StackOverflow
     http://stackoverflow.com/questions/10177276/pyparsing-setparseaction-function-is-getting-no-arguments
     """
-    num_args = len(inspect.getargspec(func).args)
+    if sys.version_info[0] > 2:
+        func_items = inspect.signature(func).parameters.items()
+        func_args = [name for name, param in func_items
+                     if param.kind == param.POSITIONAL_OR_KEYWORD]
+    else:
+        func_args = inspect.getargspec(func).args
+    num_args = len(func_args)
     if num_args > 3:
         raise ValueError('Input function must take at most 3 parameters.')
 

--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -640,7 +640,7 @@ def _apply_new_symbol_names(dbf, symbol_name_map):
     dbf.symbols = {name: S(expr).xreplace({Symbol(s): Symbol(v) for s, v in symbol_name_map.items()}) for name, expr in dbf.symbols.items()}
     # finally propagate through to the parameters
     for p in dbf._parameters.all():
-        dbf._parameters.update({'parameter': S(p['parameter']).xreplace({Symbol(s): Symbol(v) for s, v in symbol_name_map.items()})}, eids=[p.eid])
+        dbf._parameters.update({'parameter': S(p['parameter']).xreplace({Symbol(s): Symbol(v) for s, v in symbol_name_map.items()})}, doc_ids=[p.doc_id])
 
 
 def write_tdb(dbf, fd, groupby='subsystem', if_incompatible='warn'):

--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -60,12 +60,7 @@ def _sympify_string(math_string):
     expr_string = \
         re.sub(r'(?<!\w)EXP(?!\w)', 'exp', expr_string,
                flags=re.IGNORECASE)
-    # Convert raw variables into StateVariable objects
-    variable_fixes = {
-        Symbol('T'): v.T,
-        Symbol('P'): v.P,
-        Symbol('R'): v.R
-    }
+
     # sympify uses eval, so we need to sanitize the input
     nodes = ast.parse(expr_string)
     nodes = ast.Expression(nodes.body[0].value)

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -560,3 +560,8 @@ def test_database_parameter_with_species_that_is_not_a_stoichiometric_formula():
     sbminus3 = dbf._parameters.search(tinydb.where('constituent_array') == ((species_dict['SB-3'],),))
     assert len(sbminus3) == 1
     assert sbminus3[0]['parameter'].args[0][0] == 10000
+
+
+def test_database_sympy_namespace_clash():
+    """Symbols that clash with sympy special objects are replaced (gh-233)"""
+    Database.from_string("""FUNCTION TEST 0.01 T*LN(CC)+FF; 6000 N TW !""", fmt='tdb')


### PR DESCRIPTION
Fixes gh-233 and fixes gh-231.

This also addresses the deprecation of `inspect.getargspec` in Python 3, as well as a reorganization of the `collections` standard library module set to go into effect in Python 3.8.

For future error reporting, the TDB parser will include some details about the line in the TDB file which caused any exception, regardless of whether it is a syntax mistake in the TDB file (`ParseException`) or a bug further up the stack. 