### PR TITLE
FIX: Calculating disordered phase only if respective ordered phase inactive

### DIFF
--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -9,7 +9,7 @@ from pycalphad import ConditionError
 from pycalphad.core.utils import point_sample, generate_dof
 from pycalphad.core.utils import endmember_matrix, unpack_kwarg
 from pycalphad.core.utils import broadcast_to, filter_phases, unpack_condition,\
-    unpack_components, get_state_variables, instantiate_models
+    unpack_components, get_state_variables, instantiate_models, check_order_disorder
 from pycalphad.core.light_dataset import LightDataset
 from pycalphad.core.cache import cacheit
 from pycalphad.core.phase_rec import PhaseRecord
@@ -318,6 +318,7 @@ def calculate(dbf, comps, phases, mode=None, output='GM', fake_points=False, bro
     # Consider only the active phases
     list_of_possible_phases = filter_phases(dbf, comps)
     active_phases = sorted(set(list_of_possible_phases).intersection(set(phases)))
+    active_phases = check_order_disorder(dbf, active_phases)
     active_phases = {name: dbf.phases[name] for name in active_phases}
     if len(list_of_possible_phases) == 0:
         raise ConditionError('There are no phases in the Database that can be active with components {0}'.format(comps))

--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -9,7 +9,7 @@ from pycalphad import ConditionError
 from pycalphad.core.utils import point_sample, generate_dof
 from pycalphad.core.utils import endmember_matrix, unpack_kwarg
 from pycalphad.core.utils import broadcast_to, filter_phases, unpack_condition,\
-    unpack_components, get_state_variables, instantiate_models, check_order_disorder
+    unpack_components, get_state_variables, instantiate_models
 from pycalphad.core.light_dataset import LightDataset
 from pycalphad.core.cache import cacheit
 from pycalphad.core.phase_rec import PhaseRecord
@@ -316,9 +316,8 @@ def calculate(dbf, comps, phases, mode=None, output='GM', fake_points=False, bro
     largest_energy = 1e10
 
     # Consider only the active phases
-    list_of_possible_phases = filter_phases(dbf, comps)
+    list_of_possible_phases = filter_phases(dbf, comps, phases)
     active_phases = sorted(set(list_of_possible_phases).intersection(set(phases)))
-    active_phases = check_order_disorder(dbf, active_phases)
     active_phases = {name: dbf.phases[name] for name in active_phases}
     if len(list_of_possible_phases) == 0:
         raise ConditionError('There are no phases in the Database that can be active with components {0}'.format(comps))

--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -316,14 +316,8 @@ def calculate(dbf, comps, phases, mode=None, output='GM', fake_points=False, bro
     largest_energy = 1e10
 
     # Consider only the active phases
-    list_of_possible_phases = filter_phases(dbf, comps, phases)
-    active_phases = sorted(set(list_of_possible_phases).intersection(set(phases)))
+    active_phases = filter_phases(dbf, comps, phases)
     active_phases = {name: dbf.phases[name] for name in active_phases}
-    if len(list_of_possible_phases) == 0:
-        raise ConditionError('There are no phases in the Database that can be active with components {0}'.format(comps))
-    if len(active_phases) == 0:
-        raise ConditionError('None of the passed phases ({0}) are active. List of possible phases: {1}.'
-                             .format(phases, list_of_possible_phases))
 
     models = instantiate_models(dbf, comps, list(active_phases.keys()), model=kwargs.pop('model', None), parameters=parameters)
 

--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -316,8 +316,12 @@ def calculate(dbf, comps, phases, mode=None, output='GM', fake_points=False, bro
     largest_energy = 1e10
 
     # Consider only the active phases
-    active_phases = filter_phases(dbf, comps, phases)
-    active_phases = {name: dbf.phases[name] for name in active_phases}
+    list_of_possible_phases = filter_phases(dbf, comps)
+    if len(list_of_possible_phases) == 0:
+        raise ConditionError('There are no phases in the Database that can be active with components {0}'.format(comps))
+    active_phases = {name: dbf.phases[name] for name in filter_phases(dbf, comps, phases)}
+    if len(active_phases) == 0:
+        raise ConditionError('None of the passed phases ({0}) are active. List of possible phases: {1}.'.format(phases, list_of_possible_phases))
 
     models = instantiate_models(dbf, comps, list(active_phases.keys()), model=kwargs.pop('model', None), parameters=parameters)
 

--- a/pycalphad/core/equilibrium.py
+++ b/pycalphad/core/equilibrium.py
@@ -186,7 +186,12 @@ def equilibrium(dbf, comps, phases, conditions, output=None, model=None,
     if not broadcast:
         raise NotImplementedError('Broadcasting cannot yet be disabled')
     comps = sorted(unpack_components(dbf, comps))
-    active_phases = filter_phases(dbf, comps, unpack_phases(phases))
+    list_of_possible_phases = filter_phases(dbf, comps)
+    if len(list_of_possible_phases) == 0:
+        raise ConditionError('There are no phases in the Database that can be active with components {0}'.format(comps))
+    active_phases = {name: dbf.phases[name] for name in filter_phases(dbf, comps, phases)}
+    if len(active_phases) == 0:
+        raise ConditionError('None of the passed phases ({0}) are active. List of possible phases: {1}.'.format(phases, list_of_possible_phases))
     if isinstance(comps, (str, v.Species)):
         comps = [comps]
     if len(set(comps) - set(dbf.species)) > 0:

--- a/pycalphad/core/equilibrium.py
+++ b/pycalphad/core/equilibrium.py
@@ -186,6 +186,7 @@ def equilibrium(dbf, comps, phases, conditions, output=None, model=None,
     if not broadcast:
         raise NotImplementedError('Broadcasting cannot yet be disabled')
     comps = sorted(unpack_components(dbf, comps))
+    phases = unpack_phases(phases) or sorted(dbf.phases.keys())
     list_of_possible_phases = filter_phases(dbf, comps)
     if len(list_of_possible_phases) == 0:
         raise ConditionError('There are no phases in the Database that can be active with components {0}'.format(comps))

--- a/pycalphad/core/equilibrium.py
+++ b/pycalphad/core/equilibrium.py
@@ -186,14 +186,7 @@ def equilibrium(dbf, comps, phases, conditions, output=None, model=None,
     if not broadcast:
         raise NotImplementedError('Broadcasting cannot yet be disabled')
     comps = sorted(unpack_components(dbf, comps))
-    phases = unpack_phases(phases) or sorted(dbf.phases.keys())
-    # remove phases that cannot be active
-    list_of_possible_phases = filter_phases(dbf, comps)
-    active_phases = sorted(set(list_of_possible_phases).intersection(set(phases)))
-    if len(list_of_possible_phases) == 0:
-        raise ConditionError('There are no phases in the Database that can be active with components {0}'.format(comps))
-    if len(active_phases) == 0:
-        raise ConditionError('None of the passed phases ({0}) are active. List of possible phases: {1}.'.format(phases, list_of_possible_phases))
+    active_phases = filter_phases(dbf, comps, unpack_phases(phases))
     if isinstance(comps, (str, v.Species)):
         comps = [comps]
     if len(set(comps) - set(dbf.species)) > 0:

--- a/pycalphad/core/utils.py
+++ b/pycalphad/core/utils.py
@@ -319,7 +319,7 @@ def get_pure_elements(dbf, comps):
     return pure_elements
 
 
-def filter_phases(dbf, comps):
+def filter_phases(dbf, comps, candidate_phases=None):
     """Return phases that are valid for equilibrium calculations for the given database and components
 
     Filters out phases that
@@ -332,7 +332,8 @@ def filter_phases(dbf, comps):
         Thermodynamic database containing the relevant parameters.
     comps : list
         Names of components to consider in the calculation.
-
+    candidate_phases : list
+        Names of phases to consider in the calculation, if not passed all phases from DBF will be considered
     Returns
     -------
     list
@@ -344,25 +345,14 @@ def filter_phases(dbf, comps):
         active_sublattices = [len(set(comps).intersection(subl)) > 0 for
                               subl in phase.constituents]
         return all(active_sublattices)
-
-    candidate_phases = dbf.phases.keys()
-    #disordered_phases = [dbf.phases[phase].model_hints.get('disordered_phase') for phase in candidate_phases]
+    if candidate_phases == None:
+        candidate_phases = dbf.phases.keys()
+    disordered_phases = [dbf.phases[phase].model_hints.get('disordered_phase') for phase in candidate_phases]
     phases = [phase for phase in candidate_phases if
-                all_sublattices_active(comps, dbf.phases[phase])]
+                all_sublattices_active(comps, dbf.phases[phase]) and
+                (phase not in disordered_phases or (phase in disordered_phases and 
+                dbf.phases[phase].model_hints.get('ordered_phase') not in candidate_phases))]
     return sorted(phases)
-
-
-def check_order_disorder(dbf, phases):
-    active_phases = phases.copy()
-    to_remove = []
-    for phase in active_phases:
-        ordered = getattr(dbf.phases[phase],'model_hints').get('ordered_phase')
-        if phase != ordered and ordered in phases:
-            to_remove.append(phase)
-    if len(to_remove) > 0:
-        for phase in to_remove:
-            active_phases.remove(phase)
-    return active_phases
 
 
 def extract_parameters(parameters):

--- a/pycalphad/core/utils.py
+++ b/pycalphad/core/utils.py
@@ -346,11 +346,23 @@ def filter_phases(dbf, comps):
         return all(active_sublattices)
 
     candidate_phases = dbf.phases.keys()
-    disordered_phases = [dbf.phases[phase].model_hints.get('disordered_phase') for phase in candidate_phases]
+    #disordered_phases = [dbf.phases[phase].model_hints.get('disordered_phase') for phase in candidate_phases]
     phases = [phase for phase in candidate_phases if
-                all_sublattices_active(comps, dbf.phases[phase]) and
-                phase not in disordered_phases]
+                all_sublattices_active(comps, dbf.phases[phase])]
     return sorted(phases)
+
+
+def check_order_disorder(dbf, phases):
+    active_phases = phases.copy()
+    to_remove = []
+    for phase in active_phases:
+        ordered = getattr(dbf.phases[phase],'model_hints').get('ordered_phase')
+        if phase != ordered and ordered in phases:
+            to_remove.append(phase)
+    if len(to_remove) > 0:
+        for phase in to_remove:
+            active_phases.remove(phase)
+    return active_phases
 
 
 def extract_parameters(parameters):

--- a/pycalphad/core/utils.py
+++ b/pycalphad/core/utils.py
@@ -5,7 +5,6 @@ from __future__ import division
 import pycalphad.variables as v
 from pycalphad.core.halton import halton
 from pycalphad.core.constants import MIN_SITE_FRACTION
-from pycalphad import ConditionError
 from sympy.utilities.lambdify import lambdify
 from sympy import Symbol
 import numpy as np
@@ -346,26 +345,16 @@ def filter_phases(dbf, comps, candidate_phases=None):
         active_sublattices = [len(set(comps).intersection(subl)) > 0 for
                               subl in phase.constituents]
         return all(active_sublattices)
-    dbf_phases = dbf.phases.keys()
     if candidate_phases == None:
-        phases = dbf_phases
+        candidate_phases = dbf.phases.keys()
     else:
-        phases = sorted(set(candidate_phases).intersection(dbf_phases))
-        if len(phases) == 0:
-            raise ConditionError('None of the candidate phases ({0}) are defined in the Database'
-                                .format(candidate_phases))
-    disordered_phases = [dbf.phases[phase].model_hints.get('disordered_phase') for phase in phases]
-    possible_phases = [phase for phase in phases if
-                all_sublattices_active(comps, dbf.phases[phase])]
-    if len(possible_phases) == 0:
-        raise ConditionError('There are no phases in the Database that can be active with components {0}'.format(comps))
-    active_phases = [phase for phase in possible_phases if
+        candidate_phases = set(candidate_phases).intersection(dbf.phases.keys())
+    disordered_phases = [dbf.phases[phase].model_hints.get('disordered_phase') for phase in candidate_phases]
+    phases = [phase for phase in candidate_phases if
+                all_sublattices_active(comps, dbf.phases[phase]) and
                 (phase not in disordered_phases or (phase in disordered_phases and 
-                dbf.phases[phase].model_hints.get('ordered_phase') not in phases))]
-    if len(active_phases) == 0:
-        raise ConditionError('None of the passed phases ({0}) are active. List of possible phases: {1}.'
-                            .format(candidate_phases, dbf_phases))
-    return sorted(active_phases)
+                dbf.phases[phase].model_hints.get('ordered_phase') not in candidate_phases))]
+    return sorted(phases)
 
 
 def extract_parameters(parameters):

--- a/pycalphad/tests/test_utils.py
+++ b/pycalphad/tests/test_utils.py
@@ -2,7 +2,8 @@
 The utils test module contains tests for pycalphad utilities.
 """
 
-from pycalphad import Database, Model
+import pytest
+from pycalphad import Database, Model, ConditionError
 from pycalphad.core.utils import filter_phases, unpack_components, instantiate_models
 
 from pycalphad.tests.datasets import ALNIPT_TDB, ALCRNI_TDB
@@ -30,6 +31,13 @@ def test_filter_phases_removes_phases_with_inactive_sublattices():
     all_phases = set(ALNIPT_DBF.phases.keys())
     filtered_phases = set(filter_phases(ALNIPT_DBF, unpack_components(ALNIPT_DBF, ['AL', 'NI', 'VA'])))
     assert all_phases.difference(filtered_phases) == {'FCC_A1', 'PT8AL21', 'PT5AL21', 'PT2AL', 'PT2AL3', 'PT5AL3', 'ALPT2'}
+
+
+def test_filter_phases_raising_error_when_candidate_phases_not_in_database():
+    comps = unpack_components(ALNIPT_DBF, ['AL', 'NI', 'VA'])
+    candidate_phases = ['SIGMA', 'CHI']
+    with pytest.raises(ConditionError):
+        set(filter_phases(ALNIPT_DBF, comps, candidate_phases))
 
 
 def test_instantiate_models_only_returns_desired_phases():

--- a/pycalphad/tests/test_utils.py
+++ b/pycalphad/tests/test_utils.py
@@ -3,27 +3,33 @@ The utils test module contains tests for pycalphad utilities.
 """
 
 from pycalphad import Database, Model
-from pycalphad.core.utils import filter_phases, unpack_components, instantiate_models, check_order_disorder
+from pycalphad.core.utils import filter_phases, unpack_components, instantiate_models
 
-from pycalphad.tests.datasets import ALNIPT_TDB
+from pycalphad.tests.datasets import ALNIPT_TDB, ALCRNI_TDB
 
 ALNIPT_DBF = Database(ALNIPT_TDB)
+ALCRNI_DBF = Database(ALCRNI_TDB)
 
 def test_filter_phases_removes_disordered_phases_from_order_disorder():
-    """Databases with order-disorder models should have the disordered phases be filtered."""
-#%%
-all_phases = set(ALNIPT_DBF.phases.keys())
-filtered_phases = set(filter_phases(ALNIPT_DBF, unpack_components(ALNIPT_DBF, ['AL', 'NI', 'PT', 'VA'])))
-active_phases = check_order_disorder(ALNIPT_DBF, filtered_phases)
-assert all_phases.difference(active_phases) == {'FCC_A1'}
-#%%
+    """Databases with order-disorder models should have the disordered phases be filtered if candidate_phases kwarg is not passed to filter_phases.
+    If candidate_phases kwarg is passed, disordered phases just are filtered if respective ordered phases are inactive"""
+    all_phases = set(ALNIPT_DBF.phases.keys())
+    filtered_phases = set(filter_phases(ALNIPT_DBF, unpack_components(ALNIPT_DBF, ['AL', 'NI', 'PT', 'VA'])))
+    assert all_phases.difference(filtered_phases) == {'FCC_A1'}
+    comps = unpack_components(ALCRNI_DBF, ['NI', 'AL', 'CR', 'VA'])
+    filtered_phases = set(filter_phases(ALCRNI_DBF, comps, ['FCC_A1', 'L12_FCC', 'LIQUID', 'BCC_A2']))
+    assert filtered_phases == {'L12_FCC', 'LIQUID', 'BCC_A2'}
+    filtered_phases = set(filter_phases(ALCRNI_DBF, comps, ['FCC_A1', 'LIQUID', 'BCC_A2']))
+    assert filtered_phases == {'FCC_A1', 'LIQUID', 'BCC_A2'}
+    filtered_phases = set(filter_phases(ALCRNI_DBF, comps, ['FCC_A1']))
+    assert filtered_phases == {'FCC_A1'}
+
 
 def test_filter_phases_removes_phases_with_inactive_sublattices():
     """Phases that have no active components in any sublattice should be filtered"""
     all_phases = set(ALNIPT_DBF.phases.keys())
     filtered_phases = set(filter_phases(ALNIPT_DBF, unpack_components(ALNIPT_DBF, ['AL', 'NI', 'VA'])))
-    active_phases = check_order_disorder(ALNIPT_DBF, filtered_phases)
-    assert all_phases.difference(active_phases) == {'FCC_A1', 'PT8AL21', 'PT5AL21', 'PT2AL', 'PT2AL3', 'PT5AL3', 'ALPT2'}
+    assert all_phases.difference(filtered_phases) == {'FCC_A1', 'PT8AL21', 'PT5AL21', 'PT2AL', 'PT2AL3', 'PT5AL3', 'ALPT2'}
 
 
 def test_instantiate_models_only_returns_desired_phases():

--- a/pycalphad/tests/test_utils.py
+++ b/pycalphad/tests/test_utils.py
@@ -3,7 +3,7 @@ The utils test module contains tests for pycalphad utilities.
 """
 
 import pytest
-from pycalphad import Database, Model, ConditionError
+from pycalphad import Database, Model
 from pycalphad.core.utils import filter_phases, unpack_components, instantiate_models
 
 from pycalphad.tests.datasets import ALNIPT_TDB, ALCRNI_TDB
@@ -31,13 +31,6 @@ def test_filter_phases_removes_phases_with_inactive_sublattices():
     all_phases = set(ALNIPT_DBF.phases.keys())
     filtered_phases = set(filter_phases(ALNIPT_DBF, unpack_components(ALNIPT_DBF, ['AL', 'NI', 'VA'])))
     assert all_phases.difference(filtered_phases) == {'FCC_A1', 'PT8AL21', 'PT5AL21', 'PT2AL', 'PT2AL3', 'PT5AL3', 'ALPT2'}
-
-
-def test_filter_phases_raising_error_when_candidate_phases_not_in_database():
-    comps = unpack_components(ALNIPT_DBF, ['AL', 'NI', 'VA'])
-    candidate_phases = ['SIGMA', 'CHI']
-    with pytest.raises(ConditionError):
-        set(filter_phases(ALNIPT_DBF, comps, candidate_phases))
 
 
 def test_instantiate_models_only_returns_desired_phases():

--- a/pycalphad/tests/test_utils.py
+++ b/pycalphad/tests/test_utils.py
@@ -3,7 +3,7 @@ The utils test module contains tests for pycalphad utilities.
 """
 
 from pycalphad import Database, Model
-from pycalphad.core.utils import filter_phases, unpack_components, instantiate_models
+from pycalphad.core.utils import filter_phases, unpack_components, instantiate_models, check_order_disorder
 
 from pycalphad.tests.datasets import ALNIPT_TDB
 
@@ -11,16 +11,19 @@ ALNIPT_DBF = Database(ALNIPT_TDB)
 
 def test_filter_phases_removes_disordered_phases_from_order_disorder():
     """Databases with order-disorder models should have the disordered phases be filtered."""
-    all_phases = set(ALNIPT_DBF.phases.keys())
-    filtered_phases = set(filter_phases(ALNIPT_DBF, unpack_components(ALNIPT_DBF, ['AL', 'NI', 'PT', 'VA'])))
-    assert all_phases.difference(filtered_phases) == {'FCC_A1'}
-
+#%%
+all_phases = set(ALNIPT_DBF.phases.keys())
+filtered_phases = set(filter_phases(ALNIPT_DBF, unpack_components(ALNIPT_DBF, ['AL', 'NI', 'PT', 'VA'])))
+active_phases = check_order_disorder(ALNIPT_DBF, filtered_phases)
+assert all_phases.difference(active_phases) == {'FCC_A1'}
+#%%
 
 def test_filter_phases_removes_phases_with_inactive_sublattices():
     """Phases that have no active components in any sublattice should be filtered"""
     all_phases = set(ALNIPT_DBF.phases.keys())
     filtered_phases = set(filter_phases(ALNIPT_DBF, unpack_components(ALNIPT_DBF, ['AL', 'NI', 'VA'])))
-    assert all_phases.difference(filtered_phases) == {'FCC_A1', 'PT8AL21', 'PT5AL21', 'PT2AL', 'PT2AL3', 'PT5AL3', 'ALPT2'}
+    active_phases = check_order_disorder(ALNIPT_DBF, filtered_phases)
+    assert all_phases.difference(active_phases) == {'FCC_A1', 'PT8AL21', 'PT5AL21', 'PT2AL', 'PT2AL3', 'PT5AL3', 'ALPT2'}
 
 
 def test_instantiate_models_only_returns_desired_phases():


### PR DESCRIPTION
Fixing the bug presented at https://github.com/pycalphad/pycalphad/issues/247
A new function `check_order_disorder` is now responsible to exclude the disordered phases when its respective ordered phase are active.

Some tests in `test_utils` had to be slightly changed, to run the new function `check_order_disorder` to remove the disordered phases when active phases are active.