### PR TITLE
TST: Enable Codecov in a unified test YAML

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,6 +44,7 @@ jobs:
         shell: bash -l {0}
         run: |
           pytest -v --cov=pycalphad
+          coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   Tests:
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      max-parallel: 9
+      max-parallel: 18
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.6", "3.7", "3.8"]
@@ -44,8 +44,7 @@ jobs:
         shell: bash -l {0}
         run: |
           pytest -v --cov=pycalphad
-      - name: Coveralls
-        shell: bash -l {0}
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: coveralls
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true

--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ pycalphad, a library for the CALculation of PHAse Diagrams
     :target: https://gitter.im/pycalphad/pycalphad
     :alt: Join the chat at https://gitter.im/pycalphad/pycalphad
 
-.. image:: https://coveralls.io/repos/pycalphad/pycalphad/badge.svg?branch=develop&service=github
-    :target: https://coveralls.io/github/pycalphad/pycalphad?branch=master
+.. image:: https://codecov.io/gh/pycalphad/pycalphad/branch/develop/graph/badge.svg?token=Fu7FJZeJu0
+    :target: https://codecov.io/gh/pycalphad/pycalphad
     :alt: Test Coverage
 
 .. image:: https://github.com/pycalphad/pycalphad/workflows/Tests/badge.svg

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -27,7 +27,6 @@ dependencies:
   - tinydb>=3.8
   - xarray>=0.11.2
   # Dependences for tests only below
-  - coveralls
   - pytest
   - pytest-cov
   # Documentation dependences


### PR DESCRIPTION
Would supersede #293 if successful. Uses one `test.yaml` workflow for GitHub Actions that triggers on pull requests and pushes. We now use codecov.io for coverage on pushes and PRs (since coveralls does not support coverage from PRs, as discussed in #285).

This PR

- Introduces the codecov.io GitHub Action
- Switches the readme badge to use codecov instead of coveralls
- Drops coveralls dependency from `environment-dev.yml`