### PR TITLE
MAINT/CI: Support Python 3.9

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 18
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 
 )


### PR DESCRIPTION
Checklist
* [x] If any dependencies have changed, the changes are reflected in the
  * [x] `setup.py`
  * [x] `environment-dev.yml`

This PR
- Adds Python 3.9 to setup.py metadata
- Turns on Python 3.9 in our GitHub Actions CI