### PR TITLE
FIX: Improved custom state variable support

### DIFF
--- a/pycalphad/codegen/callables.py
+++ b/pycalphad/codegen/callables.py
@@ -90,7 +90,7 @@ def build_callables(dbf, comps, phases, models, parameter_symbols=None,
 
     state_variables = get_state_variables(models=models)
     state_variables |= additional_statevars
-    if state_variables != {v.T, v.P, v.N}:
+    if not {v.T, v.P, v.N}.issubset(state_variables):
         warnings.warn("State variables in `build_callables` are not {{N, P, T}}, but {}. This can lead to incorrectly "
                       "calculated values if the state variables used to call the generated functions do not match the "
                       "state variables used to create them. State variables can be added with the "

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -315,8 +315,10 @@ cdef void extract_equilibrium_solution(double[::1] chemical_potentials, double[:
     for i in range(free_statevar_indices.shape[0]):
         statevar_idx = free_statevar_indices[i]
         delta_statevars[statevar_idx] = equilibrium_soln[soln_index_offset + i]
-    for i in range(delta_statevars.shape[0]):
-        psc = abs(delta_statevars[i] / dof[0][i])
+        if dof[0][statevar_idx] == 0:
+            psc = np.inf
+        else:
+            psc = abs(delta_statevars[statevar_idx] / dof[0][statevar_idx])
         largest_statevar_change[0] = max(largest_statevar_change[0], psc)
 
 

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -316,7 +316,10 @@ cdef void extract_equilibrium_solution(double[::1] chemical_potentials, double[:
         statevar_idx = free_statevar_indices[i]
         delta_statevars[statevar_idx] = equilibrium_soln[soln_index_offset + i]
     for i in range(delta_statevars.shape[0]):
-        psc = abs(delta_statevars[i] / dof[0][i])
+        if dof[0][i] != 0:
+            psc = abs(delta_statevars[i] / dof[0][i])
+        else:
+            psc = abs(delta_statevars[i])
         largest_statevar_change[0] = max(largest_statevar_change[0], psc)
 
 

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -316,10 +316,7 @@ cdef void extract_equilibrium_solution(double[::1] chemical_potentials, double[:
         statevar_idx = free_statevar_indices[i]
         delta_statevars[statevar_idx] = equilibrium_soln[soln_index_offset + i]
     for i in range(delta_statevars.shape[0]):
-        if dof[0][i] != 0:
-            psc = abs(delta_statevars[i] / dof[0][i])
-        else:
-            psc = abs(delta_statevars[i])
+        psc = abs(delta_statevars[i] / dof[0][i])
         largest_statevar_change[0] = max(largest_statevar_change[0], psc)
 
 


### PR DESCRIPTION
This PR makes two small improvements to better support the use of custom state variable objects.

One change silences a callables warning that would occur every time a custom state variable was used; this has been improved to only warn when expected state variables are _missing_. The other change relaxes an implicit assumption / bug that state variables would never be equal to zero (when calculating a percent change in value); now we detect this case and switch to an absolute difference.