### PR TITLE
FIX: pyparsing 3.0 support

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -14,7 +14,7 @@ dependencies:
   - importlib_metadata  # drop when pycalphad drops support for Python<3.8
   - matplotlib-base>=3.3
   - numpy>=1.13
-  - pyparsing>=2
+  - pyparsing>=2.4
   - python>=3.7
   - python-symengine=0.7.2
   - scipy

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -14,7 +14,7 @@ dependencies:
   - importlib_metadata  # drop when pycalphad drops support for Python<3.8
   - matplotlib-base>=3.3
   - numpy>=1.13
-  - pyparsing>=2,<3
+  - pyparsing>=2
   - python>=3.7
   - python-symengine=0.7.2
   - scipy

--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -206,7 +206,7 @@ def _tdb_grammar(): #pylint: disable=R0914
     # a convenience function will handle the piecewise details
     func_expr = (float_number | ZeroOrMore(',').setParseAction(lambda t: 0.01)) + OneOrMore(SkipTo(';') \
         + Suppress(';') + ZeroOrMore(Suppress(',')) + Optional(float_number) + \
-        Suppress(Word('YNyn', exact=1) | White()))
+        Suppress(Optional(Word('Yy', exact=1))), stopOn=Word('Nn', exact=1)) + Suppress(Optional(Word('Nn', exact=1)))
     # ELEMENT
     cmd_element = TCCommand('ELEMENT') + Word(alphas+'/-', min=1, max=2) + ref_phase_name + \
         float_number + float_number + float_number + LineEnd()

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         'importlib_metadata',  # drop when pycalphad drops support for Python<3.8
         'matplotlib>=3.3',
         'numpy>=1.13',
-        'pyparsing>=2.0,<3',
+        'pyparsing>=2.0',
         'pytest',
         'pytest-cov',
         'scipy',

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         'importlib_metadata',  # drop when pycalphad drops support for Python<3.8
         'matplotlib>=3.3',
         'numpy>=1.13',
-        'pyparsing>=2.0',
+        'pyparsing>=2.4',
         'pytest',
         'pytest-cov',
         'scipy',


### PR DESCRIPTION
Fixes gh-347, which reports a regression with the pyparsing 3.0 pre-release. This change should be backwards compatible with pyparsing 2.4+. I do not know the precise root cause of the regression, as I was able to narrow the problem down empirically. My best guess is that the semantics of `pyparsing.White()` have changed in some way.

@bocklund This should be run against your private collection of TDBs to identify regressions.


Checklist
* [x] If any dependencies have changed, the changes are reflected in the
  * [x] `setup.py`
  * [x] `environment-dev.yml`
