### PR TITLE
FIX/TST: Adjust MIN_SITE_FRACTION and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ env/
 *.c
 *.h
 *.so
+*.pyd
 *.sublime-project
 *.sublime-workspace
 *.cpp

--- a/pycalphad/core/constants.py
+++ b/pycalphad/core/constants.py
@@ -4,7 +4,7 @@ in the module.
 Note that modifying these may yield unpredictable results.
 """
 # Force zero values to this amount, for numerical stability
-MIN_SITE_FRACTION = 1e-16
+MIN_SITE_FRACTION = 1e-14
 MIN_PHASE_FRACTION = 1e-6
 # Phases with mole fractions less than COMP_DIFFERENCE_TOL apart (by Chebyshev distance) are considered "the same" for
 # the purposes of CompositionSet addition and removal during energy minimization.

--- a/pycalphad/tests/test_equilibrium.py
+++ b/pycalphad/tests/test_equilibrium.py
@@ -576,8 +576,8 @@ def test_eq_alni_high_temp():
     assert set(np.squeeze(eq.Phase.values)) == {'BCC_B2', 'LIQUID', ''}
     bcc_idx = np.nonzero(np.squeeze(eq.Phase.values) == 'BCC_B2')[0][0]
     liq_idx = np.nonzero(np.squeeze(eq.Phase.values) == 'LIQUID')[0][0]
-    assert_allclose(np.squeeze(eq.X.sel(vertex=bcc_idx).values), [0.562336, 0.437664], atol=1e-6)
-    assert_allclose(np.squeeze(eq.X.sel(vertex=liq_idx).values), [0.693173, 0.306827], atol=1e-6)
+    assert_allclose(np.squeeze(eq.X.sel(vertex=bcc_idx).values), [0.563528, 0.436472], atol=1e-6)
+    assert_allclose(np.squeeze(eq.X.sel(vertex=liq_idx).values), [0.695314, 0.304686], atol=1e-6)
 
 
 @pytest.mark.solver

--- a/pycalphad/tests/test_model.py
+++ b/pycalphad/tests/test_model.py
@@ -61,7 +61,7 @@ def test_degree_of_ordering():
     conds = {v.T: 300, v.P: 101325, v.X('AL'): 0.25}
     eqx = equilibrium(ALFE_DBF, comps, my_phases, conds, output='degree_of_ordering', verbose=True)
     print('Degree of ordering: {}'.format(eqx.degree_of_ordering.sel(vertex=0).values.flatten()))
-    assert np.isclose(eqx.degree_of_ordering.sel(vertex=0).values.flatten(), np.array([0.66666666]))
+    assert np.isclose(eqx.degree_of_ordering.sel(vertex=0).values.flatten(), np.array([0.6666]), atol=1e-4)
 
 def test_detect_pure_vacancy_phases():
     "Detecting a pure vacancy phase"


### PR DESCRIPTION
- Change `MIN_SITE_FRACTION` to `1e-14`
- Add a test to confirm the high-temperature jitter in Al-Ni is fixed by the change (was checked before and after)
- Adjust `test_degree_of_ordering` tolerance to account for sensitivity of our degree-of-ordering metric to differences in `MIN_SITE_FRACTION`
- Add a test to close gh-259
- Add Windows compiled extension type `.pyd` to `.gitignore`