### PR TITLE
FIX: Fix eqplot for tie-triangles 

### DIFF
--- a/pycalphad/io/database.py
+++ b/pycalphad/io/database.py
@@ -66,10 +66,10 @@ class Database(object): #pylint: disable=R0902
 
     Attributes
     ----------
-    elements : list
-        List of elements in database.
-    species : list
-        List of species in database.
+    elements : set
+        Set of elements in database.
+    species : set
+        Set of species in database.
     phases : dict
         Phase objects indexed by their system-local name.
     symbols : dict
@@ -415,7 +415,7 @@ class Database(object): #pylint: disable=R0902
         ----------
         phase_name : string
             System-local name of the phase.
-        model_hints : list
+        model_hints : dict
             Structured "hints" for a Model trying to read this phase.
             Hints for major constituents and typedefs (Thermo-Calc) go here.
         sublattices : list

--- a/pycalphad/plot/eqplot.py
+++ b/pycalphad/plot/eqplot.py
@@ -151,7 +151,7 @@ def eqplot(eq, ax=None, x=None, y=None, z=None, tielines=True, **kwargs):
             ax.add_collection(lc)
 
     # If we found three phase regions:
-    if three_phase_idx[0].size > 0:
+    if (three_phase_idx[0].size > 0) and (len(indep_comps) == 2):
         found_three_phase = eq.Phase.values[three_phase_idx][..., :3]
         # get tieline endpoints
         three_phase_x = eq.X.sel(component=x.species.name).values[three_phase_idx][..., :3]

--- a/pycalphad/plot/eqplot.py
+++ b/pycalphad/plot/eqplot.py
@@ -137,16 +137,17 @@ def eqplot(eq, ax=None, x=None, y=None, z=None, tielines=True, **kwargs):
             two_phase_y = np.array([two_phase_y, two_phase_y]).swapaxes(0, 1)
 
         # plot two phase points
-        two_phase_plotcolors = np.array(list(map(lambda x: [colorlist[x[0]], colorlist[x[1]]], found_two_phase)), dtype='U') # from pycalphad
-        ax.scatter(two_phase_x[..., 0], two_phase_y[..., 0], s=3, c=two_phase_plotcolors[:,0], edgecolors='None', zorder=2, **kwargs)
-        ax.scatter(two_phase_x[..., 1], two_phase_y[..., 1], s=3, c=two_phase_plotcolors[:,1], edgecolors='None', zorder=2, **kwargs)
+        two_phase_plotcolors = np.array(list(map(lambda x: [colorlist[x[0]], colorlist[x[1]]], found_two_phase)), dtype='U')
+        ax.scatter(two_phase_x[..., 0], two_phase_y[..., 0], s=3, c=two_phase_plotcolors[:, 0], edgecolors='None', zorder=2, **kwargs)
+        ax.scatter(two_phase_x[..., 1], two_phase_y[..., 1], s=3, c=two_phase_plotcolors[:, 1], edgecolors='None', zorder=2, **kwargs)
 
         if tielines:
             # construct and plot tielines
             two_phase_tielines = np.array([np.concatenate((two_phase_x[..., 0][..., np.newaxis], two_phase_y[..., 0][..., np.newaxis]), axis=-1),
                                            np.concatenate((two_phase_x[..., 1][..., np.newaxis], two_phase_y[..., 1][..., np.newaxis]), axis=-1)])
             two_phase_tielines = np.rollaxis(two_phase_tielines, 1)
-            lc = mc.LineCollection(two_phase_tielines, zorder=1, colors=[0,1,0,1], linewidths=[0.5, 0.5])
+            green_tieline_color = [0, 1, 0, 1]  # RGBA
+            lc = mc.LineCollection(two_phase_tielines, zorder=1, colors=green_tieline_color, linewidths=[0.5, 0.5])
             ax.add_collection(lc)
 
     # If we found three phase regions:
