### PR TITLE
MAINT: Drop pycalphad conda channel

### DIFF
--- a/INSTALLING.rst
+++ b/INSTALLING.rst
@@ -19,7 +19,7 @@ packages and otherwise challenging to install packages.
 To install pycalphad from Anaconda
 
 1. Download and install Anaconda_
-2. From the Anaconda Prompt (Windows) or a terminal emulator (macOS and Linux) run ``conda install -c pycalphad -c conda-forge pycalphad``
+2. From the Anaconda Prompt (Windows) or a terminal emulator (macOS and Linux) run ``conda install -c conda-forge pycalphad``
 
 
 Development Versions (Advanced Users)
@@ -40,7 +40,7 @@ Installing
 To install the latest development version of pycalphad, run from the Anaconda
 Prompt (Windows) or a terminal emulator (macOS or Linux):
 
-1. Install pycalphad and the conda-forge C and C++ compilers ``conda install -c pycalphad -c conda-forge c-compiler cxx-compiler pycalphad``
+1. Install pycalphad and the conda-forge C and C++ compilers ``conda install -c conda-forge c-compiler cxx-compiler pycalphad``
 #. Remove the installed pycalphad package so the development version can be installed ``conda remove --force pycalphad``
 #. Get the pycalphad source ``git clone https://github.com/pycalphad/pycalphad.git pycalphad/`` (or download from https://github.com/pycalphad/pycalphad)
 #. Go to the top level directory of the package ``cd pycalphad``

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,16 +2,15 @@
 name: test
 channels:
   - conda-forge
-  - pycalphad
 dependencies:
   # NOTE: please try to keep any depedencies in alphabetic order so they may
   # be easily compared with other dependency lists
-  # NOTE: these dependencies may differ in name from the conda-forge and
-  # pycalphad Anaconda channels  from those on PyPI (i.e. those found in
+  # NOTE: these dependencies may differ in name in the conda-forge Anaconda
+  # channel compared to those on PyPI (i.e. those found in
   # `setup.py`). For example, conda-forge/symengine gives the C++ SymEngine
   # library, while conda-forge/python-symengine provides the Python package
   # called `symengine`.
-  - cyipopt
+  - cyipopt>=0.3
   - cython>=0.24
   - matplotlib
   - numpy>=1.13

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         # gives the C++ SymEngine library, while conda-forge/python-symengine
         # provides the Python package called `symengine`.
         'Cython>=0.24',
-        'ipopt',
+        'ipopt>=0.3',
         'matplotlib',
         'numpy>=1.13',
         'pyparsing',


### PR DESCRIPTION
Checklist
* [x] If any dependencies have changed, the changes are reflected in the
  * [x] `setup.py`
  * [x] `environment-dev.yml`

[cyipopt is now building on conda-forge for Windows](https://github.com/conda-forge/cyipopt-feedstock/pull/26) (thanks @moorepants!) so pycalphad does not require the pycalphad package anymore.

This PR 

- bumps pycalphad's dependency on cyipopt to v0.3 or later (the version required for Windows support)
- removes the pycalphad channel from the installation instructions.

Since this PR updates the installation instructions, we should not merge it until https://github.com/conda-forge/pycalphad-feedstock/pull/33 is merged and the package has propagated to the conda-forge channel.