### PR TITLE
ENH: Minimizer: refactor and convergence improvements

### DIFF
--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -841,16 +841,15 @@ cpdef find_solution(list compsets, int num_statevars, int num_components,
                 if state.phase_amt[j] < 0:
                     state.phase_amt[j] = 1e-8
 
-        remove_and_consolidate_phases(spec, state)
+        phases_changed = remove_and_consolidate_phases(spec, state)
 
         solution_is_feasible = (
             (state.largest_phase_amt_change[0] < ALLOWED_DELTA_PHASE_AMT) and
             (state.largest_y_change[0] < ALLOWED_DELTA_Y) and
             (state.largest_statevar_change[0] < ALLOWED_DELTA_STATEVAR)
         )
-        phases_changed = False
         if solution_is_feasible and (iterations_since_last_phase_change >= 5):
-            phases_changed = change_phases(spec, state, metastable_phase_iterations, times_compset_removed)
+            phases_changed = phases_changed or change_phases(spec, state, metastable_phase_iterations, times_compset_removed)
             if phases_changed:
                 iterations_since_last_phase_change = 0
             else:
@@ -873,4 +872,5 @@ cpdef find_solution(list compsets, int num_statevars, int num_components,
     for cs_dof in state.dof[1:]:
         x = np.r_[x, cs_dof[num_statevars:]]
     x = np.r_[x, phase_amt]
+    print(f'iteration {iteration}')
     return converged, x, np.array(state.chemical_potentials)

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -801,7 +801,7 @@ cpdef find_solution(list compsets, int num_statevars, int num_components,
     cdef SystemState state = SystemState(spec, compsets)
 
     # convergence criteria
-    cdef double ALLOWED_DELTA_Y = 1e-10
+    cdef double ALLOWED_DELTA_Y = 1e-12
     cdef double ALLOWED_DELTA_PHASE_AMT = 1e-10
     cdef double ALLOWED_DELTA_STATEVAR = 1e-5  # changes defined as percent change
 

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -872,5 +872,4 @@ cpdef find_solution(list compsets, int num_statevars, int num_components,
     for cs_dof in state.dof[1:]:
         x = np.r_[x, cs_dof[num_statevars:]]
     x = np.r_[x, phase_amt]
-    print(f'iteration {iteration}')
     return converged, x, np.array(state.chemical_potentials)

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -588,7 +588,7 @@ cpdef solve_state(SystemSpecification spec, SystemState state):
     return equilibrium_soln
 
 
-# TODO: pass this in from the solution or store it in the state(?)
+# TODO: should we store equilibrium_soln in the state(?)
 cpdef advance_state(SystemSpecification spec, SystemState state, double[::1] equilibrium_soln, double step_size):
     cdef bint exceeded_bounds
     cdef double minimum_step_size, phase_amt_change, psc

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -801,7 +801,7 @@ cpdef find_solution(list compsets, int num_statevars, int num_components,
     cdef SystemState state = SystemState(spec, compsets)
 
     # convergence criteria
-    cdef double ALLOWED_DELTA_Y = 1e-12
+    cdef double ALLOWED_DELTA_Y = 1e-10
     cdef double ALLOWED_DELTA_PHASE_AMT = 1e-10
     cdef double ALLOWED_DELTA_STATEVAR = 1e-5  # changes defined as percent change
 

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -843,15 +843,6 @@ cpdef find_solution(list compsets, int num_statevars, int num_components,
 
         remove_and_consolidate_phases(spec, state)
 
-        # Only include chemical potential difference if chemical potential conditions were enabled
-        # XXX: This really should be a condition defined in terms of delta_m, because chempot_diff is only necessary
-        # because mass_residual is no longer driving convergence for partially/fully open systems
-        if spec.fixed_chemical_potential_indices.shape[0] > 0:
-            chempot_diff = np.max(np.abs(np.array(state.chemical_potentials)/np.array(previous_chemical_potentials) - 1))
-        else:
-            chempot_diff = 0.0
-        # Wait for mass balance to be satisfied before changing phases
-        # Phases that "want" to be removed will keep having their phase_amt set to zero, so mass balance is unaffected
         solution_is_feasible = (
             (state.largest_phase_amt_change[0] < ALLOWED_DELTA_PHASE_AMT) and
             (state.largest_y_change[0] < ALLOWED_DELTA_Y) and


### PR DESCRIPTION
This PR contains 3 changes to the minimizer:

1. The `take_step` function is replaced with two functions to solve the equilibrium matrix and extract the chemical potentials (`solve_state`) and to take the step with the corrections in the phase amounts, state variables, and site fractions (`advance_state`). The `extract_equilibrium_solution` function is also now a part of `advance_state`. This refactor keeps the logic for advancing the state separate and contained in one function. 
2. The convergence criterion has been changed to converge based on changes in phase amounts, state variables, and site fractions, instead of depending on mass residual and/or chemical potential changes. The rationale being that if the phase amounts, state variables, and site fractions aren’t changing, the other quantities that could be convergence criteria are guaranteed to not be changing. 
3. Steps in phase amounts are now scaled such that no phase amount can ever become negative. This change helps convergence by preventing phases having negative amount, then being removed, which messes up the mass balance. If a phase amount can never become negative, the moles in the system will not change if phases with zero amounts are not removed. Scaling in phase amounts is valid, because the phase energies are always in agreement with the chemical potentials. 

These changes (particularly the third change) helps convergence as demonstrated here:


```python
from pycalphad import Database, equilibrium, variables as v
from pycalphad.plot.utils import phase_legend
import matplotlib.pyplot as plt
import numpy as np

db = Database('scratch/mc_ni_v2.034.pycalphad.tdb')
phases = ['FCC_A1','GAMMA_PRIME', 'LIQUID']
components = ['AL', 'CO', 'CR', 'MO', 'NB', 'NI', 'TI', 'W','VA']
conditions = {v.X('AL'): 0.073, v.X('CO'): 0.077, v.X('CR'): 0.151,
               v.X('MO'): 0.021, v.X('NB'): 0.022, v.X('TI'): 0.030, v.X('W'): 0.011}
conditions[v.T] = (1550, 1650, 1) # Kelvin
conditions[v.P] = 1e5 # Pa
conditions[v.N] = 1
eq = equilibrium(db, components, phases, conditions)

phases = sorted(set(eq.Phase.values.flatten()) - {''})
phase_handles, phasemap = phase_legend(phases)

plt.gca().set_title('Phase fractions vs T')
plt.gca().set_xlabel('Temperature (K)')
plt.gca().set_ylabel('Phase Fraction')
plt.gca().set_ylim((0,1.1))
plt.gca().set_xlim((1550, 1650))

for name in phases:
    plt.scatter(eq.T.broadcast_like(eq.NP), eq.NP.where(eq.Phase == name), color=phasemap[name])
plt.gca().legend(phase_handles, phases, loc='upper left')
plt.savefig('NP.png')


plt.figure()
plt.gca().scatter(eq.T.broadcast_like(eq.GM), eq.GM)
plt.gca().set_title('Gibbs energy')
plt.gca().set_xlabel('Temperature (K)')
plt.gca().set_ylabel('Gibbs energy')
plt.gca().set_ylim(-120000, -107000)
plt.savefig('GM.png')
```

Thanks to @james-saal for sharing the motivating example on our Gitter channel!

#### Develop

![NP-develop](https://user-images.githubusercontent.com/7681751/132933694-7072360d-fe63-40fb-98b8-04ced52b0932.png)


![GM-develop](https://user-images.githubusercontent.com/7681751/132933684-6542d428-ab97-4c74-aea2-d0d2a37e4a0e.png)



#### this PR (e57eb04)

![NP-solve-advance](https://user-images.githubusercontent.com/7681751/132933691-ad1cd9e0-d9b4-4d23-8ad4-9bb79306860e.png)

![GM-solve-advance](https://user-images.githubusercontent.com/7681751/132933688-90967e1e-55a6-4f2f-9284-67342f13693e.png)

Also note that if I run this same script using `phases = list(db.phases.keys())`, then `develop` has a bunch of output lines containing `** On entry to DORMBRP parameter number 13 had an illegal value`, finally ending with `terminated by signal SIGSEGV (Address boundary error)` (catastrophic failure). It works well on this PR.


