### PR TITLE
ENH/FIX: Convergence improvements for dilute case

### DIFF
--- a/pycalphad/core/constants.py
+++ b/pycalphad/core/constants.py
@@ -4,7 +4,7 @@ in the module.
 Note that modifying these may yield unpredictable results.
 """
 # Force zero values to this amount, for numerical stability
-MIN_SITE_FRACTION = 8e-13
+MIN_SITE_FRACTION = 1e-16
 MIN_PHASE_FRACTION = 1e-6
 # Phases with mole fractions less than COMP_DIFFERENCE_TOL apart (by Chebyshev distance) are considered "the same" for
 # the purposes of CompositionSet addition and removal during energy minimization.

--- a/pycalphad/core/equilibrium.py
+++ b/pycalphad/core/equilibrium.py
@@ -20,7 +20,7 @@ from datetime import datetime
 def _adjust_conditions(conds):
     "Adjust conditions values to be within the numerical limit of the solver."
     new_conds = OrderedDict()
-    minimum_composition = 1e-12
+    minimum_composition = 1e-10
     for key, value in sorted(conds.items(), key=str):
         if key == str(key):
             key = getattr(v, key, key)

--- a/pycalphad/core/equilibrium.py
+++ b/pycalphad/core/equilibrium.py
@@ -25,7 +25,7 @@ def _adjust_conditions(conds):
         if key == str(key):
             key = getattr(v, key, key)
         if isinstance(key, v.MoleFraction):
-            new_conds[key] = [max(val, MIN_SITE_FRACTION*1000) for val in unpack_condition(value)]
+            new_conds[key] = [max(val, 1e-12) for val in unpack_condition(value)]
         else:
             new_conds[key] = unpack_condition(value)
     return new_conds

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -831,7 +831,6 @@ cpdef find_solution(list compsets, int num_statevars, int num_components,
         # Phases that "want" to be removed will keep having their phase_amt set to zero, so mass balance is unaffected
         system_is_feasible = (state.mass_residual < allowed_mass_residual) and (state.largest_internal_cons_max_residual < 1e-9) and \
                              (chempot_diff < 1e-12) and (state.iteration > 5) and (largest_moles_change < 1e-9) and (phase_change_counter == 0)
-        print(f'system_is_feasible={system_is_feasible}  step_size={step_size} state.mass_residual={state.mass_residual}  state.largest_internal_cons_max_residual={state.largest_internal_cons_max_residual}')
         if system_is_feasible:
             converged = True
             new_free_stable_compset_indices = np.array([i for i in range(state.phase_amt.shape[0])

--- a/pycalphad/tests/test_equilibrium.py
+++ b/pycalphad/tests/test_equilibrium.py
@@ -99,11 +99,9 @@ def test_dilute_condition():
     """
     eq = equilibrium(ALFE_DBF, ['AL', 'FE', 'VA'], 'FCC_A1', {v.T: 1300, v.P: 101325, v.X('AL'): 0}, verbose=True)
     assert_allclose(np.squeeze(eq.GM.values), -64415.84, atol=0.1)
-    eq = equilibrium(ALFE_DBF, ['AL', 'FE', 'VA'], 'FCC_A1', {v.T: 1300, v.P: 101325, v.X('AL'): 1e-8}, verbose=True)
-    # Checked in TC
+    eq = equilibrium(ALFE_DBF, ['AL', 'FE', 'VA'], 'FCC_A1', {v.T: 1300, v.P: 101325, v.X('AL'): 1e-12}, verbose=True)
     assert_allclose(np.squeeze(eq.GM.values), -64415.841)
-    # We loosen the tolerance a bit here because our convergence tolerance is too low for the last digit
-    assert_allclose(np.squeeze(eq.MU.values), [-335723.28,  -64415.838], atol=1.0)
+    assert_allclose(np.squeeze(eq.MU.values), [-385499.682936,  -64415.837878])
 
 @pytest.mark.solver
 def test_eq_illcond_hessian():

--- a/pycalphad/tests/test_equilibrium.py
+++ b/pycalphad/tests/test_equilibrium.py
@@ -101,7 +101,7 @@ def test_dilute_condition():
     assert_allclose(np.squeeze(eq.GM.values), -64415.84, atol=0.1)
     eq = equilibrium(ALFE_DBF, ['AL', 'FE', 'VA'], 'FCC_A1', {v.T: 1300, v.P: 101325, v.X('AL'): 1e-12}, verbose=True)
     assert_allclose(np.squeeze(eq.GM.values), -64415.841)
-    assert_allclose(np.squeeze(eq.MU.values), [-385499.682936,  -64415.837878])
+    assert_allclose(np.squeeze(eq.MU.values), [-385499.682936,  -64415.837878], atol=0.1)
 
 @pytest.mark.solver
 def test_eq_illcond_hessian():

--- a/pycalphad/tests/test_model.py
+++ b/pycalphad/tests/test_model.py
@@ -61,7 +61,7 @@ def test_degree_of_ordering():
     conds = {v.T: 300, v.P: 101325, v.X('AL'): 0.25}
     eqx = equilibrium(ALFE_DBF, comps, my_phases, conds, output='degree_of_ordering', verbose=True)
     print('Degree of ordering: {}'.format(eqx.degree_of_ordering.sel(vertex=0).values.flatten()))
-    assert np.isclose(eqx.degree_of_ordering.sel(vertex=0).values.flatten(), np.array([0.66663873]))
+    assert np.isclose(eqx.degree_of_ordering.sel(vertex=0).values.flatten(), np.array([0.66666666]))
 
 def test_detect_pure_vacancy_phases():
     "Detecting a pure vacancy phase"


### PR DESCRIPTION
Fixes gh-271.

- Sets `MIN_SITE_FRACTION = 1e-16` (previously `8e-13`)
- Changes the minimum allowed composition condition to a constant, `1e-10`, instead of `1000*MIN_SITE_FRACTION` (previously `8e-10`)
- Fixes `test_degree_of_ordering` to have more significant digits of precision
- Adds `allowed_mass_residual` inside of the minimizer, which automatically adjusts the mass residual tolerance for dilute calculations