### PR TITLE
FIX: Database parsing fails if some tokens are not uppercase

### DIFF
--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -929,7 +929,7 @@ def read_tdb(dbf, fd):
     fd : file-like
         File descriptor.
     """
-    lines = fd.read()
+    lines = fd.read().upper()
     lines = lines.replace('\t', ' ')
     lines = lines.strip()
     # Split the string by newlines

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -678,3 +678,10 @@ def test_tdb_parser_raises_unterminated_parameters():
     """
     with pytest.raises(ParseException):
         Database(UNTERMINATED_PARAM_STR)
+
+def test_load_database_when_given_in_lowercase():
+    "Test loading a database coerced to lowercase loads correctly."
+    dbf = Database.from_string(ALFE_TDB, fmt='tdb')
+    dbf_lower = Database.from_string(ALFE_TDB.lower(), fmt='tdb')
+
+    assert dbf == dbf_lower


### PR DESCRIPTION
Updated the database string to always be parsed to uppercase. Also passed the test cases mentioned in the issue #359