### PR TITLE
FIX: potential sorting bug in lower_convex_hull

### DIFF
--- a/pycalphad/core/lower_convex_hull.py
+++ b/pycalphad/core/lower_convex_hull.py
@@ -37,7 +37,7 @@ def lower_convex_hull(global_grid, state_variables, result_array):
     --------
     None yet.
     """
-    indep_conds = sorted([str(sv) for sv in state_variables if str(sv) in result_array.coords.keys()])
+
     comp_conds = sorted([x for x in sorted(result_array.coords.keys()) if x.startswith('X_')])
     comp_conds_indices = sorted([idx for idx, x in enumerate(sorted(result_array.coords['component']))
                                  if 'X_'+x in comp_conds])
@@ -91,7 +91,7 @@ def lower_convex_hull(global_grid, state_variables, result_array):
     comp_coord_shape = tuple(len(result_array.coords[cond]) for cond in comp_conds)
     pot_coord_shape = tuple(len(result_array.coords[cond]) for cond in pot_conds)
     while not it.finished:
-        indep_idx = [] # tuple(idx for idx, key in zip(it.multi_index, result_array_GM_dims) if key in indep_conds)
+        indep_idx = []
         # Relies on being ordered
         for sv in state_variables:
             if str(sv) in result_array.coords.keys():

--- a/pycalphad/core/lower_convex_hull.py
+++ b/pycalphad/core/lower_convex_hull.py
@@ -18,7 +18,7 @@ def lower_convex_hull(global_grid, state_variables, result_array):
     ----------
     global_grid : Dataset
         A sample of the energy surface of the system.
-    state_variables : list
+    state_variables : List[v.StateVariable]
         A list of the state variables (e.g., P, T) used in this calculation.
     result_array : Dataset
         This object will be modified!
@@ -37,7 +37,7 @@ def lower_convex_hull(global_grid, state_variables, result_array):
     --------
     None yet.
     """
-
+    state_variables = sorted(state_variables, key=str)
     comp_conds = sorted([x for x in sorted(result_array.coords.keys()) if x.startswith('X_')])
     comp_conds_indices = sorted([idx for idx, x in enumerate(sorted(result_array.coords['component']))
                                  if 'X_'+x in comp_conds])


### PR DESCRIPTION
Fixes a sorting bug introduced into `lower_convex_hull` by #329. We used to rely on `indep_conds` for sorting the state variables, but now we use the `state_variables` variable directly and `indep_conds` is dead code.

This PR sorts the `state_variables` now.