### PR TITLE
FIX: eqcalculate: Calculate degrees of freedom based on Model

### DIFF
--- a/pycalphad/core/equilibrium.py
+++ b/pycalphad/core/equilibrium.py
@@ -31,8 +31,8 @@ def _adjust_conditions(conds):
     return new_conds
 
 
-def _eqcalculate(dbf, comps, phases, conditions, output, data=None, per_phase=False, callables=None, parameters=None,
-                 **kwargs):
+def _eqcalculate(dbf, comps, phases, conditions, output, data=None, per_phase=False, callables=None, models=None,
+                 parameters=None, **kwargs):
     """
     WARNING: API/calling convention not finalized.
     Compute the *equilibrium value* of a property.
@@ -66,10 +66,12 @@ def _eqcalculate(dbf, comps, phases, conditions, output, data=None, per_phase=Fa
     per_phase : bool, optional
         If True, compute and return the property for each phase present.
         If False, return the total system value, weighted by the phase fractions.
-    parameters : dict, optional
-        Maps SymPy Symbol to numbers, for overriding the values of parameters in the Database.
     callables : dict
         Callable functions to compute 'output' for each phase.
+    models : a dict of phase names to Model
+        Model class to use for each phase.
+    parameters : dict, optional
+        Maps SymPy Symbol to numbers, for overriding the values of parameters in the Database.
     kwargs
         Passed to `calculate`.
 
@@ -79,7 +81,7 @@ def _eqcalculate(dbf, comps, phases, conditions, output, data=None, per_phase=Fa
     """
     if data is None:
         data = equilibrium(dbf, comps, phases, conditions, to_xarray=False)
-    active_phases = unpack_phases(phases) or sorted(dbf.phases.keys())
+    active_phases = unpack_phases(phases)
     conds = _adjust_conditions(conditions)
     indep_vars = ['N', 'P', 'T']
     # TODO: Rewrite this to use the coord dict from 'data'
@@ -101,7 +103,7 @@ def _eqcalculate(dbf, comps, phases, conditions, output, data=None, per_phase=Fa
     # For each phase select all conditions where that phase exists
     # Perform the appropriate calculation and then write the result back
     for phase in active_phases:
-        dof = sum([len(x) for x in dbf.phases[phase].constituents])
+        dof = len(models[phase].site_fractions)
         current_phase_indices = (data.Phase == phase)
         if ~np.any(current_phase_indices):
             continue
@@ -113,7 +115,7 @@ def _eqcalculate(dbf, comps, phases, conditions, output, data=None, per_phase=Fa
         if statevars.get('mode', None) is None:
             statevars['mode'] = 'numpy'
         calcres = calculate(dbf, comps, [phase], output=output, points=points, broadcast=False,
-                            callables=callables, parameters=parameters, **statevars)
+                            callables=callables, parameters=parameters, model=models, **statevars)
         result[output][np.nonzero(current_phase_indices)] = calcres[output].values
     if not per_phase:
         out = np.nansum(result[output] * data['NP'], axis=-1)
@@ -266,7 +268,7 @@ def equilibrium(dbf, comps, phases, conditions, output=None, model=None,
         else:
             per_phase = False
         eqcal = _eqcalculate(dbf, comps, active_phases, conditions, out,
-                             data=properties, per_phase=per_phase, model=models,
+                             data=properties, per_phase=per_phase, models=models,
                              callables=callables, parameters=parameters, **calc_opts)
         properties = properties.merge(eqcal, inplace=True, compat='equals')
     if to_xarray:

--- a/pycalphad/core/equilibrium.py
+++ b/pycalphad/core/equilibrium.py
@@ -56,13 +56,11 @@ def _eqcalculate(dbf, comps, phases, conditions, output, data=None, per_phase=Fa
     output : str
         Equilibrium model property (e.g., CPM, HM, etc.) to compute.
         This must be defined as an attribute in the Model class of each phase.
-    data : Dataset, optional
+    data : Dataset
         Previous result of call to `equilibrium`.
         Should contain the equilibrium configurations at the conditions of interest.
         If the databases are not the same as in the original calculation,
-        the results may be meaningless. If None, `equilibrium` will be called.
-        Specifying this keyword argument can save the user some time if several properties
-        need to be calculated in succession.
+        the results may be meaningless.
     per_phase : bool, optional
         If True, compute and return the property for each phase present.
         If False, return the total system value, weighted by the phase fractions.
@@ -80,7 +78,9 @@ def _eqcalculate(dbf, comps, phases, conditions, output, data=None, per_phase=Fa
     Dataset of property as a function of equilibrium conditions
     """
     if data is None:
-        data = equilibrium(dbf, comps, phases, conditions, to_xarray=False)
+        raise ValueError('Required kwarg "data" is not specified')
+    if models is None:
+        raise ValueError('Required kwarg "models" is not specified')
     active_phases = unpack_phases(phases)
     conds = _adjust_conditions(conditions)
     indep_vars = ['N', 'P', 'T']

--- a/pycalphad/core/utils.py
+++ b/pycalphad/core/utils.py
@@ -147,8 +147,7 @@ def unpack_phases(phases):
     if isinstance(phases, (list, tuple, set)):
         active_phases = sorted(phases)
     elif isinstance(phases, dict):
-        active_phases = sorted([phn for phn, status in phases.items() \
-            if status == 'entered'])
+        active_phases = sorted(phases.keys())
     elif type(phases) is str:
         active_phases = [phases]
     return active_phases


### PR DESCRIPTION
When the Phase is defined in a Database with many more components than are defined
to be active in the present calculation, `_eqcalculate()` would incorrectly calculate degrees of freedom based on all possible components, instead of the active ones.

This would then lead to errors inside `calculate()`, when the length of the passed `points` array would exceed the `maximum_internal_dof`.

This fix does two things:
1. Calculates degrees of freedom using the already-passed `models` object, which is based on the active components.
2. Fixes `unpack_phases` to return only the active phases, instead of returning nothing and causing a fallback to all phases in the Database. (This wasn't a correctness issue, but it did cause unnecessary computation.)