### PR TITLE
ENH: Refactor solver and improve solver performance

### DIFF
--- a/pycalphad/core/eqsolver.pyx
+++ b/pycalphad/core/eqsolver.pyx
@@ -250,7 +250,7 @@ def _solve_eq_at_conditions(properties, phase_records, grid, conds_keys, state_v
             result = solve_and_update(composition_sets, cur_conds, iter_solver)
 
             chemical_potentials[:] = result.chemical_potentials
-            changed_phases |= add_new_phases(composition_sets, removed_compsets, phase_records,
+            changed_phases = add_new_phases(composition_sets, removed_compsets, phase_records,
                                             grid, curr_idx, chemical_potentials, state_variable_values,
                                             1e-4, verbose)
             iterations += 1

--- a/pycalphad/core/eqsolver.pyx
+++ b/pycalphad/core/eqsolver.pyx
@@ -203,7 +203,7 @@ def _solve_eq_at_conditions(properties, phase_records, grid, conds_keys, state_v
                                     [np.asarray(properties.coords[b][a], dtype=np.float_)
                                      for a, b in zip(it.multi_index, conds_keys)]))
         # assume 'points' and other dimensions (internal dof, etc.) always follow
-        curr_idx = tuple(it.multi_index[i] for i, key in enumerate(conds_keys) if key in str_state_variables)
+        curr_idx = [it.multi_index[i] for i, key in enumerate(conds_keys) if key in str_state_variables]
         state_variable_values = [cur_conds[key] for key in str_state_variables]
         state_variable_values = np.array(state_variable_values)
         # sum of independently specified components
@@ -235,22 +235,6 @@ def _solve_eq_at_conditions(properties, phase_records, grid, conds_keys, state_v
             composition_sets.append(compset)
         chemical_potentials = prop_MU_values[it.multi_index]
         energy = prop_GM_values[it.multi_index]
-        # Add unrepresented phases as metastable composition sets
-        # This should help catch phases around the limit of stability
-        unrepresented_phases = sorted(set(phase_records.keys()) - set(prop_Phase_values[it.multi_index]) - {'', '_FAKE_'})
-        driving_forces = (chemical_potentials * grid.X[np.index_exp[curr_idx]]).sum(axis=-1) - grid.GM[np.index_exp[curr_idx]]
-        for phase_name in unrepresented_phases:
-            phase_record = phase_records[phase_name]
-            phase_amt = 0.0
-            compset = CompositionSet(phase_record)
-            idx_grid_for_phase = grid.Phase[np.index_exp[curr_idx]] == phase_name
-            minimum_df_idx = np.argmax(driving_forces[idx_grid_for_phase])
-            if driving_forces[idx_grid_for_phase][minimum_df_idx] < 1000:
-                continue
-            df_idx = np.arange(len(driving_forces))[idx_grid_for_phase][minimum_df_idx]
-            sfx = np.atleast_1d(np.squeeze(grid.Y[curr_idx + (df_idx,) + np.index_exp[:phase_record.phase_dof]]))
-            compset.update(sfx, phase_amt, state_variable_values)
-            composition_sets.append(compset)
         #print('Composition Sets', composition_sets)
         phase_amt_sum = 0.0
         for compset in composition_sets:

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -766,7 +766,7 @@ cdef void remove_and_consolidate_phases(SystemSpecification spec, SystemState st
             state.phase_amt[dof_idx] = 0
 
 
-cdef bint change_phases(SystemSpecification spec, SystemState state, metastable_phase_iterations, times_compset_removed, can_add_phases):
+cdef bint change_phases(SystemSpecification spec, SystemState state, int[::1] metastable_phase_iterations, int[::1] times_compset_removed, bint can_add_phases):
     cdef int idx
     phase_amt = state.phase_amt
     current_free_stable_compset_indices = state.free_stable_compset_indices

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -788,8 +788,7 @@ cpdef find_solution(list compsets, int num_statevars, int num_components,
     cdef double allowed_mass_residual, largest_chemical_potential_difference, step_size
     cdef double[::1] x
     cdef double[::1] previous_chemical_potentials = np.empty(num_components)
-    cdef int[::1] fixed_stable_compset_indices = np.array(np.nonzero([compset.fixed==True for compset in compsets])[0],
-                                                          dtype=np.int32)
+    cdef int[::1] fixed_stable_compset_indices = np.array([i for i, compset in enumerate(compsets) if compset.fixed], dtype=np.int32)
     cdef int[::1] metastable_phase_iterations = np.zeros(len(compsets), dtype=np.int32)
     cdef int[::1] times_compset_removed = np.zeros(len(compsets), dtype=np.int32)
     cdef bint converged = False

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -581,7 +581,7 @@ cdef class SystemState:
                 for i in range(num_phase_dof+spec.num_statevars):
                     csst.moles_normalization_grad[i] += csst.mass_jac[comp_idx, i]
 
-    cdef double[::1] driving_forces(self, spec):  # TODO: spec only used for # of components, is that something the State should know on its own?
+    cdef double[::1] driving_forces(self, SystemSpecification spec):  # TODO: spec only used for # of components, is that something the State should know on its own?
         cdef int idx, comp_idx
         cdef CompositionSet compset
         cdef double[::1] x

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -661,10 +661,9 @@ cpdef take_step(SystemSpecification spec, SystemState state, double step_size):
         x = state.dof[idx]
         csst = state.cs_states[idx]
         internal_cons_max_residual = 0
-        cons_tmp = np.zeros(compset.phase_record.num_internal_cons)
-        compset.phase_record.internal_cons_func(cons_tmp, x)
+        # Safe to use csst.internal_cons here because the phase dof hasn't changed yet
         for cons_idx in range(compset.phase_record.num_internal_cons):
-            internal_cons_max_residual = max(internal_cons_max_residual, abs(cons_tmp[cons_idx]))
+            internal_cons_max_residual = max(internal_cons_max_residual, abs(csst.internal_cons[cons_idx]))
 
         # Construct delta_y from Eq. 43 in Sundman 2015
         # TODO: needs charge balance contribution

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -1,5 +1,4 @@
 cimport cython
-cimport openmp
 import numpy as np
 cimport numpy as np
 from pycalphad.core.composition_set cimport CompositionSet
@@ -791,12 +790,6 @@ cpdef find_solution(list compsets, int num_statevars, int num_components,
                                                         fixed_stable_compset_indices)
     cdef SystemState state = SystemState(spec, compsets)
 
-    # Our call to LAPACK in invert_matrix uses multithreading, but most of the time it's
-    # slower than working on a single thread. We'll set single threaded here and reset
-    # back to the current value at the end.
-    cdef int omp_orig_num_threads = openmp.omp_get_max_threads()
-    openmp.omp_set_num_threads(1)
-
     if spec.prescribed_elemental_amounts.shape[0] > 0:
         allowed_mass_residual = min(1e-8, np.min(spec.prescribed_elemental_amounts)/10)
         # Also adjust mass residual if we are near the edge of composition space
@@ -868,8 +861,4 @@ cpdef find_solution(list compsets, int num_statevars, int num_components,
     for cs_dof in state.dof[1:]:
         x = np.r_[x, cs_dof[num_statevars:]]
     x = np.r_[x, phase_amt]
-
-    # Reset OpenMP threads to the initial value
-    openmp.omp_set_num_threads(omp_orig_num_threads)
-
     return converged, x, np.array(state.chemical_potentials)

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -800,7 +800,7 @@ cpdef find_solution(list compsets, int num_statevars, int num_components,
                     int[::1] free_chemical_potential_indices, int[::1] fixed_chemical_potential_indices,
                     int[::1] prescribed_element_indices, double[::1] prescribed_elemental_amounts,
                     int[::1] free_statevar_indices, int[::1] fixed_statevar_indices):
-    cdef int iteration, idx, idx2, comp_idx, phase_idx, i
+    cdef int iteration, idx, idx2, comp_idx, phase_idx, i, iterations_since_last_phase_change
     cdef int num_stable_phases, num_fixed_components, num_free_variables
     cdef CompositionSet compset, compset2
     cdef double mass_residual = 1e-30

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -49,13 +49,15 @@ cdef void compute_phase_matrix(double[:,::1] phase_matrix, double[:,::1] hess,
     cdef int comp_idx, i, j, cons_idx, fixed_dof_idx
     cdef int num_components = chemical_potentials.shape[0]
     compset.phase_record.internal_cons_jac(cons_jac_tmp, phase_dof)
-    phase_matrix[:compset.phase_record.phase_dof, :compset.phase_record.phase_dof] = hess[num_statevars:, num_statevars:]
 
-    phase_matrix[compset.phase_record.phase_dof:compset.phase_record.phase_dof+compset.phase_record.num_internal_cons,
-                 :compset.phase_record.phase_dof] = cons_jac_tmp[:, num_statevars:]
-    phase_matrix[:compset.phase_record.phase_dof,
-                 compset.phase_record.phase_dof:compset.phase_record.phase_dof+compset.phase_record.num_internal_cons] \
-        = cons_jac_tmp[:, num_statevars:].T
+    for i in range(compset.phase_record.phase_dof):
+        for j in range(compset.phase_record.phase_dof):
+            phase_matrix[i, j] = hess[num_statevars+i, num_statevars+j]
+
+    for i in range(compset.phase_record.num_internal_cons):
+        for j in range(compset.phase_record.phase_dof):
+            phase_matrix[compset.phase_record.phase_dof+i, j] = cons_jac_tmp[i, num_statevars+j]
+            phase_matrix[j, compset.phase_record.phase_dof+i] = cons_jac_tmp[i, num_statevars+j]
 
     for cons_idx in range(fixed_phase_dof_indices.shape[0]):
         fixed_dof_idx = fixed_phase_dof_indices[cons_idx]

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -837,7 +837,6 @@ cpdef find_solution(list compsets, int num_statevars, int num_components,
     iterations_since_last_phase_change = 0
     step_size = 1.0
     for iteration in range(1000):
-        print(iteration, iterations_since_last_phase_change)
         state.iteration = iteration
         if (state.mass_residual > 10) and (np.any(np.abs(state.chemical_potentials) > 1.0e10)):
             state.chemical_potentials[:] = spec.initial_chemical_potentials

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -740,7 +740,8 @@ cdef void prune_phases(SystemSpecification spec, SystemState state):
             if np.all(compset_distances < 1e-4):
                 compsets_to_remove.add(idx2)
                 if idx not in spec.fixed_stable_compset_indices:
-                    state.phase_amt[idx] += state.phase_amt[idx2]
+                    # ensure that the consolidated phase is stable
+                    state.phase_amt[idx] = max(state.phase_amt[idx] + state.phase_amt[idx2], 1e-8)
                 state.phase_amt[idx2] = 0
     new_free_stable_compset_indices = np.array(sorted(set(state.free_stable_compset_indices) - set(compsets_to_remove)), dtype=np.int32)
     if len(new_free_stable_compset_indices) == 0:

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -596,9 +596,8 @@ cpdef take_step(SystemSpecification spec, SystemState state, double step_size):
     cdef double largest_internal_cons_max_residual = 0
     cdef double largest_internal_dof_change = 0
     cdef double internal_cons_max_residual, minimum_step_size
-    cdef double[::1] cons_tmp
     cdef double[::1,:] equilibrium_matrix  # Fortran ordering required by call into lapack
-    cdef double[::1] equilibrium_rhs, equilibrium_soln, old_chemical_potentials, new_y, x
+    cdef double[::1] equilibrium_soln, old_chemical_potentials, new_y, x
     cdef CompositionSet compset
     cdef CompsetState csst
     cdef bint exceeded_bounds

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -443,6 +443,7 @@ cdef class SystemState:
 
     def __init__(self, SystemSpecification spec, list compsets):
         cdef CompositionSet compset
+        cdef int idx, comp_idx
         self.compsets = compsets
         self.cs_states = [CompsetState(spec, compset) for compset in compsets]
         self.dof = [np.array(compset.dof) for compset in compsets]
@@ -468,9 +469,9 @@ cdef class SystemState:
         self._phase_energies_per_mole_atoms = np.zeros((len(compsets), 1))
         self._phase_amounts_per_mole_atoms = np.zeros((len(compsets), spec.num_components, 1))
 
+        cdef double[:, ::1] masses_tmp = np.zeros((spec.num_components, 1))
         for idx in range(self.phase_amt.shape[0]):
             compset = self.compsets[idx]
-            masses_tmp = np.zeros((spec.num_components, 1))
             x = self.dof[idx]
             for comp_idx in range(spec.num_components):
                 compset.phase_record.formulamole_obj(masses_tmp[comp_idx, :], x, comp_idx)

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -617,9 +617,10 @@ cpdef take_step(SystemSpecification spec, SystemState state, double step_size):
         state.chemical_potentials[comp_idx] = spec.initial_chemical_potentials[comp_idx]
 
     # Update phase internal degrees of freedom
-    for idx, compset in enumerate(state.compsets):
+    for idx in range(len(state.compsets)):
         # TODO: Use better dof storage
         x = state.dof[idx]
+        compset = state.compsets[idx]
         csst = state.cs_states[idx]
 
         # Construct delta_y from Eq. 43 in Sundman 2015

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -716,9 +716,9 @@ cdef bint remove_and_consolidate_phases(SystemSpecification spec, SystemState st
 
 cdef bint change_phases(SystemSpecification spec, SystemState state, int[::1] metastable_phase_iterations, int[::1] times_compset_removed):
     cdef int idx
+    cdef double[::1] driving_forces = state.driving_forces()
     phase_amt = state.phase_amt
     current_free_stable_compset_indices = state.free_stable_compset_indices
-    driving_forces = state.driving_forces()
     compsets_to_remove = set(current_free_stable_compset_indices).intersection(set(np.nonzero(np.array(phase_amt) < 1e-9)[0]))
     # Only add phases with positive driving force which have been metastable for at least 5 iterations, which have been removed fewer than 4 times
     newly_metastable_compsets = set(np.nonzero((np.array(metastable_phase_iterations) < 5))[0]) - \

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -703,7 +703,7 @@ cpdef take_step(SystemSpecification spec, SystemState state, double step_size):
         # We need real state variable bounds support
 
 
-cdef void prune_phases(SystemSpecification spec, SystemState state):
+cdef void remove_and_consolidate_phases(SystemSpecification spec, SystemState state):
     """Remove phases that have become unstable (phase amount <= 0) and consolidate composition sets in an artificial misicbility gap.
 
     Updates the state in place.
@@ -854,7 +854,7 @@ cpdef find_solution(list compsets, int num_statevars, int num_components,
                 if state.phase_amt[j] < 0:
                     state.phase_amt[j] = 1e-8
 
-        prune_phases(spec, state) # Consolidate duplicate phases and remove unstable phases
+        remove_and_consolidate_phases(spec, state)
 
         # Only include chemical potential difference if chemical potential conditions were enabled
         # XXX: This really should be a condition defined in terms of delta_m, because chempot_diff is only necessary

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -681,7 +681,7 @@ cdef void remove_and_consolidate_phases(SystemSpecification spec, SystemState st
             compset2 = state.compsets[idx2]
             if idx == idx2:
                 continue
-            if idx2 in spec.fixed_stable_compset_indices:
+            if compset2.fixed:
                 continue
             if compset.phase_record.phase_name != compset2.phase_record.phase_name:
                 continue

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -806,9 +806,13 @@ cpdef find_solution(list compsets, int num_statevars, int num_components,
 
         take_step(spec, state, step_size)
 
-        largest_chemical_potential_difference = 0
+        # In most cases, the chemical potentials should be decreasing and the
+        # largest_chemical_potential_difference could be negative. The following check
+        # against the differences will only prevent phases from being removed if the
+        # chemical potentials _increase_ by more than 1 J. It may make more sense to
+        # adjust the condition based on the absolute value of the differences.
+        largest_chemical_potential_difference = -np.inf
         for comp_idx in range(num_components):
-            # TODO: this was the equivalent change from chempot_diff, but maybe this should be abs()?
             largest_chemical_potential_difference = max(largest_chemical_potential_difference, state.chemical_potentials[comp_idx] - previous_chemical_potentials[comp_idx])
 
         if ((state.mass_residual > 1e-2) and (largest_chemical_potential_difference > 1.0)) or (iteration == 0):

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -559,13 +559,15 @@ cdef class SystemState:
         cdef double[::1] x
         cdef int num_components = self.chemical_potentials.shape[0]
         # This needs to be done per mole of atoms, not per formula unit, since we compare phases to each other
+        self._driving_forces[:] = 0
         for idx in range(len(self.compsets)):
             compset = self.compsets[idx]
             x = self.dof[idx]
             for comp_idx in range(num_components):
                 compset.phase_record.mass_obj(self._phase_amounts_per_mole_atoms[idx, comp_idx, :], x, comp_idx)
+                self._driving_forces[idx] += self.chemical_potentials[comp_idx] * self._phase_amounts_per_mole_atoms[idx, comp_idx, 0]
             compset.phase_record.obj(self._phase_energies_per_mole_atoms[idx, :], x)
-            self._driving_forces[idx] = np.dot(self.chemical_potentials, self._phase_amounts_per_mole_atoms[idx, :, 0]) - self._phase_energies_per_mole_atoms[idx, 0]
+            self._driving_forces[idx] -= self._phase_energies_per_mole_atoms[idx, 0]
         return self._driving_forces
 
 

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -625,7 +625,6 @@ cpdef take_step(SystemSpecification spec, SystemState state, double step_size):
     for idx in range(len(state.compsets)):
         # TODO: Use better dof storage
         x = state.dof[idx]
-        compset = state.compsets[idx]
         csst = state.cs_states[idx]
 
         # Construct delta_y from Eq. 43 in Sundman 2015

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -760,7 +760,7 @@ cpdef find_solution(list compsets, int num_statevars, int num_components,
 
         take_step(spec, state, step_size)
         delta_phase_amt = np.asarray(state.phase_amt) - np.asarray(previous_phase_amt)
-        if ((state.mass_residual > 1e-2) and (not np.all(np.asarray(state.chempot_diff) < 1.0))) or (iteration == 0):
+        if ((state.mass_residual > 1e-2) and (np.any(np.asarray(state.chempot_diff) > 1.0))) or (iteration == 0):
             # When mass residual is not satisfied, do not allow phases to leave the system
             # However, if the chemical potentials are changing very little, phases may leave the system
             for j in range(state.phase_amt.shape[0]):

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -695,8 +695,8 @@ cdef void remove_and_consolidate_phases(SystemSpecification spec, SystemState st
         if state.phase_amt[idx] < 1e-10:
             compsets_to_remove.add(idx)
             continue
-        for idx2 in range(len(state.compsets)):  # TODO: used to be compsets instead of state.compsets, is this valid?
-            compset2 = state.compsets[idx2]  # TODO: used to be compsets instead of state.compsets, is this valid?
+        for idx2 in range(len(state.compsets)):
+            compset2 = state.compsets[idx2]
             if idx == idx2:
                 continue
             if idx2 in spec.fixed_stable_compset_indices:

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -367,7 +367,6 @@ cdef class CompsetState:
     cdef int[::1] fixed_phase_dof_indices
     cdef int[::1] ipiv
     cdef double[:, ::1] cons_jac_tmp
-    cdef double[:,:, ::1] mass_hess_tmp
 
     def __init__(self, SystemSpecification spec, CompositionSet compset):
         self.x = np.zeros(spec.num_statevars + compset.phase_record.phase_dof)
@@ -392,9 +391,6 @@ cdef class CompsetState:
         self.ipiv = np.empty(self.phase_matrix.shape[0], dtype=np.int32)
         self.delta_y = np.zeros(compset.phase_record.phase_dof)
         self.cons_jac_tmp = np.zeros((compset.phase_record.num_internal_cons, spec.num_statevars + compset.phase_record.phase_dof))
-        self.mass_hess_tmp = np.zeros((spec.num_components,
-                                       spec.num_statevars + compset.phase_record.phase_dof,
-                                       spec.num_statevars + compset.phase_record.phase_dof))
 
     def __getstate__(self):
         return (np.array(self.x), self.energy, np.array(self.grad), np.array(self.hess),

--- a/pycalphad/plot/binary/map.py
+++ b/pycalphad/plot/binary/map.py
@@ -59,7 +59,7 @@ def map_binary(dbf, comps, phases, conds, eq_kwargs=None, calc_kwargs=None,
     if v.N not in conds:
         conds[v.N] = [1.0]
     if 'pdens' not in calc_kwargs:
-        calc_kwargs['pdens'] = 2000
+        calc_kwargs['pdens'] = 50
 
     species = unpack_components(dbf, comps)
     phases = filter_phases(dbf, species, phases)


### PR DESCRIPTION
I have noticed in benchmarking that roughly 1/3 of the time in the solver is spent performing this copy operation on the `state`. We don't do anything meaningful with the old state except for using its data, so I propose to remove it and replace the couple instances with explicitly storing the relevant variables before taking a step.

If we want to do more advanced things with the previous state(s) later, that's definitely something we could do, but I think all the memory allocations in one of the innermost loops is probably not worth it compared to copying the values we need out.

This change could probably use a more real benchmark to justify it, but I wanted to get it posted for feedback before I invest much more time into it.