### PR TITLE
TST: Test GitHub Actions on pull_request

### DIFF
--- a/.github/workflows/tests-pull_request.yaml
+++ b/.github/workflows/tests-pull_request.yaml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   Tests:
-    name: Pull Request - Test ${{ matrix.os }} with ${{ matrix.python-version }}
+    name: Test ${{ matrix.os }} with ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/tests-pull_request.yaml
+++ b/.github/workflows/tests-pull_request.yaml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   Tests:
-    name: Pull Request: Test ${{ matrix.os }} with ${{ matrix.python-version }}
+    name: Pull Request - Test ${{ matrix.os }} with ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/tests-pull_request.yaml
+++ b/.github/workflows/tests-pull_request.yaml
@@ -1,0 +1,46 @@
+name: Tests
+
+on: [pull_request]
+
+jobs:
+  Tests:
+    name: Pull Request: Test ${{ matrix.os }} with ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      max-parallel: 9
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.6", "3.7", "3.8"]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # fetch the entire repo history, required to guarantee versioneer will pick up the tags
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+          environment-file: environment-dev.yml
+      - name: Conda info
+        # login shell should be used so conda activate runs
+        shell: bash -l {0}
+        run: conda info
+      - name: Conda list
+        shell: bash -l {0}
+        run: conda list
+      # The last conda-forge Python 3.6 build uses an old macOS deployment
+      # target that causes C++ builds to break. This is a workaround. See
+      # https://github.com/pycalphad/pycalphad/pull/285#issuecomment-731365552
+      # For the syntax of setting environment variables see
+      # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+      - name: macOS + Python 3.6 deployment target fix
+        if: matrix.os == 'macos-latest' && matrix.python-version == '3.6'
+        shell: bash -l {0}
+        run: echo "MACOSX_DEPLOYMENT_TARGET=10.9" >> $GITHUB_ENV
+      - name: Install pycalphad development version
+        shell: bash -l {0}
+        run: pip install --no-deps -e .
+      - name: Test with pytest
+        shell: bash -l {0}
+        run: |
+          pytest -v --cov=pycalphad

--- a/.github/workflows/tests-push.yaml
+++ b/.github/workflows/tests-push.yaml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   Tests:
-    name: Push: Test ${{ matrix.os }} with ${{ matrix.python-version }}
+    name: Push - Test ${{ matrix.os }} with ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/tests-push.yaml
+++ b/.github/workflows/tests-push.yaml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   Tests:
-    name: Test ${{ matrix.os }} with ${{ matrix.python-version }}
+    name: Push: Test ${{ matrix.os }} with ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/tests-push.yaml
+++ b/.github/workflows/tests-push.yaml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   Tests:
-    name: Push - Test ${{ matrix.os }} with ${{ matrix.python-version }}
+    name: Test ${{ matrix.os }} with ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
This simply copies the `push` GitHub Action to one that activates on `pull_request`. The new one that operations on `pull_requests` doesn't push coverage to coveralls because of secrets (see #285)