### PR TITLE
FIX: Support PhaseRecord pickling, switch SymEngine backend to LLVM (configurable)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,4 +9,7 @@ Below are a few things we ask you kindly to self-check before getting a review. 
 
 Checklist
 * [ ] The documentation examples have been regenerated if the Jupyter notebooks in the `examples/` have changed. To regenerate the documentation examples, run `jupyter nbconvert --to rst --output-dir=docs/examples examples/*.ipynb` from the top level directory)
-
+* [ ] If any dependencies have changed, they are changed are reflected in the
+  * [ ] `setup.py`
+  * [ ] `.travis.yml`
+  * [ ] `appveyor.yml`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@ Below are a few things we ask you kindly to self-check before getting a review. 
 
 Checklist
 * [ ] The documentation examples have been regenerated if the Jupyter notebooks in the `examples/` have changed. To regenerate the documentation examples, run `jupyter nbconvert --to rst --output-dir=docs/examples examples/*.ipynb` from the top level directory)
-* [ ] If any dependencies have changed, they are changed are reflected in the
+* [ ] If any dependencies have changed, the changes are reflected in the
   * [ ] `setup.py`
   * [ ] `.travis.yml`
   * [ ] `appveyor.yml`

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
       conda deactivate
       conda activate condaenv
       echo "!!! Installing pycalphad dependencies via conda"
-      conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib pytest pytest-cov pandas sympy pyparsing dask dill python-symengine xarray cython cyipopt
+      conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib pytest pytest-cov pandas sympy=1.5 pyparsing dask dill python-symengine=0.6 xarray cython cyipopt
       echo "!!! conda installing test packages"
       # coverage<5, see https://github.com/coveralls-clients/coveralls-python/issues/213
       conda install --yes sphinx sphinx_rtd_theme coveralls "coverage<5" ipython

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
       conda deactivate
       conda activate condaenv
       echo "!!! Installing pycalphad dependencies via conda"
-      conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib pytest pytest-cov pandas sympy=1.5 pyparsing dask dill python-symengine=0.6 xarray cython cyipopt
+      conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib pytest pytest-cov pandas sympy=1.5.1 pyparsing dask dill python-symengine=0.6 xarray cython cyipopt
       echo "!!! conda installing test packages"
       # coverage<5, see https://github.com/coveralls-clients/coveralls-python/issues/213
       conda install --yes sphinx sphinx_rtd_theme coveralls "coverage<5" ipython

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -50,6 +50,7 @@ Start with the commit checked out which was tagged with the new version.
 
 1. Generate the SHA256 hash of the build artifact (tarball) submitted to PyPI.
 2. Fork the conda-forge/pycalphad-feedstock repo.
-3. Update the version and sha256 strings in the recipe/meta.yaml file.
-4. Submit a pull request to the main pycalphad feedstock repo.
-5. Once the tests pass, merge the pull request.
+3. Update pycalphad version and sha256 strings in the ``recipe/meta.yaml`` file.
+4. If any of the dependencies changed since the last release, make sure to update the ``recipe/meta.yaml`` file.
+5. Submit a pull request to the main pycalphad feedstock repo.
+6. Once the tests pass, merge the pull request.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ install:
   - "conda config --add channels conda-forge"
   - "conda config --add channels pycalphad"
   # install pycalphad and dependencies
-  - "conda install --yes -n condaenv --quiet vc=14 pip setuptools pytest numpy pandas scipy sympy pyparsing matplotlib xarray 'tinydb>=3.8' cython cyipopt libpython symengine python-symengine"
+  - "conda install --yes -n condaenv --quiet vc=14 pip setuptools pytest numpy pandas scipy sympy=1.5 pyparsing matplotlib xarray 'tinydb>=3.8' cython cyipopt libpython symengine python-symengine=0.6"
   # Hack to force compiler: https://github.com/pypa/pip/issues/18#issuecomment-73703672
   - "pip install --global-option build_ext --global-option --compiler=msvc --editable ."
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ install:
   - "conda config --add channels conda-forge"
   - "conda config --add channels pycalphad"
   # install pycalphad and dependencies
-  - "conda install --yes -n condaenv --quiet vc=14 pip setuptools pytest numpy pandas scipy sympy=1.5.1 pyparsing matplotlib xarray 'tinydb>=3.8' cython cyipopt ipopt=3.12.13 libpython symengine python-symengine=0.6"
+  - "conda install --yes -n condaenv --quiet vc=14 pip setuptools pytest numpy pandas scipy sympy=1.5.1 pyparsing matplotlib xarray 'tinydb>=3.8' cython cyipopt libpython symengine python-symengine=0.6"
   # Hack to force compiler: https://github.com/pypa/pip/issues/18#issuecomment-73703672
   - "pip install --global-option build_ext --global-option --compiler=msvc --editable ."
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ install:
   - "conda config --add channels conda-forge"
   - "conda config --add channels pycalphad"
   # install pycalphad and dependencies
-  - "conda install --yes -n condaenv --quiet vc=14 pip setuptools pytest numpy pandas scipy sympy=1.5.1 pyparsing matplotlib xarray 'tinydb>=3.8' cython cyipopt=0.1.7 libpython symengine python-symengine=0.6"
+  - "conda install --yes -n condaenv --quiet vc=14 pip setuptools pytest numpy pandas scipy sympy=1.5.1 pyparsing matplotlib xarray 'tinydb>=3.8' cython cyipopt libpython symengine python-symengine=0.6"
   # Hack to force compiler: https://github.com/pypa/pip/issues/18#issuecomment-73703672
   - "pip install --global-option build_ext --global-option --compiler=msvc --editable ."
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ install:
   - "conda config --add channels conda-forge"
   - "conda config --add channels pycalphad"
   # install pycalphad and dependencies
