### PR TITLE
FIX: pure vacancy phase detection

### DIFF
--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -136,6 +136,7 @@ class Model(object):
         self.site_ratios = tuple(self.site_ratios)
 
         # Verify that this phase is still possible to build
+        is_pure_VA = set()
         for sublattice in phase.constituents:
             sublattice_comps = set(sublattice).intersection(self.components)
             if len(sublattice_comps) == 0:
@@ -146,13 +147,14 @@ class Model(object):
                     .format(self.phase_name, sublattice,
                             phase.constituents,
                             self.components))
-            if sum(set(map(lambda s : getattr(s, 'number_of_atoms'),sublattice_comps))) == 0:
-                #The only possible component in a sublattice is vacancy
-                #We cannot build a model of this phase
-                raise DofError(
-                    '{0}: Sublattices of {1} contains only VA (VACUUM) constituents' \
-                    .format(self.phase_name, phase.constituents))
+            is_pure_VA.add(sum(set(map(lambda s : getattr(s, 'number_of_atoms'),sublattice_comps))))
             self.constituents.append(sublattice_comps)
+        if sum(is_pure_VA) == 0:
+            #The only possible component in a sublattice is vacancy
+            #We cannot build a model of this phase
+            raise DofError(
+                '{0}: Sublattices of {1} contains only VA (VACUUM) constituents' \
+                .format(self.phase_name, phase.constituents))
         self.components = sorted(self.components)
         desired_active_pure_elements = [list(x.constituents.keys()) for x in self.components]
         desired_active_pure_elements = [el.upper() for constituents in desired_active_pure_elements

--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -1097,7 +1097,3 @@ class TestModel(Model):
                                                                 for j in range(kmax)]))**2
                       for i in range(kmax)])
         self.models['test'] = scale_factor * Add(*[(varname - sol)**2 for varname, sol in self.solution.items()]) + polys
-
-
-
-#%%

--- a/pycalphad/tests/datasets.py
+++ b/pycalphad/tests/datasets.py
@@ -4310,3 +4310,18 @@ $
 $------------------------------------------------------------ END OF LINE
 $ CU-MG NIMS
 """
+
+ZRO2_CUBIC_BCC_TDB = """
+ ELEMENT /-   ELECTRON_GAS              0.0000E+00  0.0000E+00  0.0000E+00!
+ ELEMENT VA   VACUUM                    0.0000E+00  0.0000E+00  0.0000E+00!
+ ELEMENT AL   FCC_A1                    2.6982E+01  4.5773E+03  2.8321E+01!
+ ELEMENT CU   FCC_A1                    6.3546E+01  5.0041E+03  3.3150E+01!
+ ELEMENT O    1/2_MOLE_O2(G)            1.5999E+01  4.3410E+03  1.0252E+02!
+ ELEMENT ZR   HCP_A3                    9.1224E+01  5.5663E+03  3.9181E+01!
+
+ PHASE BCC_A2  %  2 1   3 !
+    CONSTITUENT BCC_A2  :AL,CU,ZR : O,VA% :  !
+
+ PHASE ZRO2_CUBIC  %  2 1   2 !
+    CONSTITUENT ZRO2_CUBIC  :VA,ZR% : O%,VA :  !
+"""

--- a/pycalphad/tests/test_model.py
+++ b/pycalphad/tests/test_model.py
@@ -3,8 +3,10 @@ The test_model module contains unit tests for the Model object.
 """
 from __future__ import print_function
 from pycalphad import Database, Model, variables as v, equilibrium
-from pycalphad.tests.datasets import ALCRNI_TDB, ALNIPT_TDB, ALFE_TDB
+from pycalphad.tests.datasets import ALCRNI_TDB, ALNIPT_TDB, ALFE_TDB, ZRO2_CUBIC_BCC_TDB
+from pycalphad.core.errors import DofError
 import numpy as np
+import pytest
 
 ALCRNI_DBF = Database(ALCRNI_TDB)
 ALNIPT_DBF = Database(ALNIPT_TDB)
@@ -61,3 +63,9 @@ def test_degree_of_ordering():
     eqx = equilibrium(ALFE_DBF, comps, my_phases, conds, output='degree_of_ordering', verbose=True)
     print('Degree of ordering: {}'.format(eqx.degree_of_ordering.sel(vertex=0).values.flatten()))
     assert np.isclose(eqx.degree_of_ordering.sel(vertex=0).values.flatten(), np.array([0.66663873]))
+
+def test_detect_pure_vacancy_phases():
+    "Detecting a pure vacancy phase"
+    dbf = Database(ZRO2_CUBIC_BCC_TDB)
+    with pytest.raises(DofError):
+        Model(dbf,['AL','CU','VA'],'ZRO2_CUBIC')


### PR DESCRIPTION
Bugfix to detect phases containing pure vacancy sublattices, according to: https://github.com/pycalphad/pycalphad/issues/191

When any phase satisfies the requirement (containing at least one pure vacancy sublattice) an error message is raised. 