### PR TITLE
FIX: Minimizer: CompositionSet objects set for removal are not removed

### DIFF
--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -832,13 +832,6 @@ cpdef find_solution(list compsets, int num_statevars, int num_components,
         system_is_feasible = (state.mass_residual < allowed_mass_residual) and (state.largest_internal_cons_max_residual < 1e-9) and \
                              (chempot_diff < 1e-12) and (state.iteration > 5) and (largest_moles_change < 1e-9) and (phase_change_counter == 0)
         if system_is_feasible:
-            converged = True
-            new_free_stable_compset_indices = np.array([i for i in range(state.phase_amt.shape[0])
-                                                        if (state.phase_amt[i] > MIN_SITE_FRACTION) and \
-                                                        (i not in suspended_compsets)], dtype=np.int32)
-            if set(state.free_stable_compset_indices) == set(new_free_stable_compset_indices):
-                converged = True
-            state.free_stable_compset_indices = new_free_stable_compset_indices
             # Check driving forces for metastable phases
             # This needs to be done per mole of atoms, not per formula unit, since we compare phases to each other
             driving_forces = np.zeros(len(state.compsets))


### PR DESCRIPTION
The `new_free_stable_compset_indices` are created after phase removal [here](https://github.com/pycalphad/pycalphad/blob/657f5ba38ef582573a31cf6646ea5528286db83b/pycalphad/core/minimizer.pyx#L816), but these new stable indices with the phases removed are essentially reset [here](https://github.com/pycalphad/pycalphad/blob/657f5ba38ef582573a31cf6646ea5528286db83b/pycalphad/core/minimizer.pyx#L841) (by the code removed in this change).

This is just one way to address this issue, maybe the most straightforward? An alternative could be set the phase amounts to the phases scheduled for removal to zero and to leave in the code that reconstructs the `new_stable_compset_indices` (which won't include the phases with new zero phase amounts).

The removed code could also fix a bug where a fixed phase is included in the free stable phase indices if it has non-zero phase amount.