-  - "conda install --yes -n condaenv --quiet vc=14 pip setuptools pytest numpy pandas scipy sympy=1.5.1 pyparsing matplotlib xarray 'tinydb>=3.8' cython cyipopt=0.1.7 libpython symengine python-symengine=0.6"
+  - "conda install --yes -n condaenv --quiet vc=14 pip setuptools pytest numpy pandas scipy sympy=1.5.1 pyparsing matplotlib xarray 'tinydb>=3.8' cython cyipopt ipopt=3.12.13 libpython symengine python-symengine=0.6"
   # Hack to force compiler: https://github.com/pypa/pip/issues/18#issuecomment-73703672
   - "pip install --global-option build_ext --global-option --compiler=msvc --editable ."
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ install:
   - "conda config --add channels conda-forge"
   - "conda config --add channels pycalphad"
   # install pycalphad and dependencies
-  - "conda install --yes -n condaenv --quiet vc=14 pip setuptools pytest numpy pandas scipy sympy=1.5.1 pyparsing matplotlib xarray 'tinydb>=3.8' cython cyipopt ipopt=3.12.13 libpython symengine python-symengine=0.6"
+  - "conda install --yes -n condaenv --quiet vc=14 pip setuptools pytest numpy pandas scipy sympy=1.5.1 pyparsing matplotlib xarray 'tinydb>=3.8' cython cyipopt=0.1.7 libpython symengine python-symengine=0.6"
   # Hack to force compiler: https://github.com/pypa/pip/issues/18#issuecomment-73703672
   - "pip install --global-option build_ext --global-option --compiler=msvc --editable ."
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ install:
   - "conda config --add channels conda-forge"
   - "conda config --add channels pycalphad"
   # install pycalphad and dependencies
-  - "conda install --yes -n condaenv --quiet vc=14 pip setuptools pytest numpy pandas scipy sympy=1.5.1 pyparsing matplotlib xarray 'tinydb>=3.8' cython cyipopt libpython symengine python-symengine=0.6"
+  - "conda install --yes -n condaenv --quiet vc=14 pip setuptools pytest numpy pandas scipy sympy=1.5.1 pyparsing matplotlib xarray 'tinydb>=3.8' cython cyipopt ipopt=3.12.13 libpython symengine python-symengine=0.6"
   # Hack to force compiler: https://github.com/pypa/pip/issues/18#issuecomment-73703672
   - "pip install --global-option build_ext --global-option --compiler=msvc --editable ."
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ install:
   - "conda config --add channels conda-forge"
   - "conda config --add channels pycalphad"
   # install pycalphad and dependencies
-  - "conda install --yes -n condaenv --quiet vc=14 pip setuptools pytest numpy pandas scipy sympy=1.5 pyparsing matplotlib xarray 'tinydb>=3.8' cython cyipopt libpython symengine python-symengine=0.6"
+  - "conda install --yes -n condaenv --quiet vc=14 pip setuptools pytest numpy pandas scipy sympy=1.5.1 pyparsing matplotlib xarray 'tinydb>=3.8' cython cyipopt libpython symengine python-symengine=0.6"
   # Hack to force compiler: https://github.com/pypa/pip/issues/18#issuecomment-73703672
   - "pip install --global-option build_ext --global-option --compiler=msvc --editable ."
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ install:
   - "conda config --add channels conda-forge"
   - "conda config --add channels pycalphad"
   # install pycalphad and dependencies
-  - "conda install --yes -n condaenv --quiet vc=14 pip setuptools pytest numpy pandas scipy sympy=1.5.1 pyparsing matplotlib xarray 'tinydb>=3.8' cython cyipopt libpython symengine python-symengine=0.6"
+  - "conda install --yes -n condaenv --quiet vc=14 pip setuptools pytest numpy pandas scipy sympy=1.5.1 pyparsing matplotlib xarray 'tinydb>=3.8' cython cyipopt=0.1.7 libpython symengine python-symengine=0.6"
   # Hack to force compiler: https://github.com/pypa/pip/issues/18#issuecomment-73703672
   - "pip install --global-option build_ext --global-option --compiler=msvc --editable ."
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,4 +53,5 @@ install:
 build: false
 
 test_script:
+  - conda list
   - "python -c \"import pytest ; exit(pytest.main())\" -s -v pycalphad"

