### PR TITLE
BUG: Changes to the ChemSage DAT parser to be more consistent with the TDB parser

### DIFF
--- a/pycalphad/io/cs_dat.py
+++ b/pycalphad/io/cs_dat.py
@@ -123,6 +123,10 @@ class IntervalBase:
         raise NotImplementedError("Subclasses of IntervalBase must define an expression for the energy")
 
     def cond(self, T_min=298.15):
+        if T_min == self.T_max:
+            # To avoid an impossible, always False condition an open interval
+            # is assumed. We choose 10000 K as the dummy (as in TDBs).
+            return And((T_min <= v.T), (v.T < 10000))
         return And((T_min <= v.T), (v.T < self.T_max))
 
     def expr_cond_pair(self, *args, T_min=298.15, **kwargs):

--- a/pycalphad/io/cs_dat.py
+++ b/pycalphad/io/cs_dat.py
@@ -232,7 +232,7 @@ class EndmemberMagnetic(Endmember):
         super().insert(dbf, phase_name, pure_elements, gibbs_coefficient_idxs)
 
         # also add magnetic parameters
-        dbf.add_parameter('BMAG', phase_name, self.constituent_array(),
+        dbf.add_parameter('BMAGN', phase_name, self.constituent_array(),
                           0, self.magnetic_moment, force_insert=False)
         dbf.add_parameter('TC', phase_name, self.constituent_array(),
                           0, self.curie_temperature, force_insert=False)
@@ -369,7 +369,7 @@ class ExcessRKMMagnetic(ExcessBase):
         # See the comment about sorting in ExcessRKM
         const_array = self.constituent_array(phase_constituents)
         dbf.add_parameter('TC', phase_name, const_array, self.parameter_order, self.curie_temperature, force_insert=False)
-        dbf.add_parameter('BMAG', phase_name, const_array, self.parameter_order, self.magnetic_moment, force_insert=False)
+        dbf.add_parameter('BMAGN', phase_name, const_array, self.parameter_order, self.magnetic_moment, force_insert=False)
 
 
 @dataclass

--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -422,9 +422,9 @@ def to_interval(relational):
         return Interval(S.NegativeInfinity, S.Infinity, left_open=True, right_open=True)
 
     if len(relational.free_symbols) != 1:
-        raise ValueError('Relational must only have one free symbol')
+        raise ValueError(f'Relational must only have one free symbol. Got {len(relational.free_symbols)} ({relational.free_symbols}) for relational {relational}')
     if len(relational.args) != 2:
-        raise ValueError('Relational must only have two arguments')
+        raise ValueError(f'Relational must only have two arguments. Got {len(relational.args)} ({relational.args}) for relational {relational}')
     free_symbol = list(relational.free_symbols)[0]
     lhs = relational.args[0]
     rhs = relational.args[1]


### PR DESCRIPTION
- Floating point Gibbs energy exponents (for fixed T/P terms) for read-write equality comparison support
- Use Database.add_structure_entry
- Use phase "BLANK" instead of None (needs a string for type stability) and "BLANK" is consistent with how pycalphad treats TDBs
- Use a global default minimum temperature for piecewise intervals of 0.01 K, in agreement with how we handle TDBs
- Some DAT files have two temperature intervals in a row with the same upper limit. I am interpreting that as an implication that the function should extrapolate beyond that point, so we choose a default upper limit of 10000 K, in agreement with TDBs
- Fix a bug in magnetic parameters: `BMAG` should have been `BMAGN`.
- Improve error messages for `pycalphad.io.tdb.to_interval` that users may find more helpful when debugging.