### PR TITLE
MAINT: SymPy 1.5 compatibility

### DIFF
--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - pandas
     - pytest
     - xarray >=0.11.2
-    - sympy ==1.4
+    - sympy ==1.5
     - pyparsing
     - tinydb >=3.8
     - scipy
@@ -46,7 +46,7 @@ requirements:
     - matplotlib
     - pandas
     - xarray >=0.11.2
-    - sympy ==1.4
+    - sympy ==1.5
     - pyparsing
     - tinydb >=3.8
     - scipy

--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -455,7 +455,7 @@ class TCPrinter(StrPrinter):
         # Need to verify that each cond's highlim equals the next cond's lowlim
         # to_interval() is used instead of sympy.Relational.as_set() for performance reasons
         intervals = [to_interval(i.cond) for i in filtered_args]
-        if (len(intervals) > 1) and Intersection(*intervals) != EmptySet():
+        if (len(intervals) > 1) and not Intersection(*intervals) is EmptySet:
             raise ValueError('Overlapping intervals cannot be represented: {}'.format(intervals))
         if not isinstance(Union(*intervals), Interval):
             raise ValueError('Piecewise intervals must be continuous')

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     license='MIT',
     long_description=read('README.rst'),
     url='https://pycalphad.org/',
-    install_requires=['matplotlib', 'pandas', 'xarray>=0.11.2', 'sympy==1.4', 'pyparsing', 'Cython>=0.24',
+    install_requires=['matplotlib', 'pandas', 'xarray>=0.11.2', 'sympy==1.5', 'pyparsing', 'Cython>=0.24',
                       'tinydb>=3.8', 'scipy', 'numpy>=1.13', 'ipopt', 'symengine==0.5.1'],
     classifiers=[
         # How mature is this project? Common values are


### PR DESCRIPTION
SymPy 1.5 release candidate 1 is out now. There is one breakage: EmptySet is now a singleton instead of a class ([see release notes](https://github.com/sympy/sympy/wiki/Release-Notes-for-1.5#backwards-compatibility-breaks-and-deprecations) ).

Here is the simplest change. We also need to bump the requirements to pin sympy>=1.5.

There are a couple other options for changes:

1. Current change, use the singleton comparison instead of the class
2. Use the `.is_EmptySet` property, which is now deprecated in favor of the `.is_empty` property. Allows us to stay backwards compatible until the deprecated code is removed (https://github.com/sympy/sympy/issues/17523)
3. Use the `.is_empty` property, which would still require bumping the version to sympy>=1.5

Staying with comparing to the singleton makes sense to me. I'm opening this PR for discussion. We cannot merge this until SymPy 1.5 is released.