### PR TITLE
ENH: Allow passing dictionaries of PhaseRecord objects to equilibrium and calculate

### DIFF
--- a/pycalphad/codegen/callables.py
+++ b/pycalphad/codegen/callables.py
@@ -146,7 +146,7 @@ def build_callables(dbf, comps, phases, models, parameter_symbols=None,
     return {output: _callables}
 
 
-def build_phase_records(dbf, comps, phases, conds, models, output='GM',
+def build_phase_records(dbf, comps, phases, state_variables, models, output='GM',
                         callables=None, parameters=None, verbose=False,
                         build_gradients=True, build_hessians=True
                         ):
@@ -161,10 +161,10 @@ def build_phase_records(dbf, comps, phases, conds, models, output='GM',
         List of active pure elements or species.
     phases : list
         List of phase names
-    conds : dict or None
-        Conditions for calculation
-    models : dict
-        Dictionary of {'phase_name': Model()}
+    state_variables : Iterable[v.StateVariable]
+        State variables used to produce the generated functions.
+    models : Mapping[str, Model]
+        Mapping of phase names to model instances
     parameters : dict, optional
         Maps SymPy Symbol to numbers, for overriding the values of parameters in the Database.
     callables : dict, optional
@@ -204,7 +204,7 @@ def build_phase_records(dbf, comps, phases, conds, models, output='GM',
         'internal_cons_hess': {},
     }
     phase_records = {}
-    state_variables = sorted(get_state_variables(models=models, conds=conds), key=str)
+    state_variables = sorted(get_state_variables(models=models, conds=state_variables), key=str)
     param_symbols, param_values = extract_parameters(parameters)
 
     if callables.get(output) is None:

--- a/pycalphad/codegen/callables.py
+++ b/pycalphad/codegen/callables.py
@@ -157,8 +157,8 @@ def build_phase_records(dbf, comps, phases, conds, models, output='GM',
     ----------
     dbf : Database
         A Database object
-    comps : List[v.Species]
-        List of active species
+    comps : List[Union[str, v.Species]]
+        List of active pure elements or species.
     phases : list
         List of phase names
     conds : dict or None
@@ -195,6 +195,7 @@ def build_phase_records(dbf, comps, phases, conds, models, output='GM',
     build the constraints and phase records.
 
     """
+    comps = sorted(unpack_components(dbf, comps))
     parameters = parameters if parameters is not None else {}
     callables = callables if callables is not None else {}
     _constraints = {

--- a/pycalphad/codegen/callables.py
+++ b/pycalphad/codegen/callables.py
@@ -148,7 +148,7 @@ def build_callables(dbf, comps, phases, models, parameter_symbols=None,
 
 def build_phase_records(dbf, comps, phases, conds, models, output='GM',
                         callables=None, parameters=None, verbose=False,
-                        build_gradients=False, build_hessians=False
+                        build_gradients=True, build_hessians=True
                         ):
     """
     Combine compiled callables and callables from conditions into PhaseRecords.

--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -5,6 +5,7 @@ property surface of a system.
 
 import itertools
 from collections import OrderedDict
+from collections.abc import Mapping
 import numpy as np
 from numpy import broadcast_to
 import pycalphad.variables as v
@@ -12,6 +13,7 @@ from pycalphad import ConditionError
 from pycalphad.codegen.callables import build_phase_records
 from pycalphad.core.cache import cacheit
 from pycalphad.core.light_dataset import LightDataset
+from pycalphad.model import Model
 from pycalphad.core.phase_rec import PhaseRecord
 from pycalphad.core.utils import endmember_matrix, extract_parameters, \
     filter_phases, instantiate_models, point_sample, \
@@ -268,8 +270,9 @@ def calculate(dbf, comps, phases, mode=None, output='GM', fake_points=False, bro
         Maps SymPy Symbol to numbers, for overriding the values of parameters in the Database.
     phase_records : Optional[Mapping[str, PhaseRecord]]
         Mapping of phase names to PhaseRecord objects. Must include all active phases.
-        Callers must take care that the PhaseRecord objects were created with the same
-        `output` as passed to `calculate`.
+        The `model` argument must be a mapping of phase names to instances of Model
+        objects. Callers must take care that the PhaseRecord objects were created with
+        the same `output` as passed to `calculate`.
 
     Returns
     -------
@@ -286,6 +289,7 @@ def calculate(dbf, comps, phases, mode=None, output='GM', fake_points=False, bro
     callables = kwargs.pop('callables', {})
     sampler_dict = unpack_kwarg(kwargs.pop('sampler', None), default_arg=None)
     fixedgrid_dict = unpack_kwarg(kwargs.pop('grid_points', True), default_arg=True)
+    model = kwargs.pop('model', None)
     parameters = parameters or dict()
     if isinstance(parameters, dict):
         parameters = OrderedDict(sorted(parameters.items(), key=str))
@@ -309,8 +313,6 @@ def calculate(dbf, comps, phases, mode=None, output='GM', fake_points=False, bro
     if len(active_phases) == 0:
         raise ConditionError('None of the passed phases ({0}) are active. List of possible phases: {1}.'.format(phases, list_of_possible_phases))
 
-    models = instantiate_models(dbf, comps, active_phases, model=kwargs.pop('model', None), parameters=parameters)
-
     if isinstance(output, (list, tuple, set)):
         raise NotImplementedError('Only one property can be specified in calculate() at a time')
     output = output if output is not None else 'GM'
@@ -331,15 +333,23 @@ def calculate(dbf, comps, phases, mode=None, output='GM', fake_points=False, bro
 
     # Build phase records if they weren't passed
     if phase_records is None:
+        models = instantiate_models(dbf, comps, active_phases, model=model, parameters=parameters)
         phase_records = build_phase_records(dbf, comps, active_phases, statevar_dict,
                                             models=models, parameters=parameters,
                                             output=output, callables=callables,
                                             build_gradients=False, build_hessians=False,
                                             verbose=kwargs.pop('verbose', False))
     else:
-        active_phases_without_phase_records = set(active_phases).difference(set(phase_records.keys()))
+        # phase_records were provided, instantiated models must also be provided by the caller
+        models = model
+        if not isinstance(models, Mapping):
+            raise ValueError("A dictionary of instantiated models must be passed to `equilibrium` with the `model` argument if the `phase_records` argument is used.")
+        active_phases_without_models = [name for name in active_phases if not isinstance(models.get(name), Model)]
+        active_phases_without_phase_records = [name for name in active_phases if not isinstance(phase_records.get(name), PhaseRecord)]
         if len(active_phases_without_phase_records) > 0:
-            raise ValueError(f"phase_records must contain a PhaseRecord object for every active phase. Missing PhaseRecord objects for {sorted(active_phases_without_phase_records)}")
+            raise ValueError(f"phase_records must contain a PhaseRecord instance for every active phase. Missing PhaseRecord objects for {sorted(active_phases_without_phase_records)}")
+        if len(active_phases_without_models) > 0:
+            raise ValueError(f"model must contain a Model instance for every active phase. Missing Model objects for {sorted(active_phases_without_models)}")
 
     maximum_internal_dof = max(len(models[phase_name].site_fractions) for phase_name in active_phases)
     for phase_name in sorted(active_phases):

--- a/pycalphad/core/equilibrium.py
+++ b/pycalphad/core/equilibrium.py
@@ -3,6 +3,9 @@ The equilibrium module defines routines for interacting with
 calculated phase equilibria.
 """
 import warnings
+from collections import OrderedDict
+from collections.abc import Mapping
+from datetime import datetime
 import pycalphad.variables as v
 from pycalphad.core.utils import unpack_components, unpack_condition, unpack_phases, filter_phases, instantiate_models, get_state_variables
 from pycalphad import calculate
@@ -10,11 +13,11 @@ from pycalphad.core.errors import EquilibriumError, ConditionError
 from pycalphad.core.starting_point import starting_point
 from pycalphad.codegen.callables import build_phase_records
 from pycalphad.core.eqsolver import _solve_eq_at_conditions
+from pycalphad.core.phase_rec import PhaseRecord
 from pycalphad.core.solver import Solver
 from pycalphad.core.light_dataset import LightDataset
+from pycalphad.model import Model
 import numpy as np
-from collections import OrderedDict
-from datetime import datetime
 
 
 def _adjust_conditions(conds):
@@ -182,7 +185,8 @@ def equilibrium(dbf, comps, phases, conditions, output=None, model=None,
         Pre-computed callable functions for equilibrium calculation.
     phase_records : Optional[Mapping[str, PhaseRecord]]
         Mapping of phase names to PhaseRecord objects with `'GM'` output. Must include
-        all active phases.
+        all active phases. The `model` argument must be a mapping of phase names to
+        instances of Model objects.
 
     Returns
     -------
@@ -212,7 +216,6 @@ def equilibrium(dbf, comps, phases, conditions, output=None, model=None,
     parameters = parameters if parameters is not None else dict()
     if isinstance(parameters, dict):
         parameters = OrderedDict(sorted(parameters.items(), key=str))
-    models = instantiate_models(dbf, comps, active_phases, model=model, parameters=parameters)
     # Temporary solution until constraint system improves
     if conditions.get(v.N) is None:
         conditions[v.N] = 1
@@ -225,7 +228,6 @@ def equilibrium(dbf, comps, phases, conditions, output=None, model=None,
     for cond in conds.keys():
         if isinstance(cond, (v.MoleFraction, v.ChemicalPotential)) and cond.species not in comps:
             raise ConditionError('{} refers to non-existent component'.format(cond))
-    state_variables = sorted(get_state_variables(models=models, conds=conds), key=str)
     str_conds = OrderedDict((str(key), value) for key, value in conds.items())
     components = [x for x in sorted(comps)]
     desired_active_pure_elements = [list(x.constituents.keys()) for x in components]
@@ -240,17 +242,27 @@ def equilibrium(dbf, comps, phases, conditions, output=None, model=None,
     output |= {'GM'}
     output = sorted(output)
     if phase_records is None:
+        models = instantiate_models(dbf, comps, active_phases, model=model, parameters=parameters)
         phase_records = build_phase_records(dbf, comps, active_phases, conds, models,
                                             output='GM', callables=callables,
                                             parameters=parameters, verbose=verbose,
                                             build_gradients=True, build_hessians=True)
     else:
-        active_phases_without_phase_records = set(active_phases).difference(set(phase_records.keys()))
+        # phase_records were provided, instantiated models must also be provided by the caller
+        models = model
+        if not isinstance(models, Mapping):
+            raise ValueError("A dictionary of instantiated models must be passed to `equilibrium` with the `model` argument if the `phase_records` argument is used.")
+        active_phases_without_models = [name for name in active_phases if not isinstance(models.get(name), Model)]
+        active_phases_without_phase_records = [name for name in active_phases if not isinstance(phase_records.get(name), PhaseRecord)]
         if len(active_phases_without_phase_records) > 0:
-            raise ValueError(f"phase_records must contain a PhaseRecord object for every active phase. Missing PhaseRecord objects for {sorted(active_phases_without_phase_records)}")
+            raise ValueError(f"phase_records must contain a PhaseRecord instance for every active phase. Missing PhaseRecord objects for {sorted(active_phases_without_phase_records)}")
+        if len(active_phases_without_models) > 0:
+            raise ValueError(f"model must contain a Model instance for every active phase. Missing Model objects for {sorted(active_phases_without_models)}")
 
     if verbose:
         print('[done]', end='\n')
+
+    state_variables = sorted(get_state_variables(models=models, conds=conds), key=str)
 
     # 'calculate' accepts conditions through its keyword arguments
     grid_opts = calc_opts.copy()

--- a/pycalphad/core/utils.py
+++ b/pycalphad/core/utils.py
@@ -431,8 +431,8 @@ def get_state_variables(models=None, conds=None):
     ----------
     models : dict, optional
         Dictionary mapping phase names to instances of Model objects
-    conds : dict, optional
-        Dictionary mapping pycalphad StateVariables to values
+    conds : Iterable[v.StateVariable]
+        An iterable of StateVariables or a dictionary mapping pycalphad StateVariables to values
 
     Returns
     -------
@@ -451,7 +451,7 @@ def get_state_variables(models=None, conds=None):
         for mod in models.values():
             state_vars.update(mod.state_variables)
     if conds is not None:
-        for c in conds.keys():
+        for c in conds:
             # StateVariable instances are ok (e.g. P, T, N, V, S),
             # however, subclasses (X, Y, MU, NP) are not ok.
             if type(c) is v.StateVariable:

--- a/pycalphad/tests/test_calculate.py
+++ b/pycalphad/tests/test_calculate.py
@@ -118,7 +118,7 @@ def test_missing_phase_records_passed_to_calculate_raises():
 
     models = instantiate_models(ALFE_DBF, comps, subset_phases)
     # Dummy conditions are just needed to get all the state variables into the PhaseRecord objects
-    phase_records = build_phase_records(ALFE_DBF, comps, subset_phases, {v.N: None, v.P: None, v.T: None}, models)
+    phase_records = build_phase_records(ALFE_DBF, comps, subset_phases, [v.T, v.P, v.N], models)
 
     with pytest.raises(ValueError):
         calculate(ALFE_DBF, comps, my_phases, T=1200, P=101325, N=1, phase_records=phase_records)

--- a/pycalphad/tests/test_codegen.py
+++ b/pycalphad/tests/test_codegen.py
@@ -61,7 +61,7 @@ def test_phase_records_are_picklable():
     dof = np.array([300, 1.0])
 
     mod = Model(ALNIPT_DBF, ['AL'], 'LIQUID')
-    prxs = build_phase_records(ALNIPT_DBF, [v.Species('AL')], ['LIQUID'], {v.T: 300}, {'LIQUID': mod}, build_gradients=True, build_hessians=True)
+    prxs = build_phase_records(ALNIPT_DBF, [v.Species('AL')], ['LIQUID'], [v.T], {'LIQUID': mod}, build_gradients=True, build_hessians=True)
     prx_liquid = prxs['LIQUID']
 
     out = np.array([0.0])

--- a/pycalphad/tests/test_equilibrium.py
+++ b/pycalphad/tests/test_equilibrium.py
@@ -10,9 +10,9 @@ from sympy import Symbol
 from numpy.testing import assert_allclose
 import numpy as np
 from pycalphad import Database, Model, calculate, equilibrium, EquilibriumError, ConditionError
-from pycalphad.codegen.callables import build_callables
+from pycalphad.codegen.callables import build_callables, build_phase_records
 from pycalphad.core.solver import SolverBase, Solver
-from pycalphad.core.utils import get_state_variables
+from pycalphad.core.utils import get_state_variables, instantiate_models
 import pycalphad.variables as v
 from pycalphad.tests.datasets import *
 
@@ -52,6 +52,39 @@ def test_eq_binary():
     conds = {v.T: 1400, v.P: 101325, v.X('AL'): 0.55}
     eqx = equilibrium(ALFE_DBF, comps, my_phases, conds, verbose=True)
     assert_allclose(eqx.GM.values.flat[0], -9.608807e4)
+
+
+def test_phase_records_passed_to_equilibrium():
+    "Pre-built phase records can be passed to equilibrium."
+    my_phases = ['LIQUID', 'FCC_A1', 'HCP_A3', 'AL5FE2', 'AL2FE', 'AL13FE4', 'AL5FE4']
+    comps = ['AL', 'FE', 'VA']
+    conds = {v.T: 1400, v.P: 101325, v.N: 1.0, v.X('AL'): 0.55}
+
+    models = instantiate_models(ALFE_DBF, comps, my_phases)
+    phase_records = build_phase_records(ALFE_DBF, comps, my_phases, conds, models)
+
+    # Without models passed
+    eqx = equilibrium(ALFE_DBF, comps, my_phases, conds, verbose=True, phase_records=phase_records)
+    assert_allclose(eqx.GM.values.flat[0], -9.608807e4)
+
+    # With models passed
+    eqx = equilibrium(ALFE_DBF, comps, my_phases, conds, verbose=True, model=models, phase_records=phase_records)
+    assert_allclose(eqx.GM.values.flat[0], -9.608807e4)
+
+
+def test_missing_phase_records_passed_to_equilibrium_raises():
+    "equilibrium should raise an error if all the active phases are not included in the phase_records"
+    my_phases = ['LIQUID', 'FCC_A1']
+    subset_phases = ['FCC_A1']
+    comps = ['AL', 'FE', 'VA']
+    conds = {v.T: 1400, v.P: 101325, v.N: 1.0, v.X('AL'): 0.55}
+
+    models = instantiate_models(ALFE_DBF, comps, subset_phases)
+    phase_records = build_phase_records(ALFE_DBF, comps, subset_phases, conds, models)
+
+    with pytest.raises(ValueError):
+        equilibrium(ALFE_DBF, comps, my_phases, conds, verbose=True, phase_records=phase_records)
+
 
 @pytest.mark.solver
 def test_eq_single_phase():

--- a/pycalphad/tests/test_equilibrium.py
+++ b/pycalphad/tests/test_equilibrium.py
@@ -63,13 +63,23 @@ def test_phase_records_passed_to_equilibrium():
     models = instantiate_models(ALFE_DBF, comps, my_phases)
     phase_records = build_phase_records(ALFE_DBF, comps, my_phases, conds, models)
 
-    # Without models passed
-    eqx = equilibrium(ALFE_DBF, comps, my_phases, conds, verbose=True, phase_records=phase_records)
-    assert_allclose(eqx.GM.values.flat[0], -9.608807e4)
-
     # With models passed
     eqx = equilibrium(ALFE_DBF, comps, my_phases, conds, verbose=True, model=models, phase_records=phase_records)
     assert_allclose(eqx.GM.values.flat[0], -9.608807e4)
+
+
+def test_missing_models_with_phase_records_passed_to_equilibrium_raises():
+    "equilibrium should raise an error if all the active phases are not included in the phase_records"
+    my_phases = ['LIQUID', 'FCC_A1', 'HCP_A3', 'AL5FE2', 'AL2FE', 'AL13FE4', 'AL5FE4']
+    comps = ['AL', 'FE', 'VA']
+    conds = {v.T: 1400, v.P: 101325, v.N: 1.0, v.X('AL'): 0.55}
+
+    models = instantiate_models(ALFE_DBF, comps, my_phases)
+    phase_records = build_phase_records(ALFE_DBF, comps, my_phases, conds, models)
+
+    with pytest.raises(ValueError):
+        # model=models NOT passed
+        equilibrium(ALFE_DBF, comps, my_phases, conds, verbose=True, phase_records=phase_records)
 
 
 def test_missing_phase_records_passed_to_equilibrium_raises():
@@ -79,11 +89,19 @@ def test_missing_phase_records_passed_to_equilibrium_raises():
     comps = ['AL', 'FE', 'VA']
     conds = {v.T: 1400, v.P: 101325, v.N: 1.0, v.X('AL'): 0.55}
 
-    models = instantiate_models(ALFE_DBF, comps, subset_phases)
-    phase_records = build_phase_records(ALFE_DBF, comps, subset_phases, conds, models)
+    models = instantiate_models(ALFE_DBF, comps, my_phases)
+    phase_records = build_phase_records(ALFE_DBF, comps, my_phases, conds, models)
 
+    models_subset = instantiate_models(ALFE_DBF, comps, subset_phases)
+    phase_records_subset = build_phase_records(ALFE_DBF, comps, subset_phases, conds, models_subset)
+
+    # Under-specified models
     with pytest.raises(ValueError):
-        equilibrium(ALFE_DBF, comps, my_phases, conds, verbose=True, phase_records=phase_records)
+        equilibrium(ALFE_DBF, comps, my_phases, conds, verbose=True, model=models_subset, phase_records=phase_records)
+
+    # Under-specified phase_records
+    with pytest.raises(ValueError):
+        equilibrium(ALFE_DBF, comps, my_phases, conds, verbose=True, model=models, phase_records=phase_records_subset)
 
 
 @pytest.mark.solver


### PR DESCRIPTION
Changes:

- `build_phase_records`
  - Defaults to build derivatives of the output. This is the more common case and SymEngine makes the compilation fast enough that's it's not as much of a burden to build them by default.
  - The `comps` argument now accepts string components or `Species` objects via `unpack_components`. Before this change, only `Species` objects were allowed.
- `calculate` and `equilibrium`
  - Accept the `phase_records` keyword argument 
  - The `callables` keyword argument is used if the phase records are constructed. If the `phase_records` argument is supplied by the caller, the `callables` argument is ignored.
  - `equilibrium` passes `phase_records` down to `calculate` instead of rebuilding them in `calculate`
  - Both functions check that all the active phases have entries in `phase_records` and raise an error if not. We currently don't check that the `output` is correct at all
- This approach is relatively simple, but one gap is that there's no mechanism to pass `phase_records` in to `equilibrium` that get re-used by `_eqcalculate`. `calculate` will always build `phase_records` when called from `_eqcalculate` (the `callables` can still be passed down for now).