### PR TITLE
FIX: TCPrinter: Special-case printing for exponential function

### DIFF
--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -462,7 +462,7 @@ class TCPrinter(object):
         elif isinstance(expr, Mul):
             terms = self._stringify_expr(expr.args[0])
             for arg in expr.args[1:]:
-                terms += '*' + self._stringify_expr(arg)
+                terms += ' * ' + self._stringify_expr(arg)
             return terms
         elif isinstance(expr, Pow):
             if expr.args[0] == E:

--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -10,7 +10,7 @@ from pyparsing import delimitedList, ParseException
 import re
 from symengine.lib.symengine_wrapper import UniversalSet, Union, Complement
 from symengine import sympify, And, Or, Not, EmptySet, Interval, Piecewise, Add, Mul, Pow
-from symengine import Symbol, LessThan, StrictLessThan, S
+from symengine import Symbol, LessThan, StrictLessThan, S, E
 from pycalphad import Database
 from pycalphad.io.database import DatabaseExportError
 from pycalphad.io.grammar import float_number, chemical_formula
@@ -465,14 +465,14 @@ class TCPrinter(object):
                 terms += '*' + self._stringify_expr(arg)
             return terms
         elif isinstance(expr, Pow):
-            if int(expr.args[1]) != float(expr.args[1]):
-                raise ValueError('Exponent must be integer to be TDB compatible')
-            exponent = int(expr.args[1])
-            if exponent < 0:
-                exponent = '('+str(exponent)+')'
+            if expr.args[0] == E:
+                # This is the exponential function
+                terms = 'exp(' + self._stringify_expr(expr.args[1]) + ')'
             else:
-                exponent = str(exponent)
-            terms = self._stringify_expr(expr.args[0]) + '**' + exponent
+                argument = self._stringify_expr(expr.args[0])
+                if isinstance(expr.args[0], (Add, Mul)):
+                    argument = '( ' + argument + ' )'
+                terms = argument + '**' + '(' + self._stringify_expr(expr.args[1]) + ')'
             return terms
         else:
             return str(expr)

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -818,3 +818,9 @@ def test_tc_printer_no_division_symbols():
     test_expr = Piecewise((S('VV0000/T + T*VV0004 + T**2*VV0001 + T**3*VV0002 + T*LOG(T)*VV0003'), v.T>0))
     result = TCPrinter().doprint(test_expr)
     assert '/' not in result
+
+def test_tc_printer_exp():
+    "TCPrinter prints the exponential function when the argument is not an integer."
+    test_expr = S('exp(-300T**(-1))')
+    result = TCPrinter()._stringify_expr(test_expr)
+    assert result == 'exp(-300*T**(-1))'

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -823,4 +823,4 @@ def test_tc_printer_exp():
     "TCPrinter prints the exponential function when the argument is not an integer."
     test_expr = S('exp(-300T**(-1))')
     result = TCPrinter()._stringify_expr(test_expr)
-    assert result == 'exp(-300*T**(-1))'
+    assert result == 'exp(-300 * T**(-1))'


### PR DESCRIPTION
Fixes gh-399.

- TCPrinter: Remove check for non-integer exponent of power operator, which is probably unnecessary
- TCPrinter: Special-case printing of exponential function, which is represented as `e**x` in SymEngine

This was a regression from gh-376. This PR includes a test for the fixed behavior.