### PR TITLE
BLD: Use `setup_requires` for build Python build dependences

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = [
+    "Cython",
+    "numpy>=1.13",
+    "scipy",
+    "setuptools",
+    "wheel",
+]
+

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,8 @@
-from setuptools import setup, Extension
 import os
+from setuptools import setup, Extension
+from Cython.Build import cythonize
+import numpy as np
 import versioneer
-
-try:
-    from Cython.Build import cythonize
-    import numpy as np
-    import scipy
-except ImportError:
-     raise ImportError("Cython, numpy, and scipy must be installed before pycalphad can be installed.")
 
 
 # Utility function to read the README file.

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,13 @@ from setuptools import setup, Extension
 import os
 import versioneer
 
+try:
+    from Cython.Build import cythonize
+    import numpy as np
+    import scipy
+except ImportError:
+     raise ImportError("Cython, numpy, and scipy must be installed before pycalphad can be installed.")
+
 
 # Utility function to read the README file.
 # Used for the long_description.  It's nice, because now 1) we have a top level
@@ -57,11 +64,6 @@ setup(
     license='MIT',
     long_description=read('README.rst'),
     url='https://pycalphad.org/',
-    setup_requires=[
-        'Cython>=0.24',
-        'numpy>=1.13',
-        'scipy',
-    ],
     install_requires=[
         # NOTE: please try to keep any depedencies in alphabetic order so they
         # may be easily compared with other dependency lists

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,6 @@ from setuptools import setup, Extension
 import os
 import versioneer
 
-try:
-    from Cython.Build import cythonize
-    import numpy as np
-    import scipy
-except ImportError:
-     raise ImportError("Cython, numpy, and scipy must be installed before pycalphad can be installed.")
-
 
 # Utility function to read the README file.
 # Used for the long_description.  It's nice, because now 1) we have a top level
@@ -64,6 +57,11 @@ setup(
     license='MIT',
     long_description=read('README.rst'),
     url='https://pycalphad.org/',
+    setup_requires=[
+        'Cython>=0.24',
+        'numpy>=1.13',
+        'scipy',
+    ],
     install_requires=[
         # NOTE: please try to keep any depedencies in alphabetic order so they
         # may be easily compared with other dependency lists


### PR DESCRIPTION
<!--

Thank you for pull request.

Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.

-->


Checklist
* [x] The documentation examples have been regenerated if the Jupyter notebooks in the `examples/` have changed. To regenerate the documentation examples, run `jupyter nbconvert --to rst --output-dir=docs/examples examples/*.ipynb` from the top level directory)
* [x] If any dependencies have changed, the changes are reflected in the
  * [x] `setup.py`
  * [x] `environment-dev.yml`

This PR:
- Uses setuptools `setup_requires` to specify that pycalphad has build-time dependences on numpy, scipy and Cython.
- No longer raises import errors in `setup.py` when these packages are missing (the build tool should install them automatically)

Closes #309.