### PR TITLE
CI: Use pip and setuptools to install pycalphad instead of Anaconda

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
         run: pip install dist/*.whl
         if: ${{ runner.os != 'Windows' }}
       - name: "Windows: pip install pycalphad wheel"
-        run: pip install dist\*.whl
+        run: pip install "dist\*.whl"
         if: ${{ runner.os == 'Windows' }}
       - run: pip check
       - run: pip list

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,9 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - run: python -m venv pycalphad-dev
+      - run: source ./pycalphad-dev/bin/activate
+        shell: bash
       - run: pip install build
       - run: python -m build --wheel
       - run: pip install dist/*.whl

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: pip install build
       - run: python -m build --wheel
+      - run: ls *
+        shell: bash
       - run: pip install dist/*.whl
       - run: pip check
       - run: pip list

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,16 +22,16 @@ jobs:
       - run: python -m venv pycalphad-dev
       # Platform dependent: environment activation script
       - run: source pycalphad-dev/bin/activate
-        if: ${{ runner.os }} != "Windows"
+        if: ${{ runner.os != "Windows" }}
       - run: pycalphad-dev\Scripts\Activate.ps1
-        if: ${{ runner.os }} == "Windows"
+        if: ${{ runner.os == "Windows" }}
       - run: pip install build
       - run: python -m build --wheel
       # Platform dependent: install path
       - run: pip install dist/*.whl
-        if: ${{ runner.os }} != "Windows"
+        if: ${{ runner.os != "Windows" }}
       - run: pip install dist\*.whl
-        if: ${{ runner.os }} == "Windows"
+        if: ${{ runner.os == "Windows" }}
       - run: pip check
       - run: pip list
       - run: pip install pytest pytest-cov

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,6 +20,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: python -m venv pycalphad-dev
+      - run: ls * pycalphad-dev/bin/activate
+        # Use bash so that the file path works cross-platform
+        shell: bash
+      - run: ls pycalphad-dev/bin/*
+        # Use bash so that the file path works cross-platform
+        shell: bash
       - run: source pycalphad-dev/bin/activate
         # Use bash so that the file path works cross-platform
         shell: bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,17 +20,19 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: python -m venv pycalphad-dev
-      # Platform dependent: environment activation script
-      - run: source pycalphad-dev/bin/activate
+      - name: "Linux/Mac: activate virtual environment"
+        run: source pycalphad-dev/bin/activate
         if: ${{ runner.os != 'Windows' }}
-      - run: pycalphad-dev\Scripts\Activate.ps1
+      - name: "Windows activate virtual environment"
+        run: pycalphad-dev\Scripts\Activate.ps1
         if: ${{ runner.os == 'Windows' }}
       - run: pip install build
       - run: python -m build --wheel
-      # Platform dependent: install path
-      - run: pip install dist/*.whl
+      - name: "Linux/Mac: pip install pycalphad wheel"
+        run: pip install dist/*.whl
         if: ${{ runner.os != 'Windows' }}
-      - run: pip install dist\*.whl
+      - name: "Windows: pip install pycalphad wheel"
+        run: pip install dist\*.whl
         if: ${{ runner.os == 'Windows' }}
       - run: pip check
       - run: pip list

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,20 +20,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: python -m venv pycalphad-dev
-      - name: "Linux/Mac: activate virtual environment"
+      - name: "Activate virtual environment (Linux/Mac)"
         run: source pycalphad-dev/bin/activate
         if: ${{ runner.os != 'Windows' }}
-      - name: "Windows activate virtual environment"
+      - name: "Activate virtual environment (Windows)"
         run: pycalphad-dev\Scripts\Activate.ps1
         if: ${{ runner.os == 'Windows' }}
       - run: pip install build
       - run: python -m build --wheel
-      - name: "Linux/Mac: pip install pycalphad wheel"
-        run: pip install dist/*.whl
-        if: ${{ runner.os != 'Windows' }}
-      - name: "Windows: pip install pycalphad wheel"
-        run: pip install "dist\*.whl"
-        if: ${{ runner.os == 'Windows' }}
+      - run: pip install dist/*.whl
+        shell: bash  # support cross-platform paths
       - run: pip check
       - run: pip list
       - run: pip install pytest pytest-cov

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,11 +19,11 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip list
       - run: pip install build
       - run: python -m build --wheel
       - run: pip install dist/*.whl
       - run: pip check
+      - run: pip list
       - run: pip install pytest pytest-cov
       # append import mode to test the installed package over the local one
       # see here: https://docs.pytest.org/en/6.2.x/pythonpath.html#import-modes

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,35 +16,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0  # fetch the entire repo history, required to guarantee versioneer will pick up the tags
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/setup-python@v2
         with:
-          auto-update-conda: true
           python-version: ${{ matrix.python-version }}
-          environment-file: environment-dev.yml
-      - name: Conda info
-        # login shell should be used so conda activate runs
-        shell: bash -l {0}
-        run: conda info
-      - name: Conda list
-        shell: bash -l {0}
-        run: conda list
-      # The last conda-forge Python 3.6 build uses an old macOS deployment
-      # target that causes C++ builds to break. This is a workaround. See
-      # https://github.com/pycalphad/pycalphad/pull/285#issuecomment-731365552
-      # For the syntax of setting environment variables see
-      # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
-      - name: macOS + Python 3.6 deployment target fix
-        if: matrix.os == 'macos-latest' && matrix.python-version == '3.6'
-        shell: bash -l {0}
-        run: echo "MACOSX_DEPLOYMENT_TARGET=10.9" >> $GITHUB_ENV
-      - name: Install pycalphad development version
-        shell: bash -l {0}
-        run: pip install --no-deps -e .
-      - name: pip check
-        shell: bash -l {0}
-        run: pip check
+      - run: pip list
+      - run: pip install build
+      - run: python -m build --wheel
+      - run: pip install dist/*.whl
+      - run: pip check
       - name: Test with pytest
-        shell: bash -l {0}
         run: |
           pytest -v --cov=pycalphad
           coverage xml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: python -m venv pycalphad-dev
-      - run: source ./pycalphad-dev/bin/activate
+      - run: source pycalphad-dev/bin/activate
+        # Use bash so that the file path works cross-platform
         shell: bash
       - run: pip install build
       - run: python -m build --wheel
@@ -30,8 +31,9 @@ jobs:
       - run: pip check
       - run: pip list
       - run: pip install pytest pytest-cov
-      # append import mode to test the installed package over the local one
-      # see here: https://docs.pytest.org/en/6.2.x/pythonpath.html#import-modes
+      # pytest:
+      # - The `--import-mode=append` and `--pyargs pycalphad` flags test the installed package over the local one
+      # - The `--cov` flag is required to turn on coverage
       - run: pytest -v --import-mode=append --cov --cov-config=pyproject.toml --pyargs pycalphad
       - run: coverage xml
       - name: Upload coverage to Codecov

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
       - run: python -m build --wheel
       - run: pip install dist/*.whl
       - run: pip check
-      - run: pip install pytest
+      - run: pip install pytest pytest-cov
       # append import mode to test the installed package over the local one
       # see here: https://docs.pytest.org/en/6.2.x/pythonpath.html#import-modes
       - run: pytest -v --import-mode=append --cov=pycalphad --pyargs pycalphad

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,16 +22,16 @@ jobs:
       - run: python -m venv pycalphad-dev
       # Platform dependent: environment activation script
       - run: source pycalphad-dev/bin/activate
-        if: ${{ runner.os != "Windows" }}
+        if: ${{ runner.os != 'Windows' }}
       - run: pycalphad-dev\Scripts\Activate.ps1
-        if: ${{ runner.os == "Windows" }}
+        if: ${{ runner.os == 'Windows' }}
       - run: pip install build
       - run: python -m build --wheel
       # Platform dependent: install path
       - run: pip install dist/*.whl
-        if: ${{ runner.os != "Windows" }}
+        if: ${{ runner.os != 'Windows' }}
       - run: pip install dist\*.whl
-        if: ${{ runner.os == "Windows" }}
+        if: ${{ runner.os == 'Windows' }}
       - run: pip check
       - run: pip list
       - run: pip install pytest pytest-cov

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,9 +21,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: pip install build
       - run: python -m build --wheel
-      - run: ls *
-        shell: bash
       - run: pip install dist/*.whl
+        # Use bash so that the file path works cross-platform
+        shell: bash
       - run: pip check
       - run: pip list
       - run: pip install pytest pytest-cov

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,6 @@ jobs:
         shell: bash  # support cross-platform paths
       - run: pip check
       - run: pip list
-      - run: pip install pytest pytest-cov
       # pytest:
       # - The `--import-mode=append` and `--pyargs pycalphad` flags test the installed package over the local one
       # - The `--cov` flag is required to turn on coverage

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,20 +20,18 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: python -m venv pycalphad-dev
-      - run: ls * pycalphad-dev/bin/activate
-        # Use bash so that the file path works cross-platform
-        shell: bash
-      - run: ls pycalphad-dev/bin/*
-        # Use bash so that the file path works cross-platform
-        shell: bash
+      # Platform dependent: environment activation script
       - run: source pycalphad-dev/bin/activate
-        # Use bash so that the file path works cross-platform
-        shell: bash
+        if: ${{ runner.os }} != "Windows"
+      - run: pycalphad-dev\Scripts\Activate.ps1
+        if: ${{ runner.os }} == "Windows"
       - run: pip install build
       - run: python -m build --wheel
+      # Platform dependent: install path
       - run: pip install dist/*.whl
-        # Use bash so that the file path works cross-platform
-        shell: bash
+        if: ${{ runner.os }} != "Windows"
+      - run: pip install dist\*.whl
+        if: ${{ runner.os }} == "Windows"
       - run: pip check
       - run: pip list
       - run: pip install pytest pytest-cov

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
       - run: pip install pytest pytest-cov
       # append import mode to test the installed package over the local one
       # see here: https://docs.pytest.org/en/6.2.x/pythonpath.html#import-modes
-      - run: pytest -v --import-mode=append --cov=pycalphad --pyargs pycalphad
+      - run: pytest -v --import-mode=append --cov --cov-config=pyproject.toml --pyargs pycalphad
       - run: coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,10 +24,11 @@ jobs:
       - run: python -m build --wheel
       - run: pip install dist/*.whl
       - run: pip check
-      - name: Test with pytest
-        run: |
-          pytest -v --cov=pycalphad
-          coverage xml
+      - run: pip install pytest
+      # append import mode to test the installed package over the local one
+      # see here: https://docs.pytest.org/en/6.2.x/pythonpath.html#import-modes
+      - run: pytest -v --import-mode=append --cov=pycalphad --pyargs pycalphad
+      - run: coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,18 @@ requires = [
 ]
 # Use the legacy backend because the local `versioneer.py` dependency that prevents isolated builds
 build-backend = "setuptools.build_meta:__legacy__"
+
+[tool.coverage.paths]
+# the first path is the path to the modules to report coverage against
+# all following paths are patterns to match against the collected data
+# matches will be combined with the first path for coverage
+source = [
+    "./pycalphad",
+    "*/lib/*/site-packages/pycalphad",  # allows testing against site-packages for a local virtual environment
+]
+
+[tool.coverage.run]
+# Packages to consider coverage for
+source_pkgs = [
+    "pycalphad"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,11 @@ requires = [
 # Use the legacy backend because the local `versioneer.py` dependency that prevents isolated builds
 build-backend = "setuptools.build_meta:__legacy__"
 
+[tool.pytest.ini_options]
+markers = [
+    "solver: mark for tests that verify the correctness of the solver",
+]
+
 [tool.coverage.paths]
 # the first path is the path to the modules to report coverage against
 # all following paths are patterns to match against the collected data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,16 +15,16 @@ markers = [
 ]
 
 [tool.coverage.paths]
-# the first path is the path to the modules to report coverage against
-# all following paths are patterns to match against the collected data
-# matches will be combined with the first path for coverage
+# The first path is the path to the modules to report coverage against.
+# All following paths are patterns to match against the collected data.
+# Any matches will be combined with the first path for coverage.
 source = [
     "./pycalphad",
     "*/lib/*/site-packages/pycalphad",  # allows testing against site-packages for a local virtual environment
 ]
 
 [tool.coverage.run]
-# Packages to consider coverage for
+# Only consider coverage for these packages:
 source_pkgs = [
     "pycalphad"
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,3 @@ versionfile_source = pycalphad/_version.py
 versionfile_build = pycalphad/_version.py
 tag_prefix =
 parentdir_prefix = pycalphad-
-[tool:pytest]
-markers =
-    solver: mark for tests that verify the correctness of the solver

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author='Richard Otis',
     author_email='richard.otis@outlook.com',
     description='CALPHAD tools for designing thermodynamic models, calculating phase diagrams and investigating phase equilibria.',
-    packages=['pycalphad', 'pycalphad.codegen', 'pycalphad.core', 'pycalphad.io', 'pycalphad.plot', 'pycalphad.plot.binary'],
+    packages=['pycalphad', 'pycalphad.codegen', 'pycalphad.core', 'pycalphad.io', 'pycalphad.plot', 'pycalphad.plot.binary', 'pycalphad.tests'],
     # "error: '::hypot' has not been declared when compiling with MingGW64"
     # https://github.com/Theano/Theano/issues/4926
     ext_modules=cythonize([Extension('pycalphad.core.hyperplane',

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,8 @@ setup(
         'matplotlib>=3.3',
         'numpy>=1.13',
         'pyparsing',
+        'pytest',
+        'pytest-cov',
         'scipy',
         'symengine==0.7.2',  # python-symengine on conda-forge
         'sympy==1.8',


### PR DESCRIPTION
The new minimizer (#329) allowed us to drop IPOPT as a solver. All our remaining package dependencies are pure Python or have wheels shipped on PyPI (specifically, SymEngine), so installing all our dependencies from pip is now possible.

This PR:
- Changes the Github Actions scripts to use PyPA/build to build a wheel and pip to install the package
- Packages the `pycalphad.tests` package
- Uses the pytest flags `--import-mode=append` and `--pyargs pycalphad` flags to ensure that we test the installed version of the package and not the local version in the working directory.

I (accidentally) verified that we test the installed package because pytest didn't discover the tests until I packaged them in `setup.py`.


Things to consider:

1. Should we add pytest (and pytest-cov?) as runtime dependencies so users can reproduce tests locally without installing extra packages?
2. We could think about introducing something like [`tox`](https://tox.readthedocs.io/en/latest/index.html) to automate this process and make it easier to build and test the installed version locally. That is probably overengineering it - I don't think we've hit any issues yet to justify our need, but it is an alternative.