--- a/pycalphad/codegen/sympydiff_utils.py
+++ b/pycalphad/codegen/sympydiff_utils.py
@@ -43,6 +43,12 @@ def build_functions(sympy_graph, variables, parameters=None, wrt=None, include_o
             grad = lambdify(inp, grad_graphs, backend=grad_backend, cse=cse)
         if include_hess:
             hess_graphs = list(list(g.diff(w) for w in wrt) for g in grad_graphs)
+            hess_ops = sum(sum(count_ops(xy) for xy in x) for x in hess_graphs)
+            if hess_ops > BACKEND_OPS_THRESHOLD:
+                hess_backend = 'lambda'
+            else:
+                hess_backend = 'llvm'
+            print(f'Hess backend: {hess_backend} ({hess_ops} ops)')
             # Hessians are hard-coded to always use the lambda backend, for performance
-            hess = lambdify(inp, hess_graphs, backend='lambda', cse=cse)
+            hess = lambdify(inp, hess_graphs, backend=hess_backend, cse=cse)
     return BuildFunctionsResult(func=func, grad=grad, hess=hess)

--- a/pycalphad/codegen/sympydiff_utils.py
+++ b/pycalphad/codegen/sympydiff_utils.py
@@ -48,7 +48,9 @@ def _get_lambidfy_options(user_options):
 
 
 @cacheit
-def build_functions(sympy_graph, variables, parameters=None, wrt=None, include_grad=False, include_hess=False, func_options=None, grad_options=None, hess_options=None):
+def build_functions(sympy_graph, variables, parameters=None, wrt=None,
+                    include_obj=True, include_grad=False, include_hess=False,
+                    func_options=None, grad_options=None, hess_options=None):
     """Build function, gradient, and Hessian callables of the sympy_graph.
 
     Parameters
@@ -66,12 +68,15 @@ def build_functions(sympy_graph, variables, parameters=None, wrt=None, include_g
     wrt : Optional[List[sympy.core.symbol.Symbol]]
         Variables to differentiate *with respect to* for gradient and Hessian
         callables. If None, the default is to differentiate w.r.t. all variables.
+    include_obj : Optional[bool]
+        Whether to build the sympy_graph callable,
+        :math:`f(x) : \mathbb{R}^{n} \\rightarrow \mathbb{R}`
     include_grad : Optional[bool]
         Whether to build the gradient callable,
-        :math:`\\pmb{g} = \\nabla f(x) : \mathbb{R}^{n} \\rightarrow \mathbb{R}^{n}`
+        :math:`\\pmb{g}(x) = \\nabla f(x) : \mathbb{R}^{n} \\rightarrow \mathbb{R}^{n}`
     include_hess : Optional[bool]
         Whether to build the Hessian callable,
-        :math:`\mathbb{H} = \\nabla^2 f(x) : \mathbb{R}^{n} \\rightarrow \mathbb{R}^{n \\times n}`
+        :math:`\mathbb{H}(x) = \\nabla^2 f(x) : \mathbb{R}^{n} \\rightarrow \mathbb{R}^{n \\times n}`
     func_options : Optional[Dict[str, str]]
         Options to pass to ``lambdify`` when compiling the function.
     grad_options : Optional[Dict[str, str]]

--- a/pycalphad/codegen/sympydiff_utils.py
+++ b/pycalphad/codegen/sympydiff_utils.py
@@ -87,7 +87,6 @@ def build_functions(sympy_graph, variables, parameters=None, wrt=None, include_g
     -----
     Default options for compiling the function, gradient and Hessian are defined by ``_get_lambdify_options``.
 
-
     """
     if wrt is None:
         wrt = sympify(tuple(variables))

--- a/pycalphad/codegen/sympydiff_utils.py
+++ b/pycalphad/codegen/sympydiff_utils.py
@@ -3,17 +3,62 @@ This module constructs gradient functions for Models.
 """
 from pycalphad.core.cache import cacheit
 from pycalphad.core.utils import wrap_symbol_symengine
-from symengine import sympify, lambdify, count_ops
+from symengine import sympify, lambdify
 from collections import namedtuple
 
 
 BuildFunctionsResult = namedtuple('BuildFunctionsResult', ['func', 'grad', 'hess'])
 
-BACKEND_OPS_THRESHOLD = 50000
-
 
 @cacheit
-def build_functions(sympy_graph, variables, parameters=None, wrt=None, include_obj=True, include_grad=False, include_hess=False, cse=True):
+def build_functions(sympy_graph, variables, parameters=None, wrt=None, include_grad=False, include_hess=False, func_options=None, grad_options=None, hess_options=None):
+    """Build function, gradient, and Hessian callables of the sympy_graph
+
+    Parameters
+    ----------
+    sympy_graph : sympy.core.expr.Expr
+        SymPy expression to compile,
+        :math:`f(x) : \mathbb{R}^{n} \\rightarrow \mathbb{R}`,
+        which will be called by ``sympy_graph(variables+parameters)``
+    variables : List[sympy.core.symbol.Symbol]
+        Free variables in the sympy_graph, by convention these are usually all
+        StateVariables instances.
+    parameters : Optional[List[sympy.core.symbol.Symbol]]
+        Free variables in the sympy_graph, these are typically external
+        parameters that are controlled by the user.
+    wrt : Optional[List[sympy.core.symbol.Symbol]]
+        Variables to differentiate *with respect to* for gradient and Hessian
+        callables. If None, the default is to differentiate w.r.t. all variables.
+    include_grad : Optional[bool]
+        Whether to build the gradient callable,
+        :math:`\\pmb{g} = \\nabla f(x) : \mathbb{R}^{n} \\rightarrow \mathbb{R}^{n}`
+    include_hess : Optional[bool]
+        Whether to build the Hessian callable,
+        :math:`\mathbb{H} = \\nabla^2 f(x) : \mathbb{R}^{n} \\rightarrow \mathbb{R}^{n \\times n}`
+    func_options : Optional[Dict[str, str]]
+        Options to pass to ``lambdify`` when compiling the function.
+    grad_options : Optional[Dict[str, str]]
+        Options to pass to ``lambdify`` when compiling the gradient.
+    hess_options : Optional[Dict[str, str]]
+        Options to pass to ``lambdify`` when compiling Hessian.
+
+    Returns
+    -------
+    BuildFunctionsResult
+
+    Notes
+    -----
+    Default options for compiling the function, gradient and Hessian are::
+
+        {'backend': 'llvm', 'cse': True}
+
+    """
+    def _get_options(user_options):
+        default_options = {'backend': 'llvm', 'cse': True}
+        if user_options is not None:
+            default_options.update(user_options)
+        return default_options
+
     if wrt is None:
         wrt = sympify(tuple(variables))
     if parameters is None:
@@ -25,30 +70,13 @@ def build_functions(sympy_graph, variables, parameters=None, wrt=None, include_o
     func, grad, hess = None, None, None
     inp = sympify(variables + parameters)
     graph = sympify(sympy_graph)
-    if count_ops(graph) > BACKEND_OPS_THRESHOLD:
-        backend = 'lambda'
-    else:
-        backend = 'llvm'
     # TODO: did not replace zoo with oo
-    if include_obj:
-        func = lambdify(inp, [graph], backend=backend, cse=cse)
+    func = lambdify(inp, [graph], **_get_options(func_options))
     if include_grad or include_hess:
         grad_graphs = list(graph.diff(w) for w in wrt)
-        grad_ops = sum(count_ops(x) for x in grad_graphs)
-        if grad_ops > BACKEND_OPS_THRESHOLD:
-            grad_backend = 'lambda'
-        else:
-            grad_backend = 'llvm'
         if include_grad:
-            grad = lambdify(inp, grad_graphs, backend=grad_backend, cse=cse)
+            grad = lambdify(inp, grad_graphs, **_get_options(grad_options))
         if include_hess:
             hess_graphs = list(list(g.diff(w) for w in wrt) for g in grad_graphs)
-            hess_ops = sum(sum(count_ops(xy) for xy in x) for x in hess_graphs)
-            if hess_ops > BACKEND_OPS_THRESHOLD:
-                hess_backend = 'lambda'
-            else:
-                hess_backend = 'llvm'
-            print(f'Hess backend: {hess_backend} ({hess_ops} ops)')
-            # Hessians are hard-coded to always use the lambda backend, for performance
-            hess = lambdify(inp, hess_graphs, backend=hess_backend, cse=cse)
+            hess = lambdify(inp, hess_graphs, **_get_options(hess_options))
     return BuildFunctionsResult(func=func, grad=grad, hess=hess)

--- a/pycalphad/codegen/sympydiff_utils.py
+++ b/pycalphad/codegen/sympydiff_utils.py
@@ -1,18 +1,55 @@
 """
-This module constructs gradient functions for Models.
+This module defines functions compiling symbolic SymPy/SymEngine expressions
+into fast callable functions.
+
+The SymEngine ``lambdify`` function is used to compile the functions using a
+particular backend, with or without common subexpressions eimination (CSE).
+
+By default, the LLVM backend is used and common subexpression elimination is
+on, as defined by the module constants::
+
+    LAMBDIFY_DEFAULT_BACKEND = 'llvm'
+    LAMBDIFY_DEFAULT_CSE = True
+
+Note that as of February 2020, SymEngine only supports using ``'lambda'`` or
+``'llvm'`` backends. The LLVM backend uses the LLVM compiler to compile the
+expressions, and is slower to build the callable functions than the Lambda
+backend, though in principle the LLVM runtime performance can is better as
+LLVM can optimize the functions.
+
+Additionally, callables from the Lambda backend cannot be pickled, since
+SymEngine does not define how its object should be serialized. The following
+issues track this behavior:
+
+* SymEngine: https://github.com/symengine/symengine/issues/1394
+* SymEngine.py: https://github.com/symengine/symengine.py/issues/294
+
 """
 from pycalphad.core.cache import cacheit
 from pycalphad.core.utils import wrap_symbol_symengine
 from symengine import sympify, lambdify
 from collections import namedtuple
 
-
 BuildFunctionsResult = namedtuple('BuildFunctionsResult', ['func', 'grad', 'hess'])
+ConstraintFunctions = namedtuple('ConstraintFunctions', ['cons_func', 'cons_jac', 'cons_hess'])
+
+LAMBDIFY_DEFAULT_BACKEND = 'llvm'
+LAMBDIFY_DEFAULT_CSE = True
+
+
+def _get_lambidfy_options(user_options):
+    default_options = {
+        'backend': LAMBDIFY_DEFAULT_BACKEND,
+        'cse': LAMBDIFY_DEFAULT_CSE
+    }
+    if user_options is not None:
+        default_options.update(user_options)
+    return default_options
 
 
 @cacheit
 def build_functions(sympy_graph, variables, parameters=None, wrt=None, include_grad=False, include_hess=False, func_options=None, grad_options=None, hess_options=None):
-    """Build function, gradient, and Hessian callables of the sympy_graph
+    """Build function, gradient, and Hessian callables of the sympy_graph.
 
     Parameters
     ----------
@@ -21,10 +58,10 @@ def build_functions(sympy_graph, variables, parameters=None, wrt=None, include_g
         :math:`f(x) : \mathbb{R}^{n} \\rightarrow \mathbb{R}`,
         which will be called by ``sympy_graph(variables+parameters)``
     variables : List[sympy.core.symbol.Symbol]
-        Free variables in the sympy_graph, by convention these are usually all
+        Free variables in the sympy_graph. By convention these are usually all
         StateVariables instances.
     parameters : Optional[List[sympy.core.symbol.Symbol]]
-        Free variables in the sympy_graph, these are typically external
+        Free variables in the sympy_graph. These are typically external
         parameters that are controlled by the user.
     wrt : Optional[List[sympy.core.symbol.Symbol]]
         Variables to differentiate *with respect to* for gradient and Hessian
@@ -48,17 +85,10 @@ def build_functions(sympy_graph, variables, parameters=None, wrt=None, include_g
 
     Notes
     -----
-    Default options for compiling the function, gradient and Hessian are::
+    Default options for compiling the function, gradient and Hessian are defined by ``_get_lambdify_options``.
 
-        {'backend': 'llvm', 'cse': True}
 
     """
-    def _get_options(user_options):
-        default_options = {'backend': 'llvm', 'cse': True}
-        if user_options is not None:
-            default_options.update(user_options)
-        return default_options
-
     if wrt is None:
         wrt = sympify(tuple(variables))
     if parameters is None:
@@ -71,12 +101,58 @@ def build_functions(sympy_graph, variables, parameters=None, wrt=None, include_g
     inp = sympify(variables + parameters)
     graph = sympify(sympy_graph)
     # TODO: did not replace zoo with oo
-    func = lambdify(inp, [graph], **_get_options(func_options))
+    func = lambdify(inp, [graph], **_get_lambidfy_options(func_options))
     if include_grad or include_hess:
         grad_graphs = list(graph.diff(w) for w in wrt)
         if include_grad:
-            grad = lambdify(inp, grad_graphs, **_get_options(grad_options))
+            grad = lambdify(inp, grad_graphs, **_get_lambidfy_options(grad_options))
         if include_hess:
             hess_graphs = list(list(g.diff(w) for w in wrt) for g in grad_graphs)
-            hess = lambdify(inp, hess_graphs, **_get_options(hess_options))
+            hess = lambdify(inp, hess_graphs, **_get_lambidfy_options(hess_options))
     return BuildFunctionsResult(func=func, grad=grad, hess=hess)
+
+
+@cacheit
+def build_constraint_functions(variables, constraints, parameters=None, func_options=None, jac_options=None, hess_options=None):
+    """Build callables functions for the constraints, constraint Jacobian, and constraint Hessian.
+
+    Parameters
+    ----------
+    variables : List[sympy.core.symbol.Symbol]
+        Free variables in the constraint expressions. By convention these are usually all
+        StateVariables instances.
+    constraints : List[sympy.core.expr.Expr]
+        List of SymPy expression to compile
+    parameters : Optional[List[sympy.core.symbol.Symbol]]
+        Free variables in the sympy_graph. These are typically external
+        parameters that are controlled by the user.
+    func_options : None, optional
+        Options to pass to ``lambdify`` when compiling the function.
+    jac_options : Optional[Dict[str, str]]
+        Options to pass to ``lambdify`` when compiling the Jacobian.
+    hess_options : Optional[Dict[str, str]]
+        Options to pass to ``lambdify`` when compiling Hessian.
+
+    Returns
+    -------
+    ConstraintFunctions
+
+    """
+    if parameters is None:
+        parameters = []
+    else:
+        parameters = [wrap_symbol_symengine(p) for p in parameters]
+    variables = tuple(variables)
+    wrt = variables
+    parameters = tuple(parameters)
+    constraint_func, jacobian_func, hessian_func = None, None, None
+    inp = sympify(variables + parameters)
+    graph = sympify(constraints)
+    constraint_func = lambdify(inp, [graph], **_get_lambidfy_options(func_options))
+
+    grad_graphs = list(list(c.diff(w) for w in wrt) for c in graph)
+    jacobian_func = lambdify(inp, grad_graphs, **_get_lambidfy_options(jac_options))
+
+    hess_graphs = list(list(list(g.diff(w) for w in wrt) for g in c) for c in grad_graphs)
+    hessian_func = lambdify(inp, hess_graphs, **_get_lambidfy_options(hess_options))
+    return ConstraintFunctions(cons_func=constraint_func, cons_jac=jacobian_func, cons_hess=hessian_func)

--- a/pycalphad/codegen/sympydiff_utils.py
+++ b/pycalphad/codegen/sympydiff_utils.py
@@ -35,15 +35,18 @@ ConstraintFunctions = namedtuple('ConstraintFunctions', ['cons_func', 'cons_jac'
 
 LAMBDIFY_DEFAULT_BACKEND = 'llvm'
 LAMBDIFY_DEFAULT_CSE = True
+LAMBDIFY_DEFAULT_LLVM_OPT_LEVEL = 0
 
 
 def _get_lambidfy_options(user_options):
     default_options = {
         'backend': LAMBDIFY_DEFAULT_BACKEND,
-        'cse': LAMBDIFY_DEFAULT_CSE
+        'cse': LAMBDIFY_DEFAULT_CSE,
     }
     if user_options is not None:
         default_options.update(user_options)
+    if default_options['backend'] == 'llvm' and 'opt_level' not in default_options:
+        default_options['opt_level'] = LAMBDIFY_DEFAULT_LLVM_OPT_LEVEL
     return default_options
 
 

--- a/pycalphad/core/constraints.py
+++ b/pycalphad/core/constraints.py
@@ -21,12 +21,12 @@ def _build_constraint_functions(variables, constraints, parameters=None, cse=Tru
     constraint__func, jacobian_func, hessian_func = None, None, None
     inp = sympify(variables + parameters)
     graph = sympify(constraints)
-    constraint_func = lambdify(inp, [graph], backend='lambda', cse=cse)
+    constraint_func = lambdify(inp, [graph], backend='llvm', cse=cse)
     grad_graphs = list(list(c.diff(w) for w in wrt) for c in graph)
-    jacobian_func = lambdify(inp, grad_graphs, backend='lambda', cse=cse)
+    jacobian_func = lambdify(inp, grad_graphs, backend='llvm', cse=cse)
 
     hess_graphs = list(list(list(g.diff(w) for w in wrt) for g in c) for c in grad_graphs)
-    hessian_func = lambdify(inp, hess_graphs, backend='lambda', cse=cse)
+    hessian_func = lambdify(inp, hess_graphs, backend='llvm', cse=cse)
     return ConstraintFunctions(cons_func=constraint_func, cons_jac=jacobian_func, cons_hess=hessian_func)
 
 

--- a/pycalphad/core/phase_rec.pxd
+++ b/pycalphad/core/phase_rec.pxd
@@ -54,4 +54,16 @@ cdef public class PhaseRecord(object)[type PhaseRecordType, object PhaseRecordOb
     cpdef void mass_obj_2d(self, double[::1] out, double[:, ::1] dof, int comp_idx) nogil
     cpdef void mass_grad(self, double[::1] out, double[::1] dof, int comp_idx) nogil
     cpdef void mass_hess(self, double[:,::1] out, double[::1] dof, int comp_idx) nogil
-
+    # Used only to reconstitute if pickled (i.e. via __reduce__)
+    cdef public object ofunc_
+    cdef public object gfunc_
+    cdef public object hfunc_
+    cdef public object internal_cons_func_
+    cdef public object internal_cons_jac_
+    cdef public object internal_cons_hess_
+    cdef public object multiphase_cons_func_
+    cdef public object multiphase_cons_jac_
+    cdef public object multiphase_cons_hess_
+    cdef public object massfuncs_
+    cdef public object massgradfuncs_
+    cdef public object masshessianfuncs_

--- a/pycalphad/core/phase_rec.pyx
+++ b/pycalphad/core/phase_rec.pyx
@@ -69,9 +69,10 @@ cdef public class PhaseRecord(object)[type PhaseRecordType, object PhaseRecordOb
     """
     def __reduce__(self):
             return PhaseRecord, (self.components, self.state_variables, self.variables, np.array(self.parameters),
-                                 self._obj, self._grad, self._hess, self._masses, self._massgrads,
-                                 self._masshessians, self._internal_cons_func, self._internal_cons_jac, self._internal_cons_hess,
-                                 self._multiphase_cons_func, self._multiphase_cons_jac, self._multiphase_cons_hess,
+                                 self.ofunc_, self.gfunc_, self.hfunc_,
+                                 self.massfuncs_, self.massgradfuncs_, self.masshessianfuncs_,
+                                 self.internal_cons_func_, self.internal_cons_jac_, self.internal_cons_hess_,
+                                 self.multiphase_cons_func_, self.multiphase_cons_jac_, self.multiphase_cons_hess_,
                                  self.num_internal_cons, self.num_multiphase_cons)
 
     def __cinit__(self, object comps, object state_variables, object variables,
@@ -103,6 +104,20 @@ cdef public class PhaseRecord(object)[type PhaseRecordType, object PhaseRecordOb
                 continue
             self.phase_name = <unicode>variable.phase_name
             self.phase_dof += 1
+
+        # Used only to reconstitute if pickled (i.e. via __reduce__)
+        self.ofunc_ = ofunc
+        self.gfunc_ = gfunc
+        self.hfunc_ = hfunc
+        self.internal_cons_func_ = internal_cons_func
+        self.internal_cons_jac_ = internal_cons_jac
+        self.internal_cons_hess_ = internal_cons_hess
+        self.multiphase_cons_func_ = multiphase_cons_func
+        self.multiphase_cons_jac_ = multiphase_cons_jac
+        self.multiphase_cons_hess_ = multiphase_cons_hess
+        self.massfuncs_ = massfuncs
+        self.massgradfuncs_ = massgradfuncs
+        self.masshessianfuncs_ = masshessianfuncs
 
         if ofunc is not None:
             self._obj = FastFunction(ofunc)

--- a/pycalphad/core/phase_rec.pyx
+++ b/pycalphad/core/phase_rec.pyx
@@ -8,6 +8,8 @@ import pycalphad.variables as v
 import ctypes
 
 cdef class FastFunction:
+    """``FastFunction`` provides a stable(-ish) interface that encapsulates SymEngine function pointers.
+    """
     def __cinit__(self, object func):
         if func is None:
             self.f_ptr = NULL

--- a/pycalphad/tests/test_codegen.py
+++ b/pycalphad/tests/test_codegen.py
@@ -1,0 +1,53 @@
+"""
+Tests for code generation from SymPy/SymEngine objects.
+"""
+
+from symengine.lib.symengine_wrapper import LambdaDouble, LLVMDouble
+from pycalphad import Database, Model
+from pycalphad.codegen.sympydiff_utils import build_functions, build_constraint_functions
+from pycalphad.tests.datasets import ALNIPT_TDB
+
+
+ALNIPT_DBF = Database(ALNIPT_TDB)
+
+
+def test_build_functions_options():
+    """The correct SymEngine backend can be chosen for build_functions"""
+    mod = Model(ALNIPT_DBF, ['AL'], 'LIQUID')
+    int_cons = mod.get_internal_constraints()
+
+    backend = 'lambda'
+    fs_lambda = build_functions(mod.GM, mod.GM.free_symbols,
+                                include_obj=True, func_options={'backend': backend},
+                                include_grad=True, grad_options={'backend': backend},
+                                include_hess=True, hess_options={'backend': backend})
+    assert isinstance(fs_lambda.func, LambdaDouble)
+    assert isinstance(fs_lambda.grad, LambdaDouble)
+    assert isinstance(fs_lambda.hess, LambdaDouble)
+
+    cfs_lambda = build_constraint_functions(mod.GM.free_symbols, int_cons,
+                                            func_options={'backend': backend},
+                                            jac_options={'backend': backend},
+                                            hess_options={'backend': backend})
+    assert isinstance(cfs_lambda.cons_func, LambdaDouble)
+    assert isinstance(cfs_lambda.cons_jac, LambdaDouble)
+    assert isinstance(cfs_lambda.cons_hess, LambdaDouble)
+
+    backend = 'llvm'
+    fs_llvm = build_functions(mod.GM, mod.GM.free_symbols,
+                              include_obj=True, func_options={'backend': backend},
+                              include_grad=True, grad_options={'backend': backend},
+                              include_hess=True, hess_options={'backend': backend})
+    print(fs_llvm.func)
+    print(fs_lambda.func)
+    assert isinstance(fs_llvm.func, LLVMDouble)
+    assert isinstance(fs_llvm.grad, LLVMDouble)
+    assert isinstance(fs_llvm.hess, LLVMDouble)
+
+    cfs_llvm = build_constraint_functions(mod.GM.free_symbols, int_cons,
+                                          func_options={'backend': backend},
+                                          jac_options={'backend': backend},
+                                          hess_options={'backend': backend})
+    assert isinstance(cfs_llvm.cons_func, LLVMDouble)
+    assert isinstance(cfs_llvm.cons_jac, LLVMDouble)
+    assert isinstance(cfs_llvm.cons_hess, LLVMDouble)

--- a/pycalphad/tests/test_utils.py
+++ b/pycalphad/tests/test_utils.py
@@ -3,9 +3,10 @@ The utils test module contains tests for pycalphad utilities.
 """
 
 import pytest
+from symengine.lib.symengine_wrapper import LambdaDouble, LLVMDouble
 from pycalphad import Database, Model
 from pycalphad.core.utils import filter_phases, unpack_components, instantiate_models
-
+from pycalphad.codegen.sympydiff_utils import build_functions, build_constraint_functions
 from pycalphad.tests.datasets import ALNIPT_TDB, ALCRNI_TDB
 
 ALNIPT_DBF = Database(ALNIPT_TDB)
@@ -49,3 +50,45 @@ def test_instantiate_models_only_returns_desired_phases():
     too_few_models = {phase: Model(ALNIPT_DBF, comps, phase) for phase in too_few_phases}
     inst_mods = instantiate_models(ALNIPT_DBF, comps, phases, model=too_few_models)
     assert len(inst_mods) == len(phases)
+
+
+def test_build_functions_options():
+    """The correct SymEngine backend can be chosen for build_functions"""
+    mod = Model(ALNIPT_DBF, ['AL'], 'LIQUID')
+    int_cons = mod.get_internal_constraints()
+
+    backend = 'lambda'
+    fs_lambda = build_functions(mod.GM, mod.GM.free_symbols,
+                                include_obj=True, func_options={'backend': backend},
+                                include_grad=True, grad_options={'backend': backend},
+                                include_hess=True, hess_options={'backend': backend})
+    assert isinstance(fs_lambda.func, LambdaDouble)
+    assert isinstance(fs_lambda.grad, LambdaDouble)
+    assert isinstance(fs_lambda.hess, LambdaDouble)
+
+    cfs_lambda = build_constraint_functions(mod.GM.free_symbols, int_cons,
+                                            func_options={'backend': backend},
+                                            jac_options={'backend': backend},
+                                            hess_options={'backend': backend})
+    assert isinstance(cfs_lambda.cons_func, LambdaDouble)
+    assert isinstance(cfs_lambda.cons_jac, LambdaDouble)
+    assert isinstance(cfs_lambda.cons_hess, LambdaDouble)
+
+    backend = 'llvm'
+    fs_llvm = build_functions(mod.GM, mod.GM.free_symbols,
+                              include_obj=True, func_options={'backend': backend},
+                              include_grad=True, grad_options={'backend': backend},
+                              include_hess=True, hess_options={'backend': backend})
+    print(fs_llvm.func)
+    print(fs_lambda.func)
+    assert isinstance(fs_llvm.func, LLVMDouble)
+    assert isinstance(fs_llvm.grad, LLVMDouble)
+    assert isinstance(fs_llvm.hess, LLVMDouble)
+
+    cfs_llvm = build_constraint_functions(mod.GM.free_symbols, int_cons,
+                                          func_options={'backend': backend},
+                                          jac_options={'backend': backend},
+                                          hess_options={'backend': backend})
+    assert isinstance(cfs_llvm.cons_func, LLVMDouble)
+    assert isinstance(cfs_llvm.cons_jac, LLVMDouble)
+    assert isinstance(cfs_llvm.cons_hess, LLVMDouble)

--- a/pycalphad/tests/test_utils.py
+++ b/pycalphad/tests/test_utils.py
@@ -3,14 +3,14 @@ The utils test module contains tests for pycalphad utilities.
 """
 
 import pytest
-from symengine.lib.symengine_wrapper import LambdaDouble, LLVMDouble
 from pycalphad import Database, Model
 from pycalphad.core.utils import filter_phases, unpack_components, instantiate_models
-from pycalphad.codegen.sympydiff_utils import build_functions, build_constraint_functions
+
 from pycalphad.tests.datasets import ALNIPT_TDB, ALCRNI_TDB
 
 ALNIPT_DBF = Database(ALNIPT_TDB)
 ALCRNI_DBF = Database(ALCRNI_TDB)
+
 
 def test_filter_phases_removes_disordered_phases_from_order_disorder():
     """Databases with order-disorder models should have the disordered phases be filtered if candidate_phases kwarg is not passed to filter_phases.
@@ -50,45 +50,3 @@ def test_instantiate_models_only_returns_desired_phases():
     too_few_models = {phase: Model(ALNIPT_DBF, comps, phase) for phase in too_few_phases}
     inst_mods = instantiate_models(ALNIPT_DBF, comps, phases, model=too_few_models)
     assert len(inst_mods) == len(phases)
-
-
-def test_build_functions_options():
-    """The correct SymEngine backend can be chosen for build_functions"""
-    mod = Model(ALNIPT_DBF, ['AL'], 'LIQUID')
-    int_cons = mod.get_internal_constraints()
-
-    backend = 'lambda'
-    fs_lambda = build_functions(mod.GM, mod.GM.free_symbols,
-                                include_obj=True, func_options={'backend': backend},
-                                include_grad=True, grad_options={'backend': backend},
-                                include_hess=True, hess_options={'backend': backend})
-    assert isinstance(fs_lambda.func, LambdaDouble)
-    assert isinstance(fs_lambda.grad, LambdaDouble)
-    assert isinstance(fs_lambda.hess, LambdaDouble)
-
-    cfs_lambda = build_constraint_functions(mod.GM.free_symbols, int_cons,
-                                            func_options={'backend': backend},
-                                            jac_options={'backend': backend},
-                                            hess_options={'backend': backend})
-    assert isinstance(cfs_lambda.cons_func, LambdaDouble)
-    assert isinstance(cfs_lambda.cons_jac, LambdaDouble)
-    assert isinstance(cfs_lambda.cons_hess, LambdaDouble)
-
-    backend = 'llvm'
-    fs_llvm = build_functions(mod.GM, mod.GM.free_symbols,
-                              include_obj=True, func_options={'backend': backend},
-                              include_grad=True, grad_options={'backend': backend},
-                              include_hess=True, hess_options={'backend': backend})
-    print(fs_llvm.func)
-    print(fs_lambda.func)
-    assert isinstance(fs_llvm.func, LLVMDouble)
-    assert isinstance(fs_llvm.grad, LLVMDouble)
-    assert isinstance(fs_llvm.hess, LLVMDouble)
-
-    cfs_llvm = build_constraint_functions(mod.GM.free_symbols, int_cons,
-                                          func_options={'backend': backend},
-                                          jac_options={'backend': backend},
-                                          hess_options={'backend': backend})
-    assert isinstance(cfs_llvm.cons_func, LLVMDouble)
-    assert isinstance(cfs_llvm.cons_jac, LLVMDouble)
-    assert isinstance(cfs_llvm.cons_hess, LLVMDouble)

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     license='MIT',
     long_description=read('README.rst'),
     url='https://pycalphad.org/',
-    install_requires=['matplotlib', 'pandas', 'xarray>=0.11.2', 'sympy==1.5', 'pyparsing', 'Cython>=0.24',
+    install_requires=['matplotlib', 'pandas', 'xarray>=0.11.2', 'sympy==1.5.1', 'pyparsing', 'Cython>=0.24',
                       'tinydb>=3.8', 'scipy', 'numpy>=1.13', 'ipopt', 'symengine==0.6'],
     classifiers=[
         # How mature is this project? Common values are

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     long_description=read('README.rst'),
     url='https://pycalphad.org/',
     install_requires=['matplotlib', 'pandas', 'xarray>=0.11.2', 'sympy==1.5', 'pyparsing', 'Cython>=0.24',
-                      'tinydb>=3.8', 'scipy', 'numpy>=1.13', 'ipopt', 'symengine==0.5.1'],
+                      'tinydb>=3.8', 'scipy', 'numpy>=1.13', 'ipopt', 'symengine==0.6'],
     classifiers=[
         # How mature is this project? Common values are
         #   3 - Alpha


### PR DESCRIPTION
This PR includes the following changes:

1. PhaseRecords can now be pickled, provided that all callables are built with LLVM callables. This is from adding internal references (e.g. `ofunc_` to to callable functions that are pickled and reused to create the `FastFunction` objects when unpickling.
2. LLVM callables are now the default everywhere, but this can be configured at runtime or through the `build_functions` or `build_constraint_functions` function APIs.
3. Improved module documentation for `sympydiff_utils` and `build_functions`/`build_constraint_functions`.
4. Updates to pin to `symengine=0.6`. This drastically improves the compile time performance for some of the worst-case systems and makes the compile times go from impossible on LLVM (>20,000 sec) to possible (~30-60 sec).
5. Updates releasing docs and GH PR template to include a checklist item for updating dependencies everywhere (this has been missed in release and tests few times)

Some performance benchmarks for the test suite:

Lambda: 138 s
LLVM `opt_level = 3`: 174 s
LLVM `opt_level=0`: 135 s
LLVM `opt_level=3` everywhere, Lambda Hessians: 125 s

From this data, it does appear that there's some runtime/compile time performance trade off, and the most reasonable defaults is LLVM everywhere (so everything can be pickled).

I'm pretty happy with the design and ability to override the options, but one potential gotcha is that if `build_functions` is called and the result cached, a subsequent change to the `DEFAULT_LAMBDIFY_XYZ` options will not take effect for the cached function (non-cached functions will work as expected). I think this is a pretty small tradeoff for the flexibility of this approach, and the fix for the aforementioned "gotcha" is just to restart the Python kernel and don't compile until the global `DEFAULT_LAMBDIFY_XYZ` is changed. 