### PR TITLE
FIX: Improve Triangular axes projection

### DIFF
--- a/pycalphad/plot/eqplot.py
+++ b/pycalphad/plot/eqplot.py
@@ -112,8 +112,6 @@ def eqplot(eq, ax=None, x=None, y=None, z=None, tielines=True, tieline_color=(0,
     elif projection == 'triangular':
         x = indep_comps[0] if x is None else x
         y = indep_comps[1] if y is None else y
-        # plot settings
-        ax.yaxis.label.set_rotation(60)
         # Here we adjust the x coordinate of the ylabel.
         # We make it reasonably comparable to the position of the xlabel from the xaxis
         # As the figure size gets very large, the label approaches ~0.55 on the yaxis

--- a/pycalphad/plot/triangular.py
+++ b/pycalphad/plot/triangular.py
@@ -43,7 +43,9 @@ class TriangularAxes(Axes):
 
     def cla(self):
         """
-        Override to set up some reasonable defaults.
+        Hard-code axes limits to be on [0, 1] for both axes.
+
+        Warning: Limits not on [0, 1] may lead to clipping issues!
         """
         # Don't forget to call the base class
         super().cla()

--- a/pycalphad/plot/triangular.py
+++ b/pycalphad/plot/triangular.py
@@ -164,7 +164,7 @@ class TriangularAxes(Axes):
         return self._xaxis_transform
 
     def get_xaxis_text1_transform(self, pad):
-        return super().get_xaxis_text1_transform(pad)[0], 'bottom', 'center'
+        return super().get_xaxis_text1_transform(pad)[0], 'top', 'center'
 
     def get_xaxis_text2_transform(self, pad):
         return super().get_xaxis_text2_transform(pad)[0], 'top', 'center'

--- a/pycalphad/plot/triangular.py
+++ b/pycalphad/plot/triangular.py
@@ -91,10 +91,7 @@ class TriangularAxes(Axes):
         # a simple affine change to the figure has been made (such as
         # resizing the window or changing the dpi).
 
-        # 1) The core transformation from data space into
-        # rectilinear space defined in the HammerTransform class.
-        self.transProjection = IdentityTransform()
-        # 2) The above has an output range that is not in the unit
+        # The above has an output range that is not in the unit
         # rectangle, so scale and translate it so it fits correctly
         # within the axes.  The peculiar calculations of xscale and
         # yscale are specific to a Aitoff-Hammer projection, so don't
@@ -142,7 +139,7 @@ class TriangularAxes(Axes):
         # pixels from the edge of the axes ellipse.
 
         self._yaxis_transform = self.transData
-        yaxis_text_base = self.transProjection + (self.transAffine + self.transAxes)
+        yaxis_text_base = self.transAffine + self.transAxes
         self._yaxis_text1_transform = yaxis_text_base + Affine2D().translate(-8.0, 0.0)
         self._yaxis_text2_transform = yaxis_text_base + Affine2D().translate(8.0, 0.0)
 

--- a/pycalphad/plot/triangular.py
+++ b/pycalphad/plot/triangular.py
@@ -83,6 +83,10 @@ class TriangularAxes(Axes):
         #    b d f
         #    0 0 1
 
+        # A useful reference for the different coordinate systems can be found
+        # in a table in the matplotlib transforms tutorial:
+        # https://matplotlib.org/tutorials/advanced/transforms_tutorial.html#transformations-tutorial
+
         # The goal of this transformation is to get from the data space to axes
         # space. We perform an affine transformation on the y-axis, i.e.
         # transforming the y-axis from (0, 1) to (0.5, sqrt(3)/2).

--- a/pycalphad/plot/triangular.py
+++ b/pycalphad/plot/triangular.py
@@ -99,11 +99,8 @@ class TriangularAxes(Axes):
         # within the axes.  The peculiar calculations of xscale and
         # yscale are specific to a Aitoff-Hammer projection, so don't
         # worry about them too much.
-        self.transAffine = Affine2D.from_values(
-                1., 0, 0.5, np.sqrt(3)/2., 0, 0)
-        self.transAffinedep = Affine2D.from_values(
-                1., 0, -0.5, np.sqrt(3)/2., 0, 0)
-        #self.transAffine = IdentityTransform()
+        self.transAffine = Affine2D.from_values(1., 0, 0.5, np.sqrt(3)/2., 0, 0)
+        self.transAffinedep = Affine2D.from_values(1., 0, -0.5, np.sqrt(3)/2., 0, 0)
 
         # 3) This is the transformation from axes space to display
         # space.
@@ -114,10 +111,7 @@ class TriangularAxes(Axes):
         # transforms will be applied "in order".  The transforms are
         # automatically simplified, if possible, by the underlying
         # transformation framework.
-        self.transData = \
-            self.transProjection + \
-            self.transAffine + \
-            self.transAxes
+        self.transData = self.transAffine + self.transAxes
 
         # The main data transformation is set up.  Now deal with
         # gridlines and tick labels.
@@ -130,9 +124,7 @@ class TriangularAxes(Axes):
         # pixels from the equator.
 
         self._xaxis_pretransform = IdentityTransform()
-        self._xaxis_transform = \
-            self._xaxis_pretransform + \
-            self.transData
+        self._xaxis_transform = self._xaxis_pretransform + self.transData
         self._xaxis_text1_transform = \
             Affine2D().scale(1.0, 0.0) + \
             self.transData + \
@@ -150,19 +142,12 @@ class TriangularAxes(Axes):
         # pixels from the edge of the axes ellipse.
 
         self._yaxis_transform = self.transData
-        yaxis_text_base = \
-            self.transProjection + \
-            (self.transAffine + \
-             self.transAxes)
-        self._yaxis_text1_transform = \
-            yaxis_text_base + \
-            Affine2D().translate(-8.0, 0.0)
-        self._yaxis_text2_transform = \
-            yaxis_text_base + \
-            Affine2D().translate(8.0, 0.0)
+        yaxis_text_base = self.transProjection + (self.transAffine + self.transAxes)
+        self._yaxis_text1_transform = yaxis_text_base + Affine2D().translate(-8.0, 0.0)
+        self._yaxis_text2_transform = yaxis_text_base + Affine2D().translate(8.0, 0.0)
 
-    def get_xaxis_transform(self,which='grid'):
-        assert which in ['tick1','tick2','grid']
+    def get_xaxis_transform(self, which='grid'):
+        assert which in ['tick1', 'tick2', 'grid']
         return self._xaxis_transform
 
     def get_xaxis_text1_transform(self, pad):
@@ -171,8 +156,8 @@ class TriangularAxes(Axes):
     def get_xaxis_text2_transform(self, pad):
         return super().get_xaxis_text2_transform(pad)[0], 'top', 'center'
 
-    def get_yaxis_transform(self,which='grid'):
-        assert which in ['tick1','tick2','grid']
+    def get_yaxis_transform(self, which='grid'):
+        assert which in ['tick1', 'tick2', 'grid']
         return self._yaxis_transform
 
     def get_yaxis_text1_transform(self, pad):
@@ -197,8 +182,7 @@ class TriangularAxes(Axes):
         background of the plot.  It should be a subclass of Patch.
         Any data and gridlines will be clipped to this shape.
         """
-
-        return Polygon([[0,0], [0.5,np.sqrt(3)/2], [1,0]], closed=True)
+        return Polygon([[0, 0], [0.5, np.sqrt(3)/2], [1, 0]], closed=True)
 
     # Interactive panning and zooming is not supported with this projection,
     # so we override all of the following methods to disable it.
@@ -207,10 +191,13 @@ class TriangularAxes(Axes):
         Return True if this axes support the zoom box
         """
         return False
+
     def start_pan(self, x, y, button):
         pass
+
     def end_pan(self):
         pass
+
     def drag_pan(self, button, key, x, y):
         pass
 

--- a/pycalphad/plot/triangular.py
+++ b/pycalphad/plot/triangular.py
@@ -87,7 +87,7 @@ class TriangularAxes(Axes):
         self.transAffinedep = Affine2D.from_values(
                 1., 0, -0.5, np.sqrt(3)/2., 0, 0)
         #self.transAffine = IdentityTransform()
-        
+
         # 3) This is the transformation from axes space to display
         # space.
         self.transAxes = BboxTransformTo(self.bbox)

--- a/pycalphad/plot/triangular.py
+++ b/pycalphad/plot/triangular.py
@@ -170,6 +170,35 @@ class TriangularAxes(Axes):
     def drag_pan(self, button, key, x, y):
         pass
 
+    def set_ylabel(self, ylabel, fontdict=None, labelpad=None, rotation=60, **kwargs):
+        """
+        Set the label for the y-axis.
+
+        Rotated to 60 degrees (parallel to the axis) by default.
+
+        Parameters
+        ----------
+        ylabel : str
+            The label text.
+
+        labelpad : scalar, optional, default: None
+            Spacing in points from the axes bounding box including ticks
+            and tick labels.
+
+        Other Parameters
+        ----------------
+        **kwargs : `.Text` properties
+            `.Text` properties control the appearance of the label.
+
+        See also
+        --------
+        text : for information on how override and the optional args work
+
+        """
+        if labelpad is not None:
+            self.yaxis.labelpad = labelpad
+        return self.yaxis.set_label_text(ylabel, fontdict, rotation=rotation, **kwargs)
+
 
 # Now register the projection with matplotlib so the user can select it.
 register_projection(TriangularAxes)

--- a/pycalphad/plot/triangular.py
+++ b/pycalphad/plot/triangular.py
@@ -98,38 +98,16 @@ class TriangularAxes(Axes):
         # space. The '+' operator applies these in order.
         self.transData = self.transAffine + self.transAxes
 
-        # The main data transformation is set up.  Now deal with
-        # gridlines and tick labels.
-
-        # Longitude gridlines and ticklabels.  The input to these
-        # transforms are in display space in x and axes space in y.
-        # Therefore, the input values will be in range (-xmin, 0),
-        # (xmax, 1).  The goal of these transforms is to go from that
-        # space to display space.  The tick labels will be offset 4
-        # pixels from the equator.
-
-        self._xaxis_pretransform = IdentityTransform()
-        self._xaxis_transform = self._xaxis_pretransform + self.transData
-        self._xaxis_text1_transform = \
-            Affine2D().scale(1.0, 0.0) + \
-            self.transData + \
-            Affine2D().translate(0.0, -20.0)
-        self._xaxis_text2_transform = \
-            Affine2D().scale(1.0, 0.0) + \
-            self.transData + \
-            Affine2D().translate(0.0, -4.0)
-
-        # Now set up the transforms for the latitude ticks.  The input to
-        # these transforms are in axes space in x and display space in
-        # y.  Therefore, the input values will be in range (0, -ymin),
-        # (1, ymax).  The goal of these transforms is to go from that
-        # space to display space.  The tick labels will be offset 4
-        # pixels from the edge of the axes ellipse.
+        # The main data transformation is set up.  Now deal with gridlines and
+        # tick labels. For these, we want the same trasnform as the, so we
+        # apply transData directly.
+        self._xaxis_transform = self.transData
+        self._xaxis_text1_transform = self.transData
+        self._xaxis_text2_transform = self.transData
 
         self._yaxis_transform = self.transData
-        yaxis_text_base = self.transAffine + self.transAxes
-        self._yaxis_text1_transform = yaxis_text_base + Affine2D().translate(-8.0, 0.0)
-        self._yaxis_text2_transform = yaxis_text_base + Affine2D().translate(8.0, 0.0)
+        self._yaxis_text1_transform = self.transData
+        self._yaxis_text2_transform = self.transData
 
     def get_xaxis_transform(self, which='grid'):
         assert which in ['tick1', 'tick2', 'grid']

--- a/pycalphad/plot/triangular.py
+++ b/pycalphad/plot/triangular.py
@@ -170,34 +170,34 @@ class TriangularAxes(Axes):
     def drag_pan(self, button, key, x, y):
         pass
 
-    def set_ylabel(self, ylabel, fontdict=None, labelpad=None, rotation=60, **kwargs):
+    def set_ylabel(self, ylabel, fontdict=None, labelpad=None, *, loc=None, **kwargs):
         """
-        Set the label for the y-axis.
-
-        Rotated to 60 degrees (parallel to the axis) by default.
+        Set the label for the y-axis. Default rotation=60 degrees.
 
         Parameters
         ----------
         ylabel : str
             The label text.
 
-        labelpad : scalar, optional, default: None
+        labelpad : float, default: None
             Spacing in points from the axes bounding box including ticks
             and tick labels.
+
+        loc : {'bottom', 'center', 'top'}, default: :rc:`yaxis.labellocation`
+            The label position. This is a high-level alternative for passing
+            parameters *y* and *horizontalalignment*.
 
         Other Parameters
         ----------------
         **kwargs : `.Text` properties
             `.Text` properties control the appearance of the label.
 
-        See also
+        See Also
         --------
-        text : for information on how override and the optional args work
-
+        text : Documents the properties supported by `.Text`.
         """
-        if labelpad is not None:
-            self.yaxis.labelpad = labelpad
-        return self.yaxis.set_label_text(ylabel, fontdict, rotation=rotation, **kwargs)
+        kwargs.setdefault('rotation', 60)
+        return super().set_ylabel(ylabel, fontdict, labelpad, loc=loc, **kwargs)
 
 
 # Now register the projection with matplotlib so the user can select it.

--- a/pycalphad/plot/triangular.py
+++ b/pycalphad/plot/triangular.py
@@ -149,31 +149,30 @@ class TriangularAxes(Axes):
         return self._xaxis_transform
 
     def get_xaxis_text1_transform(self, pad):
-        return self._xaxis_text1_transform, 'bottom', 'center'
+        return super().get_xaxis_text1_transform(pad)[0], 'bottom', 'center'
 
     def get_xaxis_text2_transform(self, pad):
-        return self._xaxis_text2_transform, 'top', 'center'
+        return super().get_xaxis_text2_transform(pad)[0], 'top', 'center'
 
     def get_yaxis_transform(self,which='grid'):
         assert which in ['tick1','tick2','grid']
         return self._yaxis_transform
 
     def get_yaxis_text1_transform(self, pad):
-        return self._yaxis_text1_transform, 'center', 'right'
+        return super().get_yaxis_text1_transform(pad)[0], 'center', 'right'
 
     def get_yaxis_text2_transform(self, pad):
-        return self._yaxis_text2_transform, 'center', 'left'
+        return super().get_yaxis_text2_transform(pad)[0], 'center', 'left'
 
     def _gen_axes_spines(self):
-        dep_spine = mspines.Spine.linear_spine(self,
-                                                   'right')
+        dep_spine = mspines.Spine.linear_spine(self, 'right')
         # Fix dependent axis to be transformed the correct way
         dep_spine.set_transform(self.transAffinedep + self.transAxes)
-        return {'left':mspines.Spine.linear_spine(self,
-                                                   'left'),
-                'bottom':mspines.Spine.linear_spine(self,
-                                                   'bottom'),
-        'right':dep_spine}
+        return {
+            'left': mspines.Spine.linear_spine(self, 'left'),
+            'bottom': mspines.Spine.linear_spine(self, 'bottom'),
+            'right': dep_spine,
+        }
 
     def _gen_axes_patch(self):
         """

--- a/pycalphad/plot/triangular.py
+++ b/pycalphad/plot/triangular.py
@@ -15,8 +15,8 @@ matplotlib.
 
 from matplotlib.axes import Axes
 from matplotlib.patches import Polygon
-from matplotlib.ticker import NullLocator, Formatter, FixedLocator
-from matplotlib.transforms import Affine2D, BboxTransformTo, IdentityTransform
+from matplotlib.ticker import NullLocator
+from matplotlib.transforms import Affine2D, BboxTransformTo
 from matplotlib.projections import register_projection
 import matplotlib.spines as mspines
 import matplotlib.axis as maxis

--- a/pycalphad/plot/triangular.py
+++ b/pycalphad/plot/triangular.py
@@ -1,3 +1,18 @@
+"""
+Register a ``'triangular'`` projection with matplotlib to plot diagrams on
+triangular axes.
+
+Users should not have to instantiate the TriangularAxes class directly.
+Instead, the projection name can be passed as a keyword argument to
+matplotlib.
+
+>>> import matplotlib.pyplot as plt
+>>> import numpy as np
+>>> plt.gca(projection='triangular')
+>>> plt.scatter(np.random.random(10), np.random.random(10))
+
+"""
+
 from matplotlib.axes import Axes
 from matplotlib.patches import Polygon
 from matplotlib.ticker import NullLocator, Formatter, FixedLocator

--- a/pycalphad/plot/triangular.py
+++ b/pycalphad/plot/triangular.py
@@ -8,6 +8,7 @@ import matplotlib.axis as maxis
 
 import numpy as np
 
+
 class TriangularAxes(Axes):
     """
     A custom class for triangular projections.
@@ -16,7 +17,7 @@ class TriangularAxes(Axes):
     name = 'triangular'
 
     def __init__(self, *args, **kwargs):
-        Axes.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.set_aspect(1, adjustable='box', anchor='SW')
         self.cla()
 
@@ -30,8 +31,8 @@ class TriangularAxes(Axes):
         Override to set up some reasonable defaults.
         """
         # Don't forget to call the base class
-        Axes.cla(self)
-        
+        super().cla()
+
         x_min = 0
         y_min = 0
         x_max = 1
@@ -42,8 +43,8 @@ class TriangularAxes(Axes):
         self.yaxis.set_minor_locator(NullLocator())
         self.xaxis.set_ticks_position('bottom')
         self.yaxis.set_ticks_position('left')
-        Axes.set_xlim(self, x_min, x_max)
-        Axes.set_ylim(self, y_min, y_max)
+        super().set_xlim(x_min, x_max)
+        super().set_ylim(y_min, y_max)
         self.xaxis.set_ticks(np.arange(x_min, x_max+x_spacing, x_spacing))
         self.yaxis.set_ticks(np.arange(y_min, y_max+y_spacing, y_spacing))
 


### PR DESCRIPTION
This PR houses a few changes, all in the `TriangluarAxes` projection class.


1. simplification of the transformations code
2. stop calling classmethods of `Axes` and passing self
3. fix several methods, such as `get_xaxis_text1_transform`, to call the superclass and get the transform *after* padding. This means setting the padding of the ticks and axis labels now works correctly for both axes.
4. add an override to `set_ylabel` that sets a default rotation of 60 degrees