### PR TITLE
ENH: Reading large databases

### DIFF
--- a/pycalphad/io/database.py
+++ b/pycalphad/io/database.py
@@ -211,7 +211,6 @@ class Database(object): #pylint: disable=R0902
         try:
             dbf = Database()
             format_registry[fmt.lower()].read(dbf, fd)
-            dbf._parameter_queue_process()
         finally:
             # Close file descriptors created in this routine
             # Otherwise that's left up to the calling function
@@ -473,7 +472,7 @@ class Database(object): #pylint: disable=R0902
         """
         return self._parameters.search(query)
 
-    def _parameter_queue_process(self):
+    def process_parameter_queue(self):
         """
         Process the queue of parameters so they are added to the TinyDB in one transaction.
         This avoids repeated (expensive) calls to insert().

--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -72,7 +72,7 @@ def _sympify_string(math_string):
             raise ValueError('Expression from TDB file not in whitelist: '
                              '{}'.format(expr_string))
 
-    return sympify(expr_string, locals=clashing_namespace, evaluate=False)
+    return sympify(expr_string, locals=clashing_namespace)
 
 def _parse_action(func):
     """
@@ -244,7 +244,12 @@ def _tdb_grammar(): #pylint: disable=R0914
         Suppress(White()) + Suppress(':') + constituent_array + \
         Suppress(':') + LineEnd()
     # PARAMETER
-    cmd_parameter = TCCommand('PARAMETER') + SkipTo(LineEnd())
+    cmd_parameter = TCCommand('PARAMETER') + param_types + \
+        Suppress('(') + symbol_name + \
+        Optional(Suppress('&') + Word(alphas+'/-', min=1, max=2), default=None) + \
+        Suppress(',') + constituent_array + \
+        Optional(Suppress(';') + int_number, default=0) + \
+        Suppress(')') + func_expr.setParseAction(_make_piecewise_ast)
     # Now combine the grammar together
     all_commands = cmd_element | \
                     cmd_species | \

--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -943,6 +943,7 @@ def read_tdb(dbf, fd):
             print("Failed while parsing: " + command)
             print("Tokens: " + str(tokens))
             raise
+    dbf.process_parameter_queue()
     del dbf.tdbtypedefs
 
 

--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -72,7 +72,7 @@ def _sympify_string(math_string):
             raise ValueError('Expression from TDB file not in whitelist: '
                              '{}'.format(expr_string))
 
-    return sympify(expr_string, locals=clashing_namespace)
+    return sympify(expr_string, locals=clashing_namespace, evaluate=False)
 
 def _parse_action(func):
     """
@@ -244,12 +244,7 @@ def _tdb_grammar(): #pylint: disable=R0914
         Suppress(White()) + Suppress(':') + constituent_array + \
         Suppress(':') + LineEnd()
     # PARAMETER
-    cmd_parameter = TCCommand('PARAMETER') + param_types + \
-        Suppress('(') + symbol_name + \
-        Optional(Suppress('&') + Word(alphas+'/-', min=1, max=2), default=None) + \
-        Suppress(',') + constituent_array + \
-        Optional(Suppress(';') + int_number, default=0) + \
-        Suppress(')') + func_expr.setParseAction(_make_piecewise_ast)
+    cmd_parameter = TCCommand('PARAMETER') + SkipTo(LineEnd())
     # Now combine the grammar together
     all_commands = cmd_element | \
                     cmd_species | \
@@ -355,7 +350,7 @@ def _process_parameter(targetdb, param_type, phase_name, diffusing_species,
     targetdb.add_parameter(param_type, phase_name.upper(),
                            [[c.upper() for c in sorted(lx)]
                             for lx in constituent_array.asList()],
-                           param_order, param, ref, diffusing_species)
+                           param_order, param, ref, diffusing_species, force_insert=False)
 
 def _unimplemented(*args, **kwargs): #pylint: disable=W0613
     """


### PR DESCRIPTION
I noticed `Database('steel_database_fix.tdb')` can take a long time to complete, 40-90 seconds depending on the machine. Switching to tinydb's `insert_multiple` API is a cheap and easy way to cut that time in ~half.

Most of the remaining time is in parsing the grammar for all the PARAMETERs, as well as calls to sympify for the function expressions. There's room to improve there (may be possible to get the time down to ~6 seconds), but those changes may break some internal or external APIs and will be more complicated to implement. This is the low-hanging fruit.