### PR TITLE
TST: CI maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,14 +40,14 @@ install:
       conda activate condaenv
       echo "!!! Installing pycalphad dependencies via conda"
       conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib pytest pytest-cov pandas sympy pyparsing dask dill python-symengine xarray cython cyipopt
+      echo "!!! conda installing test packages"
+      conda install sphinx sphinx_rtd_theme coveralls ipython
       echo "!!! pip pycalphad as editable"
       pip install -e .
 
 # Run test
 script:
   - |
-      echo "!!! pip installing test packages"
-      pip install sphinx sphinx_rtd_theme coveralls ipython
       echo "!!! conda list output"
       conda list
       echo "!!! matplotlib py27 fix"

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
       echo "!!! Installing pycalphad dependencies via conda"
       conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib pytest pytest-cov pandas sympy pyparsing dask dill python-symengine xarray cython cyipopt
       echo "!!! conda installing test packages"
-      conda install sphinx sphinx_rtd_theme coveralls ipython
+      conda install --yes sphinx sphinx_rtd_theme coveralls ipython
       echo "!!! pip pycalphad as editable"
       pip install -e .
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,4 +53,4 @@ install:
 build: false
 
 test_script:
-  - "python -c \"import pytest ; pytest.main()\" -s -v pycalphad"
+  - "python -c \"import pytest ; exit(pytest.main())\" -s -v pycalphad"

--- a/pycalphad/tests/test_energy.py
+++ b/pycalphad/tests/test_energy.py
@@ -20,9 +20,6 @@ CRFE_DBF = Database(CRFE_BCC_MAGNETIC_TDB)
 CUMG_DBF = Database(CUMG_TDB)
 VA_INTERACTION_DBF = Database(VA_INTERACTION_TDB)
 
-def test_junk():
-    assert 1 == 2
-
 def test_sympify_safety():
     "Parsing malformed strings throws exceptions instead of executing code."
     from pycalphad.io.tdb import _sympify_string

--- a/pycalphad/tests/test_energy.py
+++ b/pycalphad/tests/test_energy.py
@@ -20,6 +20,9 @@ CRFE_DBF = Database(CRFE_BCC_MAGNETIC_TDB)
 CUMG_DBF = Database(CUMG_TDB)
 VA_INTERACTION_DBF = Database(VA_INTERACTION_TDB)
 
+def test_junk():
+    assert 1 == 2
+
 def test_sympify_safety():
     "Parsing malformed strings throws exceptions instead of executing code."
     from pycalphad.io.tdb import _sympify_string


### PR DESCRIPTION
This PR updates 

* Travis CI's installation of the testing dependencies to use conda rather than pip, avoiding an issue where Python 3.6 failed to install the certifi package
* Appveyor's `pytest` call to correctly return the error code from the `pytest.main` function. Previously, the Python script exited at the end of the command with a successful error code, regardless of the status of the test suite.

The behavior was verified by writing a dummy `assert 1 == 2` test that caused all tests to fail (ade9aca), then removing that test to observe all tests succeeded (4a80675).