@@ -157,12 +158,13 @@ def eqplot(eq, ax=None, x=None, y=None, z=None, tielines=True, **kwargs):
         three_phase_y = eq.X.sel(component=y.species.name).values[three_phase_idx][..., :3]
         # three phase tielines, these are tie triangles and we always plot them
         three_phase_tielines = np.array([np.concatenate((three_phase_x[..., 0][..., np.newaxis], three_phase_y[..., 0][..., np.newaxis]), axis=-1),
-                                     np.concatenate((three_phase_x[..., 1][..., np.newaxis], three_phase_y[..., 1][..., np.newaxis]), axis=-1),
-                                     np.concatenate((three_phase_x[..., 2][..., np.newaxis], three_phase_y[..., 2][..., np.newaxis]), axis=-1)])
-        three_phase_tielines = np.rollaxis(three_phase_tielines,1)
-        three_lc = mc.LineCollection(three_phase_tielines, zorder=1, colors=[1,0,0,1], linewidths=[0.5, 0.5])
+                                         np.concatenate((three_phase_x[..., 1][..., np.newaxis], three_phase_y[..., 1][..., np.newaxis]), axis=-1),
+                                         np.concatenate((three_phase_x[..., 2][..., np.newaxis], three_phase_y[..., 2][..., np.newaxis]), axis=-1)])
+        three_phase_tielines = np.rollaxis(three_phase_tielines, 1)
+        red_tie_triangle_color = [1, 0, 0, 1]  # RGBA
+        three_lc = mc.LineCollection(three_phase_tielines, zorder=1, colors=red_tie_triangle_color, linewidths=[0.5, 0.5])
         # plot three phase points and tielines
-        three_phase_plotcolors = np.array(list(map(lambda x: [colorlist[x[0]], colorlist[x[1]], colorlist[x[2]]], found_three_phase)), dtype='U') # from pycalphad
+        three_phase_plotcolors = np.array(list(map(lambda x: [colorlist[x[0]], colorlist[x[1]], colorlist[x[2]]], found_three_phase)), dtype='U')
         ax.scatter(three_phase_x[..., 0], three_phase_y[..., 0], s=3, c=three_phase_plotcolors[:, 0], edgecolors='None', zorder=2, **kwargs)
         ax.scatter(three_phase_x[..., 1], three_phase_y[..., 1], s=3, c=three_phase_plotcolors[:, 1], edgecolors='None', zorder=2, **kwargs)
         ax.scatter(three_phase_x[..., 2], three_phase_y[..., 2], s=3, c=three_phase_plotcolors[:, 2], edgecolors='None', zorder=2, **kwargs)


### PR DESCRIPTION
In 2D phase diagrams, 2D three phase regions (and tie-triangles) can only exist in where two molar quantities are axis variables. A binary temperature-composition phase diagram can only have three phases exist on an invariant line that occurs at an infinitesimally small temperature. In a binary system under fixed pressure, temperature and composition conditions, it _should_ be impossible to find three phases in equilibrium, however numerically it is possible to achieve three phase stability within pycalphad's convergence limits under these conditions.

`eqplot` only supports T-X binary phase diagrams and X-X ternary isothermal phase diagrams, and implicitly assumes that all three phase equilibria belong to a three phase region in a isothermal phase diagram. If three phases were found to be stable in a binary system and a user tried to plot the phase diagram using `eqplot`, they would see an exception because `eqplot` tries to find the composition of two independent components when plotting the tie-triangles, but only one independent composition existed. This PR changes `eqplot.py:153` from `if three_phase_idx[0].size > 0:` to `if (three_phase_idx[0].size > 0) and (len(indep_comps) == 2):`, i.e. tie-triangles will only be plotted if there are two independent composition conditions. 

I tried to write a test case that exercised the behavior before the PR (raising an except for a three phase equilibrium), but I wasn't able to create a database or use an existing example that reproduced a three phase equilibrium in a binary system.

This PR has some minor code quality cleanups and documentation corrections.