### PR TITLE
MAINT: Switch to matplotlib-base; bump to v3.3

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -12,7 +12,7 @@ dependencies:
   # called `symengine`.
   - cyipopt>=1.0
   - cython>=0.24
-  - matplotlib-base >=3.3
+  - matplotlib-base>=3.3
   - numpy>=1.13
   - pyparsing
   - python>=3.6

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -12,7 +12,7 @@ dependencies:
   # called `symengine`.
   - cyipopt>=1.0
   - cython>=0.24
-  - matplotlib
+  - matplotlib-base >=3.3
   - numpy>=1.13
   - pyparsing
   - python>=3.6

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         # provides the Python package called `symengine`.
         'Cython>=0.24',
         'ipopt>=1.0',
-        'matplotlib',
+        'matplotlib>=3.3',
         'numpy>=1.13',
         'pyparsing',
         'scipy',


### PR DESCRIPTION
Switch conda-forge dependency to `matplotlib-base` so users aren't forced need to pull in the `pyqt` backend.

Bump matplotlib requirement to 3.3 so we can use the `loc` argument in `set_ylabel`. Closes #303.