### PR TITLE
DOC/BLD: Fix documentation builds

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - develop
-      - BLD-fix-sphinx-builds
   pull_request:  # all pull requests
 
 jobs:
@@ -13,7 +12,7 @@ jobs:
     name: Build and deploy latest documentation
     runs-on: ubuntu-latest
     env:
-      TARGET_BRANCH: FAKEBRANCH
+      TARGET_BRANCH: website
       DEPLOY_NAME: latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - develop
+  pull:  # all pull requests
 
 jobs:
   Latest-Docs:
@@ -15,26 +16,30 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0  # fetch the entire repo history, required to guarantee versioneer will pick up the tags
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/setup-python@v2
         with:
-          auto-update-conda: true
-          python-version: "3.8"
-          environment-file: environment-dev.yml
-      - name: Conda Info
-        # login shell should be used so conda activate runs
-        shell: bash -l {0}
-        run: conda info
-      - name: Conda list
-        shell: bash -l {0}
-        run: conda list
-      - name: Install pycalphad development version
-        shell: bash -l {0}
-        run: pip install --no-deps -e .
-      - name: Sphinx Build
-        shell: bash -l {0}
-        run: sphinx-build -b html docs docs/_build/html
+          python-version: ${{ matrix.python-version }}
+      - run: python -m venv pycalphad-dev
+      - name: "Activate virtual environment (Linux/Mac)"
+        run: source pycalphad-dev/bin/activate
+        if: ${{ runner.os != 'Windows' }}
+      - name: "Activate virtual environment (Windows)"
+        run: pycalphad-dev\Scripts\Activate.ps1
+        if: ${{ runner.os == 'Windows' }}
+      - run: pip install build
+      - run: python -m build --wheel
+      - run: pip install dist/*.whl
+        shell: bash  # support cross-platform paths
+      - run: pip check
+      - run: pip list
+      # Build
+      - run: sphinx-build -b html docs docs/_build/html
+      # Deploy _only_ if a push event triggered the build
+      # Workaround since GitHub Actions does not support exiting early succesfully
       - run: git checkout $TARGET_BRANCH
+        if: ${{ github.event_name == 'push' }}
       - name: Copy Documentation to destination
+        if: ${{ github.event_name == 'push' }}
         run: |
           mkdir -p docs/$DEPLOY_NAME
           # clean any existing contents
@@ -42,6 +47,7 @@ jobs:
           # copy the output
           cp -Rf docs/_build/html/* docs/$DEPLOY_NAME
       - name: Commit and push changes
+        if: ${{ github.event_name == 'push' }}
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -27,10 +27,7 @@ jobs:
       - name: "Activate virtual environment (Windows)"
         run: pycalphad-dev\Scripts\Activate.ps1
         if: ${{ runner.os == 'Windows' }}
-      - run: pip install build
-      - run: python -m build --wheel
-      - run: pip install dist/*.whl
-        shell: bash  # support cross-platform paths
+      - run: pip install -e .
       - run: pip list
       # Build documentation
       - run: pip install ipython sphinx sphinx-rtd-theme

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,4 +1,6 @@
 name: Documentation
+# Builds on pushes to develop and all pull requests
+# Deploys only on push events
 on:
   push:
     branches:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - develop
-  pull:  # all pull requests
+  pull_request:  # all pull requests
 
 jobs:
   Latest-Docs:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - develop
+      - BLD-fix-sphinx-builds
   pull_request:  # all pull requests
 
 jobs:
@@ -10,7 +11,7 @@ jobs:
     name: Build and deploy latest documentation
     runs-on: ubuntu-latest
     env:
-      TARGET_BRANCH: website
+      TARGET_BRANCH: FAKEBRANCH
       DEPLOY_NAME: latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -31,9 +31,10 @@ jobs:
       - run: python -m build --wheel
       - run: pip install dist/*.whl
         shell: bash  # support cross-platform paths
-      - run: pip check
       - run: pip list
-      # Build
+      - run: pip check
+      # Build documentation
+      - run: pip install ipython sphinx sphinx-rtd-theme
       - run: sphinx-build -b html docs docs/_build/html
       # Deploy _only_ if a push event triggered the build
       # Workaround since GitHub Actions does not support exiting early succesfully

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: "Activate virtual environment (Windows)"
         run: pycalphad-dev\Scripts\Activate.ps1
         if: ${{ runner.os == 'Windows' }}
-      - run: pip install -e .
+      - run: python -m pip install -e .
       - run: pip list
       # Build documentation
       - run: pip install ipython sphinx sphinx-rtd-theme

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -32,7 +32,6 @@ jobs:
       - run: pip install dist/*.whl
         shell: bash  # support cross-platform paths
       - run: pip list
-      - run: pip check
       # Build documentation
       - run: pip install ipython sphinx sphinx-rtd-theme
       - run: sphinx-build -b html docs docs/_build/html

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: "Activate virtual environment (Windows)"
         run: pycalphad-dev\Scripts\Activate.ps1
         if: ${{ runner.os == 'Windows' }}
-      - run: python -m pip install -e .
+      - run: pip install .
       - run: pip list
       # Build documentation
       - run: pip install ipython sphinx sphinx-rtd-theme

--- a/docs/api/pycalphad.core.rst
+++ b/docs/api/pycalphad.core.rst
@@ -108,6 +108,14 @@ pycalphad.core.lower\_convex\_hull module
    :undoc-members:
    :show-inheritance:
 
+pycalphad.core.minimizer module
+-------------------------------
+
+.. automodule:: pycalphad.core.minimizer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 pycalphad.core.patched\_piecewise module
 ----------------------------------------
 

--- a/docs/api/pycalphad.rst
+++ b/docs/api/pycalphad.rst
@@ -23,14 +23,6 @@ pycalphad.model module
    :undoc-members:
    :show-inheritance:
 
-pycalphad.refdata module
-------------------------
-
-.. automodule:: pycalphad.refdata
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 pycalphad.variables module
 --------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,28 +1,6 @@
-import sys
-import os
-
-# Single-source versioning
-ver_loader = None
-ver_module = None
-try:
-    # Python 3
-    import importlib.machinery
-    ver_loader = importlib.machinery.SourceFileLoader('_version',
-                                                      '../pycalphad/_version.py')
-    ver_module = ver_loader.load_module()
-except ImportError:
-    # Python 2
-    import imp
-    ver_module = imp.load_source('_version',
-                                 '../pycalphad/_version.py')
-
-__version__ = ver_module.get_versions()['version']
-del ver_loader, ver_module
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('../pycalphad'))
+# Single-source versioning, assumes pycalphad is installed
+# pycalphad must be on the import path for API documentation to work
+from pycalphad import __version__
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,8 @@
-# Single-source versioning, assumes pycalphad is installed
-# pycalphad must be on the import path for API documentation to work
+import sys
+import os
+
+# pycalphad must be importable to build API documentation and for version retreival
+sys.path.insert(0, os.path.abspath('../pycalphad'))
 from pycalphad import __version__
 
 # -- General configuration ------------------------------------------------


### PR DESCRIPTION
- Sphinx `conf.py`: Don't load the version from a hardcoded `_version.py` (changes from #341)
- CI: Build (but don't deploy) documentation on pull requests so we can catch regressions in the docs in the future
- CI: Use pip to install rather than conda in docs builds