### PR TITLE
FIX: Fix Python 3.8 deprecation of ast.Num in favor of ast.Constant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,8 @@ install:
       echo "!!! Installing pycalphad dependencies via conda"
       conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib pytest pytest-cov pandas sympy pyparsing dask dill python-symengine xarray cython cyipopt
       echo "!!! conda installing test packages"
-      conda install --yes sphinx sphinx_rtd_theme coveralls ipython
+      # coverage<5, see https://github.com/coveralls-clients/coveralls-python/issues/213
+      conda install --yes sphinx sphinx_rtd_theme coveralls "coverage<5" ipython
       echo "!!! pip pycalphad as editable"
       pip install -e .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ notifications:
 matrix:
     include:
         # "python" version works for Linux, but is an error on macOS
-        - name: "Python 2.7 on Xenial Linux"
-          python: 2.7
-          dist: xenial
         - name: "Python 3.6 on Xenial Linux"
           python: 3.6
           dist: xenial
@@ -20,10 +17,6 @@ matrix:
         - name: "Python 3.8 on Xenial Linux"
           python: 3.8
           dist: xenial
-        - name: "Python 2.7 on macOS"
-          language: generic
-          os: osx
-          env: TRAVIS_PYTHON_VERSION=2.7
         - name: "Python 3.6 on macOS"
           language: generic
           os: osx

--- a/pycalphad/core/cache.py
+++ b/pycalphad/core/cache.py
@@ -6,10 +6,7 @@ The difference is _HashedSeq has been modified to use a custom hash function.
 http://code.activestate.com/recipes/578078-py26-and-py30-backport-of-python-33s-lru-cache/
 """
 
-try:
-    from collections.abc import Iterable, Mapping
-except ImportError:
-    from collections import Iterable, Mapping
+from collections.abc import Iterable, Mapping
 from collections import namedtuple
 from threading import RLock
 from functools import update_wrapper

--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -3,7 +3,6 @@ The calculate module contains a routine for calculating the
 property surface of a system.
 """
 
-from __future__ import division
 from pycalphad.codegen.callables import build_phase_records
 from pycalphad import ConditionError
 from pycalphad.core.utils import point_sample, generate_dof

--- a/pycalphad/core/equilibrium.py
+++ b/pycalphad/core/equilibrium.py
@@ -2,7 +2,6 @@
 The equilibrium module defines routines for interacting with
 calculated phase equilibria.
 """
-from __future__ import print_function
 import warnings
 import pycalphad.variables as v
 from pycalphad.core.utils import unpack_components, unpack_condition, unpack_phases, filter_phases, instantiate_models, get_state_variables
@@ -244,7 +243,7 @@ def equilibrium(dbf, comps, phases, conditions, output=None, model=None,
     if 'pdens' not in grid_opts:
         grid_opts['pdens'] = 500
     grid = calculate(dbf, comps, active_phases, model=models, fake_points=True,
-                     callables=callables, output='GM', parameters=parameters, 
+                     callables=callables, output='GM', parameters=parameters,
                      to_xarray=False, **grid_opts)
     coord_dict = str_conds.copy()
     coord_dict['vertex'] = np.arange(len(pure_elements) + 1)  # +1 is to accommodate the degenerate degree of freedom at the invariant reactions

--- a/pycalphad/core/halton.py
+++ b/pycalphad/core/halton.py
@@ -2,7 +2,6 @@
 The halton module allows the construction of multi-dimensional
 scrambled Halton sequences.
 """
-from __future__ import division
 import numpy as np
 from collections import OrderedDict, defaultdict
 

--- a/pycalphad/core/lower_convex_hull.py
+++ b/pycalphad/core/lower_convex_hull.py
@@ -2,7 +2,6 @@
 The lower_convex_hull module handles geometric calculations associated with
 equilibrium calculation.
 """
-from __future__ import print_function
 from pycalphad.core.cartesian import cartesian
 from pycalphad.core.constants import MIN_SITE_FRACTION
 from .hyperplane import hyperplane

--- a/pycalphad/core/solver.py
+++ b/pycalphad/core/solver.py
@@ -2,7 +2,6 @@ import ipopt
 ipopt.setLoggingLevel(50)
 import numpy as np
 from collections import namedtuple
-from pycalphad.variables import string_type
 from pycalphad.core.constants import MIN_SITE_FRACTION
 
 SolverResult = namedtuple('SolverResult', ['converged', 'x', 'chemical_potentials'])
@@ -98,7 +97,7 @@ class InteriorPointSolver(SolverBase):
         Strings are encoded to byte strings.
         """
         for option, value in self.ipopt_options.items():
