### PR TITLE
ENH: variables.MassFraction and variables.Composition object implementations

### DIFF
--- a/pycalphad/core/equilibrium.py
+++ b/pycalphad/core/equilibrium.py
@@ -25,7 +25,7 @@ def _adjust_conditions(conds):
     for key, value in sorted(conds.items(), key=str):
         if key == str(key):
             key = getattr(v, key, key)
-        if isinstance(key, v.Composition):
+        if isinstance(key, v.MoleFraction):
             new_conds[key] = [max(val, MIN_SITE_FRACTION*1000) for val in unpack_condition(value)]
         else:
             new_conds[key] = unpack_condition(value)
@@ -214,7 +214,7 @@ def equilibrium(dbf, comps, phases, conditions, output=None, model=None,
     conds = _adjust_conditions(conditions)
 
     for cond in conds.keys():
-        if isinstance(cond, (v.Composition, v.ChemicalPotential)) and cond.species not in comps:
+        if isinstance(cond, (v.MoleFraction, v.ChemicalPotential)) and cond.species not in comps:
             raise ConditionError('{} refers to non-existent component'.format(cond))
     state_variables = sorted(get_state_variables(models=models, conds=conds), key=str)
     str_conds = OrderedDict((str(key), value) for key, value in conds.items())
@@ -244,7 +244,7 @@ def equilibrium(dbf, comps, phases, conditions, output=None, model=None,
     if 'pdens' not in grid_opts:
         grid_opts['pdens'] = 500
     grid = calculate(dbf, comps, active_phases, model=models, fake_points=True,
-                     callables=callables, output='GM', parameters=parameters, 
+                     callables=callables, output='GM', parameters=parameters,
                      to_xarray=False, **grid_opts)
     coord_dict = str_conds.copy()
     coord_dict['vertex'] = np.arange(len(pure_elements) + 1)  # +1 is to accommodate the degenerate degree of freedom at the invariant reactions

--- a/pycalphad/core/starting_point.py
+++ b/pycalphad/core/starting_point.py
@@ -27,7 +27,7 @@ def global_min_is_possible(conditions, state_variables):
     global_min = True
     for cond in conditions.keys():
         if cond in state_variables or \
-           isinstance(cond, v.Composition) or \
+           isinstance(cond, v.MoleFraction) or \
            isinstance(cond, v.ChemicalPotential) or \
            cond == v.N:
             continue

--- a/pycalphad/io/database.py
+++ b/pycalphad/io/database.py
@@ -93,7 +93,7 @@ class Database(object): #pylint: disable=R0902
     --------
     >>> mydb = Database(open('crfeni_mie.tdb'))
     >>> mydb = Database('crfeni_mie.tdb')
-    >>> f = StringIO(u'$a complete TDB file as a string\n')
+    >>> f = StringIO(u'$a complete TDB file as a string\\n')
     >>> mydb = Database(f)
     """
     def __new__(cls, *args):

--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -391,7 +391,7 @@ class Model(object):
         for statevar in sorted(conds.keys(), key=str):
             if not is_multiphase_constraint(statevar):
                 continue
-            if isinstance(statevar, v.Composition):
+            if isinstance(statevar, v.MoleFraction):
                 multiphase_constraints.append(Symbol('NP') * self.moles(statevar.species))
             elif statevar == v.N:
                 multiphase_constraints.append(Symbol('NP') * (sum(self.moles(spec) for spec in self.nonvacant_elements)))

--- a/pycalphad/plot/binary/compsets.py
+++ b/pycalphad/plot/binary/compsets.py
@@ -15,7 +15,7 @@ class BinaryCompset():
     indep_comp : str
         Name of the independent component
     composition : float
-        Composition of the independent component
+        Mole fraction of the independent component
     site_fracs : np.ndarray
         Array of floats corresponding to the site fractions.
 

--- a/pycalphad/plot/binary/map.py
+++ b/pycalphad/plot/binary/map.py
@@ -71,7 +71,7 @@ def map_binary(dbf, comps, phases, conds, eq_kwargs=None, calc_kwargs=None,
     prxs = build_phase_records(dbf, species, phases, conds, models, output='GM',
                                parameters=parameters, build_gradients=True, build_hessians=True)
 
-    indep_comp = [key for key, value in conds.items() if isinstance(key, v.Composition) and len(np.atleast_1d(value)) > 1]
+    indep_comp = [key for key, value in conds.items() if isinstance(key, v.MoleFraction) and len(np.atleast_1d(value)) > 1]
     indep_pot = [key for key, value in conds.items() if (type(key) is v.StateVariable) and len(np.atleast_1d(value)) > 1]
     if (len(indep_comp) != 1) or (len(indep_pot) != 1):
         raise ValueError('Binary map requires exactly one composition and one potential coordinate')

--- a/pycalphad/plot/eqplot.py
+++ b/pycalphad/plot/eqplot.py
@@ -15,7 +15,7 @@ _plot_labels = {v.T: 'Temperature (K)', v.P: 'Pressure (Pa)'}
 
 
 def _axis_label(ax_var):
-    if isinstance(ax_var, v.Composition):
+    if isinstance(ax_var, v.MoleFraction):
         return 'X({})'.format(ax_var.species.name)
     elif isinstance(ax_var, v.StateVariable):
         return _plot_labels[ax_var]
@@ -71,7 +71,7 @@ def eqplot(eq, ax=None, x=None, y=None, z=None, tielines=True, **kwargs):
     conds = OrderedDict([(_map_coord_to_variable(key), unpack_condition(np.asarray(value)))
                          for key, value in sorted(eq.coords.items(), key=str)
                          if (key in ('T', 'P', 'N')) or (key.startswith('X_'))])
-    indep_comps = sorted([key for key, value in conds.items() if isinstance(key, v.Composition) and len(value) > 1], key=str)
+    indep_comps = sorted([key for key, value in conds.items() if isinstance(key, v.MoleFraction) and len(value) > 1], key=str)
     indep_pots = [key for key, value in conds.items() if (type(key) is v.StateVariable) and len(value) > 1]
 
     # determine what the type of plot will be
@@ -128,7 +128,7 @@ def eqplot(eq, ax=None, x=None, y=None, z=None, tielines=True, **kwargs):
         # get tieline endpoint compositions
         two_phase_x = eq.X.sel(component=x.species.name).values[two_phase_idx][..., :2]
         # handle special case for potential
-        if isinstance(y, v.Composition):
+        if isinstance(y, v.MoleFraction):
             two_phase_y = eq.X.sel(component=y.species.name).values[two_phase_idx][..., :2]
         else:
             # it's a StateVariable. This must be True

--- a/pycalphad/plot/ternary.py
+++ b/pycalphad/plot/ternary.py
@@ -24,10 +24,10 @@ def ternplot(dbf, comps, phases, conds, x=None, y=None, eq_kwargs=None, **plot_k
     conds : dict
         Maps StateVariables to values and/or iterables of values.
         For ternplot only one changing composition and one potential coordinate each is supported.
-    x : Composition
+    x : v.MoleFraction
         instance of a pycalphad.variables.composition to plot on the x-axis.
         Must correspond to an independent condition.
-    y : Composition
+    y : v.MoleFraction
         instance of a pycalphad.variables.composition to plot on the y-axis.
         Must correspond to an independent condition.
     eq_kwargs : optional
@@ -44,7 +44,7 @@ def ternplot(dbf, comps, phases, conds, x=None, y=None, eq_kwargs=None, **plot_k
     None yet.
     """
     eq_kwargs = eq_kwargs if eq_kwargs is not None else dict()
-    indep_comps = [key for key, value in conds.items() if isinstance(key, v.Composition) and len(np.atleast_1d(value)) > 1]
+    indep_comps = [key for key, value in conds.items() if isinstance(key, v.MoleFraction) and len(np.atleast_1d(value)) > 1]
     indep_pots = [key for key, value in conds.items() if (type(key) is v.StateVariable) and len(np.atleast_1d(value)) > 1]
     if (len(indep_comps) != 2) or (len(indep_pots) != 0):
         raise ValueError('ternplot() requires exactly two composition coordinates')

--- a/pycalphad/tests/test_variables.py
+++ b/pycalphad/tests/test_variables.py
@@ -2,9 +2,36 @@
 Test variables module.
 """
 
+import numpy as np
+from pycalphad import Database
 from pycalphad import variables as v
+from .datasets import CUO_TDB
 
 
 def test_species_parse_unicode_strings():
     """Species should properly parse unicode strings."""
     s = v.Species(u"MG")
+
+
+def test_mole_and_mass_fraction_conversions():
+    """Test mole <-> mass conversions work as expected."""
+    # Passing database as a mass dict works
+    dbf = Database(CUO_TDB)
+    mole_fracs = {v.X('O'): 0.5}
+    mass_fracs = v.get_mass_fractions(mole_fracs, v.Species('CU'), dbf)
+    assert np.isclose(mass_fracs[v.W('O')], 0.20113144)  # TC
+    # Conversion back works
+    round_trip_mole_fracs = v.get_mole_fractions(mass_fracs, 'CU', dbf)
+    assert all(np.isclose(round_trip_mole_fracs[mf], mole_fracs[mf]) for mf in round_trip_mole_fracs.keys())
+
+    # Using Thermo-Calc's define components to define Al2O3 and TiO2
+    # Mass dict defined by hand
+    md = {'AL': 26.982, 'TI': 47.88, 'O': 15.999}
+    alumina = v.Species('AL2O3')
+    mass_fracs = {v.W(alumina): 0.81, v.W("TIO2"): 0.13}
+    mole_fracs = v.get_mole_fractions(mass_fracs, 'O', md)
+    assert np.isclose(mole_fracs[v.X('AL2O3')], 0.59632604)  # TC
+    assert np.isclose(mole_fracs[v.X('TIO2')], 0.12216562)  # TC
+    # Conversion back works
+    round_trip_mass_fracs = v.get_mass_fractions(mole_fracs, v.Species('O'), md)
+    assert all(np.isclose(round_trip_mass_fracs[mf], mass_fracs[mf]) for mf in round_trip_mass_fracs.keys())

--- a/pycalphad/variables.py
+++ b/pycalphad/variables.py
@@ -275,6 +275,9 @@ def get_mole_fractions(mass_fractions, dependent_species, pure_element_mass_dict
     Dict[MoleFraction, float]
 
     """
+    if not all(isinstance(mf, MassFraction) for mf in mass_fractions):
+        from pycalphad.core.errors import ConditionError
+        raise ConditionError("All mass_fractions must be instances of MassFraction (v.W). Got ", mass_fractions)
     dependent_species = Species(dependent_species)
     species_mass_fracs = {mf.species: frac for mf, frac in mass_fractions.items()}
     all_species = set(species_mass_fracs.keys()) | {dependent_species}
@@ -319,6 +322,9 @@ def get_mass_fractions(mole_fractions, dependent_species, pure_element_mass_dict
     Dict[MassFraction, float]
 
     """
+    if not all(isinstance(mf, MoleFraction) for mf in mole_fractions):
+        from pycalphad.core.errors import ConditionError
+        raise ConditionError("All mole_fractions must be instances of MoleFraction (v.X). Got ", mole_fractions)
     dependent_species = Species(dependent_species)
     species_mole_fracs = {mf.species: frac for mf, frac in mole_fractions.items()}
     all_species = set(species_mole_fracs.keys()) | {dependent_species}

--- a/pycalphad/variables.py
+++ b/pycalphad/variables.py
@@ -343,7 +343,19 @@ class Composition():
 
         Examples
         --------
-        >>> raise NotImplementedError()
+        >>> import numpy as np
+        >>> from pycalphad import variables as v
+        >>> c = v.Composition({}, {v.X('B'): 0.5, v.X('C'): 0.3}, 'A')
+        >>> new_c = c.set_dependent_component('C')
+        >>> new_c is c
+        True
+        >>> np.isclose(c[v.X('A')], 0.2)
+        True
+        >>> np.isclose(c[v.X('B')], 0.5)
+        True
+        >>> c.get(v.X('C')) is None
+        True
+
         """
         if self.dependent_component != component:
             self._composition[self._mode(self.dependent_component)] = (1-sum(self._composition.values()))
@@ -428,6 +440,8 @@ class Composition():
     def __getitem__(self, item):
         """Return a composition for an element
 
+        Alias for self.composition[item]
+
         Parameters
         ----------
         item : Union[MoleFraction, MassFraction]
@@ -438,6 +452,20 @@ class Composition():
 
         """
         return self.composition[item]
+
+    def get(self, item, default=None):
+        """Alias for self.composition.get(item)
+
+        Parameters
+        ----------
+        item : Union[MoleFraction, MassFraction]
+
+        Returns
+        -------
+        Union[float, Any]
+
+        """
+        return self.composition.get(item, default)
 
 
 class ChemicalPotential(StateVariable):

--- a/pycalphad/variables.py
+++ b/pycalphad/variables.py
@@ -390,6 +390,10 @@ class Composition():
         >>> from pycalphad import variables as v
         >>> c1 = v.Composition({}, {v.X('A'): 0.25}, 'B')
         >>> c2 = v.Composition({}, {v.X('A'): 0.75}, 'B')
+        >>> c1.mix(c2, 0.0) == c1
+        True
+        >>> c1.mix(c2, 1.0) == c2
+        True
         >>> c1.mix(c2, 0.5)[v.X('A')]
         0.5
         >>> c3 = v.Composition({}, {v.X('B'): 0.25}, 'A')
@@ -401,10 +405,7 @@ class Composition():
             raise ValueError("Compositions to mix must have the same components "
                              f"(got {sorted(self.components)} and {sorted(composition.components)})")
         # Make the end_comp here with a new instance so we don't modify the original
-        if issubclass(self._mode, MoleFraction):
-            end = composition.to_mole_fractions().set_dependent_component(self.dependent_component)
-        else:  # Assume mass fractions
-            end = composition.to_mass_fractions().set_dependent_component(self.dependent_component)
+        end = self._normalize(composition)
         interpolated = {}
         for c in self.composition.keys():
             interpolated[c] = self[c] + (end[c] - self[c])*amount
@@ -489,6 +490,18 @@ class Composition():
         Returns
         -------
         bool
+
+        Examples
+        --------
+        >>> from pycalphad import variables as v
+        >>> c1 = v.Composition({}, {v.X('A'): 0.25}, 'B')
+        >>> c2 = v.Composition({}, {v.X('A'): 0.75}, 'B')
+        >>> c1 == c1
+        True
+        >>> c2 == c2
+        True
+        >>> c1 == c2
+        False
 
         """
         if not isinstance(other, Composition):

--- a/pycalphad/variables.py
+++ b/pycalphad/variables.py
@@ -172,9 +172,9 @@ class PhaseFraction(StateVariable):
         return 'f^{'+self.phase_name.replace('_', '-') + \
             '}_{'+str(self.multiplicity)+'}'
 
-class Composition(StateVariable):
+class MoleFraction(StateVariable):
     """
-    Compositions are symbols with built-in assumptions of being real
+    MoleFractions are symbols with built-in assumptions of being real
     and nonnegative.
     """
     def __new__(cls, *args): #pylint: disable=W0221
@@ -193,7 +193,7 @@ class Composition(StateVariable):
             varname = 'X_' + phase_name + '_' + species.escaped_name.upper()
         else:
             # not defined
-            raise ValueError('Composition not defined for args: '+args)
+            raise ValueError('MoleFraction not defined for args: '+args)
 
         #pylint: disable=E1121
         new_self = StateVariable.__new__(cls, varname, nonnegative=True)
@@ -244,7 +244,7 @@ pressure = P = StateVariable('P')
 volume = V = StateVariable('V')
 moles = N = StateVariable('N')
 site_fraction = Y = SiteFraction
-X = Composition
+X = MoleFraction
 MU = ChemicalPotential
 si_gas_constant = R = Float(8.3145) # ideal gas constant
 

--- a/pycalphad/variables.py
+++ b/pycalphad/variables.py
@@ -303,6 +303,10 @@ class Composition():
             self._mode = MassFraction
         else:
             raise ValueError(f'Mixed MoleFraction and MassFraction compositions not supported (got {composition}).')
+        if any(np.array(list(composition.values())) < 0):
+            raise ValueError(f'All composition fractions must be greater than zero (got {list(composition.values())}).')
+        if sum(composition.keys()) > 1:
+            raise ValueError(f'Sum of composition fractions cannot be greater than 1 (got {sum(composition.values())}).')
         from pycalphad import Database  # Imported here to avoid circular import
         if isinstance(masses, Database):
             self.masses = {c: masses.refstates[c]['mass'] for c in self.components}

--- a/pycalphad/variables.py
+++ b/pycalphad/variables.py
@@ -415,6 +415,18 @@ class Composition():
             interpolated[c] = self[c] + (end[c] - self[c])*amount
         return Composition(self.masses, interpolated, self.dependent_component)
 
+    def distance(self, composition):
+        """Compute the euclidean distance between two compositions"""
+        if self.components != composition.components:
+            raise ValueError("Compositions to mix must have the same components "
+                             f"(got {sorted(self.components)} and {sorted(composition.components)})")
+        # Make the end_comp here with a new instance so we don't modify the original
+        other = self._normalize(composition)
+        component_distances = []
+        for c in self.composition.keys():
+            component_distances.append((self[c] - other[c]))
+        return np.sqrt(np.sum(np.square(component_distances)))
+
     def interpolate_composition(self, composition, num):
         """Return the composition of a path between two compositions with ``num`` compositions.
 

--- a/pycalphad/variables.py
+++ b/pycalphad/variables.py
@@ -293,7 +293,7 @@ class Composition():
 
     def __init__(self, masses, composition, dependent_component):
         # TODO: check degree of freedom (ncomps, n-1 independent compositions)
-        # TODO: convert any complex  species into pure element composition
+        # TODO: convert any complex species into pure element composition
         self.components = {dependent_component}
         for xw_fraction in composition.keys():
             self.components |= xw_fraction.species.constituents.keys()
@@ -305,7 +305,7 @@ class Composition():
             raise ValueError(f'Mixed MoleFraction and MassFraction compositions not supported (got {composition}).')
         if any(np.array(list(composition.values())) < 0):
             raise ValueError(f'All composition fractions must be greater than zero (got {list(composition.values())}).')
-        if sum(composition.keys()) > 1:
+        if sum(composition.values()) > 1:
             raise ValueError(f'Sum of composition fractions cannot be greater than 1 (got {sum(composition.values())}).')
         from pycalphad import Database  # Imported here to avoid circular import
         if isinstance(masses, Database):

--- a/pycalphad/variables.py
+++ b/pycalphad/variables.py
@@ -403,7 +403,14 @@ class Composition():
 
         Examples
         --------
-        >>>
+        >>> import numpy as np
+        >>> from pycalphad import variables as v
+        >>> c1 = v.Composition({}, {v.X('B'): 0.0}, 'A')
+        >>> c2 = v.Composition({}, {v.X('B'): 1.0}, 'A')
+        >>> path = c1.interpolate_composition(c2, 5)
+        >>> np.all(np.isclose(path[v.X('B')], [0, 0.25, 0.5, 0.75, 1]))
+        True
+
         """
         c1 = self
         c2 = composition

--- a/pycalphad/variables.py
+++ b/pycalphad/variables.py
@@ -278,6 +278,15 @@ class Composition():
     Attributes
     ----------
     masses : Dict[str, float]
+
+    Examples
+    --------
+    >>> from pycalphad import variables as v
+    >>> c = Composition({'AL': 26.98, 'NI': 58.69, 'CR': 52.00}, {v.W('AL'): 0.1, v.W('CR'): 0.2}, 'NI')
+    >>> new_c = c.to_mole_fractions().to_mass_fractions()
+    >>> all([np.isclose(c[comp], new_c[comp]) for comp in c.composition.keys()])
+    True
+
     """
 
     def __init__(self, masses, composition, dependent_component):


### PR DESCRIPTION
**Opening this PR for feedback.**

### Current status
I sketched out example implementations of MassFraction and Composition objects (the old Composition object was refactored to MoleFraction).

MassFraction objects are basically sister objects to MoleFraction, just using `W` instead of `X`. 

Composition objects are convenience objects that would describe a complete composition for a system as would be used in a calculation. The key ideas of a Composition are

1. All Compositions are single point compositions. 
  a. Any mixing, broadcasting, or paths between Composition objects are not Compositions themselves, but simply dicts mapping v.X or v.W to a float, tuple, or array, as in the equilibrium API.
  b. The Composition object could be a platform to create such dictionaries, but are fundamentally *not* those things.
2. Can be created from mass or mole fractions and easily convert between them
3. Dependent components can be changed
4. Equality convenience checks between two Compositions
5. Two compositions can be mixed (to create an new point Composition by `Composition.mix`) and linearly interpolated (to create a dict of `{v.X/v.W: [list of values]}` by `Composition.interpolate_path`)

The usual way I imagine a user would use this would be:

```python
from pycalphad import Database, equilibrium, variables as v
dbf = Database('multicomponent.tdb')
comps = ['FE', 'CR', 'NI', 'MO']
phases = list(dbf.phases.keys())
ss316 = v.Composition(dbf, {v.W('CR'): 0.17, v.W('NI'): 0.12, v.W('MO'): 0.025}, 'FE')
conds = {v.P: 101325, v.T: (300, 2000, 20), v.N: 1, **ss316.mole_fractions}
eq = equilibrium(dbf, comps, phases, conds)
```

### Some things that are still open:

1. A v.X/v.W of a non-pure element species will currently break things. Does it make sense to/should species support be implemented?
2. Compositions are currently instantiated by either passing a dictionary of masses or a Database (where the mass dictionary will be created from the element refdata). The main API I imagine that users will want to is `Composition(dbf, {v.X('A'): ...}, 'B')`. In principle Composition objects should be independent of any Database, besides a user might not want to load a Database (or might not have a database with the elements they want to manipulate, or might use fictitious elements). Should we provide a hardcoded mass dictionary for pure elements as the default and allow databases or custom mass dicts to be input as an optional argument?
3. Should the conditions argument in equilibrium allow for either `{statevars + v.X}` or `{statevars + v.Composition}` to be specified? What about `{statevars + v.W}` (i.e. convert to v.Composition and then to v.X internally)

