### PR TITLE
Model: redlich_kister_sum: Unwrap Piecewise with trivial branches

### DIFF
--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -607,7 +607,13 @@ class Model(object):
                     mixing_term = mixing_term.xreplace(pair_rule)
                     # This parameter is normalized differently due to the variable charge valence of vacancies
                     mixing_term *= self.site_ratios[va_subl_idx]
-            rk_terms.append(mixing_term * param['parameter'])
+            param_val = param['parameter']
+            if isinstance(param_val, Piecewise):
+                # Eliminate redundant Piecewise and extrapolate beyond temperature limits
+                filtered_args = [i for i in param_val.args if not ((i.cond == S.true) and (i.expr == S.Zero))]
+                if len(filtered_args) == 1:
+                    param_val = filtered_args[0].expr
+            rk_terms.append(mixing_term * param_val)
         return Add(*rk_terms)
 
     def reference_energy(self, dbe):


### PR DESCRIPTION
This PR changes how Redlich-Kister sums are constructed within the `Model` object. Currently all parameters read from the TDB file are wrapped in upper and lower temperature bounds, which in `Model` are represented by a SymPy `Piecewise` object. This is true even when there is only a single nonzero branch for the parameter. It turns out that when such `Piecewise` objects are propagated through complex models like the magnetic ordering model, the automatically-generated first and second derivatives will have a very large number of "zero-terms" corresponding to entries outside the temperature limits. In some cases this can even cause memory errors or slowdowns for multi-component systems.

In this fix, we simply choose to extrapolate beyond the temperature limits by removing the single nonzero branch from the `Piecewise` object and use it directly. Note that this is consistent with the behavior of other Calphad packages, which generally extrapolate beyond the upper and lower temperature limits regardless, even in the case of multiple nonzero branches.

The only disadvantage to this fix is that it may lead to misleading results in the case where there are parameters with multiple non-zero branches; this PR only unwraps single-branched `Piecewise` and does not otherwise modify the upper/lower temperature limits to extrapolate beyond the limits. However, (a) pycalphad already does not extrapolate beyond any temperature limits, and (b) that behavior could be added in a future PR if full compatibility with other packages were desired. Here, we mainly implement this behavior for performance reasons: the vast majority of TDB parameters are single-branched in temperature.
