### PR TITLE
MAINT: Remove `refdata.py`

### DIFF
--- a/pycalphad/refdata.py
+++ b/pycalphad/refdata.py
@@ -1,1 +1,0 @@
-raise ImportError('pycalphad.refdata has been moved to ESPEI. Please install ESPEI 0.3.1 or later.')


### PR DESCRIPTION
This has been deprecated and raising errors when imported for four years.

<!--

Thank you for pull request.

Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.

-->
