### PR TITLE
MAINT/BLD: Remove Cython as a runtime requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
         # conda-forge Anaconda channel. For example, conda-forge/symengine
         # gives the C++ SymEngine library, while conda-forge/python-symengine
         # provides the Python package called `symengine`.
-        'Cython>=0.24',
         'importlib_metadata',  # drop when pycalphad drops support for Python<3.8
         'matplotlib>=3.3',
         'numpy>=1.13',


### PR DESCRIPTION
Cython is not a runtime requirement and can be removed. It should stay in `pyproject.toml` and `requirements-dev.txt` since it is required at build time.

Hopefully `requirements-dev.txt` can be removed after https://github.com/pypa/setuptools/issues/2816 is complete and `pip install -e .` is PEP 517-compatible (i.e. PEP 660).

Checklist

* [x] If any dependencies have changed, the changes are reflected in the
  * [x] `setup.py` (runtime requirements)
  * [x] `pyproject.toml` (build requirements)
  * [x] `requirements-dev.txt` (build and development requirements)
