### PR TITLE
MAINT: Refactor `Model.reference_model` -> `Model.endmember_reference_model`

### DIFF
--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -360,12 +360,13 @@ class Model(object):
             mod_endmember_only.models['idmix'] = 0
             if self.models.get('ord', S.Zero) != S.Zero:
                 warnings.warn(
-                    "The choice of endmembers for the endmember reference model used "
-                    "by `_MIX` properties is ambiguous for partitioned models. The "
-                    "`Model.set_reference_state` method is a better choice for "
-                    "computing mixing energy. "
-                    "See https://pycalphad.org/docs/latest/examples/ReferenceStateExamples.html"
-                    " for an example."
+                    f"{self.phase_name} is a partitioned model with an ordering energy "
+                    "contribution. The choice of endmembers for the endmember "
+                    "reference model used by `_MIX` properties is ambiguous for "
+                    "partitioned models. The `Model.set_reference_state` method is a "
+                    "better choice for computing mixing energy. See "
+                    "https://pycalphad.org/docs/latest/examples/ReferenceStateExamples.html "
+                    "for an example."
                 )
                 for k in mod_endmember_only.models.keys():
                     mod_endmember_only.models[k] = nan

--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -358,7 +358,6 @@ class Model(object):
             # contribution of the endmember reference model to zero to preserve ideal
             # mixing in this model.
             mod_endmember_only.models['idmix'] = 0
-            self._endmember_reference_model = mod_endmember_only
             if self.models.get('ord', S.Zero) != S.Zero:
                 warnings.warn(
                     "The choice of endmembers for the endmember reference model used "
@@ -368,8 +367,9 @@ class Model(object):
                     "See https://pycalphad.org/docs/latest/examples/ReferenceStateExamples.html"
                     " for an example."
                 )
-                for k in self.reference_model.models.keys():
-                    self._endmember_reference_model.models[k] = nan
+                for k in mod_endmember_only.models.keys():
+                    mod_endmember_only.models[k] = nan
+            self._endmember_reference_model = mod_endmember_only
         return self._endmember_reference_model
 
     def get_internal_constraints(self):

--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -360,6 +360,14 @@ class Model(object):
             mod_endmember_only.models['idmix'] = 0
             self._endmember_reference_model = mod_endmember_only
             if self.models.get('ord', S.Zero) != S.Zero:
+                warnings.warn(
+                    "The choice of endmembers for the endmember reference model used "
+                    "by `_MIX` properties is ambiguous for partitioned models. The "
+                    "`Model.set_reference_state` method is a better choice for "
+                    "computing mixing energy. "
+                    "See https://pycalphad.org/docs/latest/examples/ReferenceStateExamples.html"
+                    " for an example."
+                )
                 for k in self.reference_model.models.keys():
                     self._endmember_reference_model.models[k] = nan
         return self._endmember_reference_model

--- a/pycalphad/tests/test_energy.py
+++ b/pycalphad/tests/test_energy.py
@@ -356,7 +356,7 @@ def test_changing_model_ast_also_changes_mixing_energy():
                 }
     check_output(m, statevars, 'GM_MIX', 1000)
 
-    m.reference_model.models['mag'] = 1000
+    m.endmember_reference_model.models['mag'] = 1000
     check_output(m, statevars, 'GM_MIX', 0)
 
 


### PR DESCRIPTION
This PR clarifies the usage of `_MIX` models, particularly for partitioned models.

* Renames `reference_model` -> `endmember_reference_model` to be more clear about its purpose. This has potential for breakage if anyone depends on `reference_model`, but it's relatively new and I would consider it an internal API.
* Removes the `_build_reference_model` method because it's not useful enough to exist outside `endmember_reference_model`. Users could replicate the functionality by accessing `endmember_reference_model` to build it and set it to `None` to trigger a rebuild on the next access.
* Adds a warning to inform users that `endmember_reference_model` is not defined for partitioned models (after #268) and points them towards using `Model.shift_reference_state` for mixing energies with a link to the documentation for examples. Closes #304.