-            if isinstance(value, string_type):
+            if isinstance(value, str):
                 problem.addOption(option.encode(), value.encode())
             else:
                 problem.addOption(option.encode(), value)

--- a/pycalphad/core/utils.py
+++ b/pycalphad/core/utils.py
@@ -1,7 +1,6 @@
 """
 The utils module handles helper routines for equilibrium calculation.
 """
-from __future__ import division
 import pycalphad.variables as v
 from pycalphad.core.halton import halton
 from pycalphad.core.constants import MIN_SITE_FRACTION
@@ -12,10 +11,7 @@ import operator
 import functools
 import itertools
 import collections
-try:
-    from collections.abc import Iterable, Mapping
-except ImportError:
-    from collections import Iterable, Mapping
+from collections.abc import Iterable, Mapping
 
 try:
     # Only available in numpy 1.10 and newer
@@ -352,7 +348,7 @@ def filter_phases(dbf, comps, candidate_phases=None):
     disordered_phases = [dbf.phases[phase].model_hints.get('disordered_phase') for phase in candidate_phases]
     phases = [phase for phase in candidate_phases if
                 all_sublattices_active(comps, dbf.phases[phase]) and
-                (phase not in disordered_phases or (phase in disordered_phases and 
+                (phase not in disordered_phases or (phase in disordered_phases and
                 dbf.phases[phase].model_hints.get('ordered_phase') not in candidate_phases))]
     return sorted(phases)
 

--- a/pycalphad/io/database.py
+++ b/pycalphad/io/database.py
@@ -2,6 +2,7 @@
 The database module provides support for reading and writing data types
 associated with structured thermodynamic/kinetic data.
 """
+from io import StringIO
 from tinydb import TinyDB
 from tinydb.storages import MemoryStorage
 from datetime import datetime
@@ -9,20 +10,7 @@ from collections import namedtuple
 import os
 from pycalphad.variables import Species
 from pycalphad.core.cache import fhash
-try:
-    # Python 2
-    from StringIO import StringIO
-except ImportError:
-    # Python 3
-    from io import StringIO
 
-# handle missing FileExistsError in Python2
-try:
-    FileExistsError = FileExistsError
-except NameError:
-    class FileExistsError(OSError):
-        """Python 2 backported FileExistsError wrapping OSError"""
-        pass
 
 class DatabaseExportError(Exception):
     """Raised when a database cannot be written."""

--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -93,12 +93,9 @@ def _parse_action(func):
     Source: Florian Brucker on StackOverflow
     http://stackoverflow.com/questions/10177276/pyparsing-setparseaction-function-is-getting-no-arguments
     """
-    if sys.version_info[0] > 2:
-        func_items = inspect.signature(func).parameters.items()
-        func_args = [name for name, param in func_items
-                     if param.kind == param.POSITIONAL_OR_KEYWORD]
-    else:
-        func_args = inspect.getargspec(func).args
+    func_items = inspect.signature(func).parameters.items()
+    func_args = [name for name, param in func_items
+                 if param.kind == param.POSITIONAL_OR_KEYWORD]
     num_args = len(func_args)
     if num_args > 3:
         raise ValueError('Input function must take at most 3 parameters.')
@@ -932,7 +929,7 @@ def read_tdb(dbf, fd):
 
     # Temporary storage while we process type definitions
     dbf.tdbtypedefs = {}
-    
+
     grammar = _tdb_grammar()
 
     for command in commands:

--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -33,9 +33,11 @@ import warnings
 import hashlib
 from copy import deepcopy
 
-_AST_WHITELIST = [ast.Add, ast.BinOp, ast.Call, ast.Div, ast.Expression,
-                  ast.Load, ast.Mult, ast.Name, ast.Num, ast.Pow, ast.Sub,
-                  ast.UAdd, ast.UnaryOp, ast.USub]
+# ast.Num is deprecated in Python 3.8 in favor of as ast.Constant
+# Both are whitelisted for compatability across versions
+_AST_WHITELIST = [ast.Add, ast.BinOp, ast.Call, ast.Constant, ast.Div,
+                  ast.Expression, ast.Load, ast.Mult, ast.Name, ast.Num,
+                  ast.Pow, ast.Sub, ast.UAdd, ast.UnaryOp, ast.USub]
 
 # Avoid symbol names clashing with objects in sympy (gh-233)
 clashing_namespace = {}

--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -2,7 +2,6 @@
 The model module provides support for using a Database to perform
 calculations under specified conditions.
 """
-from __future__ import division
 import copy
 from sympy import exp, log, Abs, Add, And, Float, Mul, Piecewise, Pow, S, sin, StrictGreaterThan, Symbol, zoo, oo, nan
 from tinydb import where

--- a/pycalphad/tests/test_calculate.py
+++ b/pycalphad/tests/test_calculate.py
@@ -3,15 +3,10 @@ The calculate test module verifies that calculate() calculates
 Model quantities correctly.
 """
 
+from io import StringIO
 import pytest
 from pycalphad import Database, calculate, Model
 import numpy as np
-try:
-    # Python 2
-    from StringIO import StringIO
-except ImportError:
-    # Python 3
-    from io import StringIO
 from pycalphad import ConditionError
 from pycalphad.tests.datasets import ALCRNI_TDB as TDB_TEST_STRING, ALFE_TDB
 

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -1,7 +1,7 @@
 """
 The test_database module contains tests for the Database object.
 """
-from __future__ import print_function
+from io import StringIO
 import pytest
 import hashlib
 import os
@@ -10,16 +10,9 @@ from pyparsing import ParseException
 from sympy import Symbol, Piecewise, And
 from pycalphad import Database, Model, variables as v
 from pycalphad.variables import Species
-from pycalphad.io.database import FileExistsError
 from pycalphad.io.tdb import expand_keyword
 from pycalphad.io.tdb import _apply_new_symbol_names, DatabaseExportError
 from pycalphad.tests.datasets import ALCRNI_TDB, ALFE_TDB, ALNIPT_TDB, ROSE_TDB, DIFFUSION_TDB
-try:
-    # Python 2
-    from StringIO import StringIO
-except ImportError:
-    # Python 3
-    from io import StringIO
 
 
 #

--- a/pycalphad/tests/test_model.py
+++ b/pycalphad/tests/test_model.py
@@ -1,7 +1,6 @@
 """
 The test_model module contains unit tests for the Model object.
 """
-from __future__ import print_function
 from pycalphad import Database, Model, variables as v, equilibrium
 from pycalphad.tests.datasets import ALCRNI_TDB, ALNIPT_TDB, ALFE_TDB, ZRO2_CUBIC_BCC_TDB
 from pycalphad.core.errors import DofError

--- a/pycalphad/variables.py
+++ b/pycalphad/variables.py
@@ -4,12 +4,6 @@ Classes and constants for representing thermodynamic variables.
 """
 
 import sys
-# Python 2 vs 3 string types in isinstance
-if sys.version_info[0] >= 3:
-    string_type = str
-else:
-    string_type = basestring
-
 from sympy import Float, Symbol
 from pycalphad.io.grammar import parse_chemical_formula
 
@@ -53,7 +47,7 @@ class Species(object):
             new_self.charge = 0
             return new_self
 
-        if isinstance(arg, string_type):
+        if isinstance(arg, str):
             parse_list = parse_chemical_formula(arg.upper())
         else:
             parse_list = arg

--- a/setup.py
+++ b/setup.py
@@ -84,11 +84,10 @@ setup(
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7'
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 
 )


### PR DESCRIPTION
Accoring to the [Python 3.8 `ast` docs](https://docs.python.org/3.8/library/ast.html?highlight=ast#module-ast):

> Deprecated since version 3.8: Class ast.Constant is now used for all constants. Old classes ast.Num, ast.Str, ast.Bytes, ast.NameConstant and ast.Ellipsis are still available, but they will be removed in future Python releases.

The tdb.py module whitelists certain `ast` objects, including `ast.Num`, which are now `ast.Constant`, causing breakages in sympifying parsed strings. This adds `ast.Constant` to our whitelist.

Thanks @jwsiegel2510 for pointing this out at https://github.com/PhasesResearchLab/ESPEI/pull/110

As an aside: this is an interesting breakage because `ast.Num` still exists in Python 3.8, but instantiating an `ast.Num` actually gives you an `ast.Constant` instance, which breaks the whitelist even though people creating objects with `ast.Num` in Python 3.8 are not technically affected.