### PR TITLE
MAINT: Fix NumPy deprecation warnings

### DIFF
--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -114,7 +114,7 @@ def _sample_phase_constitution(phase_name, phase_constituents, sublattice_dof, c
     # Issues with this appear to be platform-dependent
     points = points[~np.isnan(points).any(axis=-1)]
     # Ensure that points has the correct dimensions and dtype
-    points = np.atleast_2d(np.asarray(points, dtype=np.float))
+    points = np.atleast_2d(np.asarray(points, dtype=np.float_))
     return points
 
 
@@ -206,12 +206,12 @@ def _compute_phase_values(components, statevar_dict,
         phase_output = broadcast_to(phase_output, points.shape[:-1])
     if isinstance(phase_compositions, (float, int)):
         phase_compositions = broadcast_to(phase_output, points.shape[:-1] + (len(pure_elements),))
-    phase_output = np.asarray(phase_output, dtype=np.float)
+    phase_output = np.asarray(phase_output, dtype=np.float_)
     if parameter_array_length <= 1:
         phase_output.shape = points.shape[:-1]
     else:
         phase_output.shape = points.shape[:-1] + (parameter_array_length,)
-    phase_compositions = np.asarray(phase_compositions, dtype=np.float)
+    phase_compositions = np.asarray(phase_compositions, dtype=np.float_)
     phase_compositions.shape = points.shape[:-1] + (len(pure_elements),)
     if fake_points:
         output_shape = points.shape[:-2] + (max_tieline_vertices,)

--- a/pycalphad/core/eqsolver.pyx
+++ b/pycalphad/core/eqsolver.pyx
@@ -258,7 +258,7 @@ def _solve_eq_at_conditions(comps, properties, phase_records, grid, conds_keys, 
         converged = False
         changed_phases = False
         cur_conds = OrderedDict(zip(conds_keys,
-                                    [np.asarray(properties.coords[b][a], dtype=np.float)
+                                    [np.asarray(properties.coords[b][a], dtype=np.float_)
                                      for a, b in zip(it.multi_index, conds_keys)]))
         # assume 'points' and other dimensions (internal dof, etc.) always follow
         curr_idx = [it.multi_index[i] for i, key in enumerate(conds_keys) if key in str_state_variables]

--- a/pycalphad/core/halton.py
+++ b/pycalphad/core/halton.py
@@ -108,16 +108,16 @@ def halton(dim, nbpts, primes=None, scramble=True):
                          'calculated when \'primes\' is only of length {1}. '
                          'Use the \'primes\' parameter to pass additional '
                          'primes.'.format(dim, len(primes)))
-    result = np.empty((nbpts, dim), dtype=np.float)
-    dim_primes = np.asarray(primes[0:dim], dtype=np.float)
+    result = np.empty((nbpts, dim), dtype=np.float_)
+    dim_primes = np.asarray(primes[0:dim], dtype=np.float_)
     for i in np.arange(dim_primes.size):
-        num_powers = np.ceil(np.log(nbpts + 1) / np.log(dim_primes[i])).astype(np.int)
+        num_powers = np.ceil(np.log(nbpts + 1) / np.log(dim_primes[i])).astype(np.int_)
         # need to be careful about precision errors here
         # cast to long double so that, e.g., halton(3, 10000) will be correct
         powers = np.power(dim_primes[i], -np.arange(1, num_powers+1, dtype=np.longdouble))
         radix_vector = np.power(dim_primes[i], -np.arange(num_powers, dtype=np.longdouble))
         # we can drop precision after the outer product for a speedup
-        sum_matrix = np.outer(np.arange(1, nbpts+1), radix_vector).astype(np.float)
+        sum_matrix = np.outer(np.arange(1, nbpts+1), radix_vector).astype(np.float_)
         mod_matrix = np.mod(scrambler[dim_primes[i]] * np.floor(sum_matrix), dim_primes[i])
         result[:, i] = np.dot(mod_matrix, powers)
     return result

--- a/pycalphad/core/utils.py
+++ b/pycalphad/core/utils.py
@@ -123,9 +123,9 @@ def unpack_condition(tup):
         if len(tup) == 1:
             return [float(tup[0])]
         elif len(tup) == 2:
-            return np.arange(tup[0], tup[1], dtype=np.float)
+            return np.arange(tup[0], tup[1], dtype=np.float_)
         elif len(tup) == 3:
-            return np.arange(tup[0], tup[1], tup[2], dtype=np.float)
+            return np.arange(tup[0], tup[1], tup[2], dtype=np.float_)
         else:
             raise ValueError('Condition tuple is length {}'.format(len(tup)))
     elif isinstance(tup, Iterable):
@@ -178,7 +178,7 @@ def endmember_matrix(dof, vacancy_indices=None):
     >>> endmember_matrix([3,3,1], vacancy_indices=[[2], [2], [0]])
     """
     total_endmembers = functools.reduce(operator.mul, dof, 1)
-    res_matrix = np.empty((total_endmembers, sum(dof)), dtype=np.float)
+    res_matrix = np.empty((total_endmembers, sum(dof)), dtype=np.float_)
     dof_arrays = [np.eye(d).tolist() for d in dof]
     row_idx = 0
     for row in itertools.product(*dof_arrays):

--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -1140,12 +1140,12 @@ class TestModel(Model):
         self.models = dict()
         variables = [v.SiteFraction(phase.upper(), 0, x) for x in sorted(self.components)]
         if solution is None:
-            solution = np.random.dirichlet(np.ones_like(variables, dtype=np.int))
+            solution = np.random.dirichlet(np.ones_like(variables, dtype=np.int_))
         self.solution = dict(list(zip(variables, solution)))
         kmax = kmax if kmax is not None else 2
         scale_factor = 1e4 * len(self.components)
-        ampl_scale = 1e3 * np.ones(kmax, dtype=np.float)
-        freq_scale = 10 * np.ones(kmax, dtype=np.float)
+        ampl_scale = 1e3 * np.ones(kmax, dtype=np.float_)
+        freq_scale = 10 * np.ones(kmax, dtype=np.float_)
         polys = Add(*[ampl_scale[i] * sin(freq_scale[i] * Add(*[Add(*[(varname - sol)**(j+1)
                                                                       for varname, sol in self.solution.items()])
                                                                 for j in range(kmax)]))**2

--- a/pycalphad/plot/eqplot.py
+++ b/pycalphad/plot/eqplot.py
@@ -128,8 +128,8 @@ def eqplot(eq, ax=None, x=None, y=None, z=None, tielines=True, tieline_color=(0,
     eq['Phase'].values = np.array(eq['Phase'].values, dtype='U')
 
     # Select all two- and three-phase regions
-    three_phase_idx = np.nonzero(np.sum(eq.Phase.values != '', axis=-1, dtype=np.int) == 3)
-    two_phase_idx = np.nonzero(np.sum(eq.Phase.values != '', axis=-1, dtype=np.int) == 2)
+    three_phase_idx = np.nonzero(np.sum(eq.Phase.values != '', axis=-1, dtype=np.int_) == 3)
+    two_phase_idx = np.nonzero(np.sum(eq.Phase.values != '', axis=-1, dtype=np.int_) == 2)
 
     legend_handles, colorlist = legend_generator(phases)
 

--- a/pycalphad/tests/test_energy.py
+++ b/pycalphad/tests/test_energy.py
@@ -58,8 +58,8 @@ def calculate_output(model, variables, output, mode='sympy'):
 def check_output(model, variables, output, known_value, mode='sympy'):
     "Check that our calculated quantity matches the known value."
     desired = calculate_output(model, variables, output, mode)
-    known_value = np.array(known_value, dtype=np.complex)
-    desired = np.array(desired, dtype=np.complex)
+    known_value = np.array(known_value, dtype=np.complex_)
+    desired = np.array(desired, dtype=np.complex_)
     # atol defaults to zero here, but it cannot be zero if desired is zero
     # we set it to a reasonably small number for energies and derivatives (in Joules)
     # An example where expected = 0, but known != 0 is for ideal mix xlogx terms
@@ -410,7 +410,7 @@ def test_ionic_liquid_energy_anion_sublattice():
         v.Y('IONIC_LIQ', 1, v.Species('VA')): 1e-12,
         v.Y('IONIC_LIQ', 1, v.Species('S', {'S': 1.0})): 1e-12,
     }
-    out = np.array(mod.ast.subs({**potentials, **em_FE_Sneg2}), dtype=np.complex)
+    out = np.array(mod.ast.subs({**potentials, **em_FE_Sneg2}), dtype=np.complex_)
     assert np.isclose(out, -148395.0, atol=0.1)
 
     em_FE_VA = {
@@ -419,7 +419,7 @@ def test_ionic_liquid_energy_anion_sublattice():
         v.Y('IONIC_LIQ', 1, v.Species('VA')): 1.0,
         v.Y('IONIC_LIQ', 1, v.Species('S', {'S': 1.0})): 1e-12,
     }
-    out = np.array(mod.ast.subs({**potentials, **em_FE_VA}), dtype=np.complex)
+    out = np.array(mod.ast.subs({**potentials, **em_FE_VA}), dtype=np.complex_)
     assert np.isclose(out, -87735.077, atol=0.1)
 
     em_FE_S = {
@@ -428,7 +428,7 @@ def test_ionic_liquid_energy_anion_sublattice():
         v.Y('IONIC_LIQ', 1, v.Species('VA')): 1e-12,
         v.Y('IONIC_LIQ', 1, v.Species('S', {'S': 1.0})): 1.0,
     }
-    out = np.array(mod.ast.subs({**potentials, **em_FE_S}), dtype=np.complex)
+    out = np.array(mod.ast.subs({**potentials, **em_FE_S}), dtype=np.complex_)
     assert np.isclose(out, -102463.52, atol=0.1)
 
     # Test some ficticious "nice" mixing cases
@@ -438,7 +438,7 @@ def test_ionic_liquid_energy_anion_sublattice():
         v.Y('IONIC_LIQ', 1, v.Species('VA')): 0.33333333,
         v.Y('IONIC_LIQ', 1, v.Species('S', {'S': 1.0})): 0.33333333,
     }
-    out = np.array(mod.ast.subs({**potentials, **mix_equal}), dtype=np.complex)
+    out = np.array(mod.ast.subs({**potentials, **mix_equal}), dtype=np.complex_)
     assert np.isclose(out, -130358.2, atol=0.1)
 
     mix_unequal = {
@@ -447,7 +447,7 @@ def test_ionic_liquid_energy_anion_sublattice():
         v.Y('IONIC_LIQ', 1, v.Species('VA')): 0.25,
         v.Y('IONIC_LIQ', 1, v.Species('S', {'S': 1.0})): 0.25,
     }
-    out = np.array(mod.ast.subs({**potentials, **mix_unequal}), dtype=np.complex)
+    out = np.array(mod.ast.subs({**potentials, **mix_unequal}), dtype=np.complex_)
     assert np.isclose(out, -138484.11, atol=0.1)
 
     # Test the energies for the two equilibrium internal DOF for the conditions
@@ -457,7 +457,7 @@ def test_ionic_liquid_energy_anion_sublattice():
         v.Y('IONIC_LIQ', 1, v.Species('VA')): 1.00545E-04,
         v.Y('IONIC_LIQ', 1, v.Species('S-2', {'S': 1.0}, charge=-2)): 6.00994E-01,
     }
-    out = np.array(mod.ast.subs({**potentials, **eq_sf_1}), dtype=np.complex)
+    out = np.array(mod.ast.subs({**potentials, **eq_sf_1}), dtype=np.complex_)
     assert np.isclose(out, -141545.37, atol=0.1)
 
     eq_sf_2 = {
@@ -466,5 +466,5 @@ def test_ionic_liquid_energy_anion_sublattice():
         v.Y('IONIC_LIQ', 1, v.Species('VA')): 1.45273E-04,
         v.Y('IONIC_LIQ', 1, v.Species('S')): 9.84476E-01,
     }
-    out = np.array(mod.ast.subs({**potentials, **eq_sf_2}), dtype=np.complex)
+    out = np.array(mod.ast.subs({**potentials, **eq_sf_2}), dtype=np.complex_)
     assert np.isclose(out, -104229.18, atol=0.1)


### PR DESCRIPTION
NumPy 1.20 deprecated the use of `np.int`, `np.float`, `np.complex`, ... ([see here](https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated)) which are type aliases that shadow the built-in types `int`, `float`, `complex`, ...

This PR was the result of 3 regex replaces on `.py`, `.pyx`, and `.pxd` files:

1. `\bnp.int\b` → `np.int_`
2. `\bnp.float\b` → `np.float_`
3. `\bnp.complex\b` → `np.complex_`

These aliases have been around a long time (they are present in our minimum NumPy version 1.13 - tested on NumPy 1.13.3) so this change is backwards compatible.  The trailing `_` versions no longer shadow built-in types and keeping the suffixed versions allows us to find/replace these in the future (compared to built-in types, which we cannot).

For future reference:  `pytest -v pycalphad -W error::DeprecationWarning` can be used to raise errors on DeprecationWarnings. Doing this resulted in 70 tests failing before this PR. Now no tests fail.
