### PR TITLE
ENH: Compatibility fixes for pyodide

### DIFF
--- a/pycalphad/codegen/sympydiff_utils.py
+++ b/pycalphad/codegen/sympydiff_utils.py
@@ -29,13 +29,16 @@ functions or PhaseRecords. The following issues track this behavior:
 """
 from pycalphad.core.cache import cacheit
 from pycalphad.core.utils import wrap_symbol
-from symengine import sympify, lambdify, zoo, oo
+from symengine import sympify, lambdify, zoo, oo, have_llvm
 from collections import namedtuple
 
 BuildFunctionsResult = namedtuple('BuildFunctionsResult', ['func', 'grad', 'hess'])
 ConstraintFunctions = namedtuple('ConstraintFunctions', ['cons_func', 'cons_jac', 'cons_hess'])
 
-LAMBDIFY_DEFAULT_BACKEND = 'llvm'
+if have_llvm:
+    LAMBDIFY_DEFAULT_BACKEND = 'llvm'
+else:
+    LAMBDIFY_DEFAULT_BACKEND = 'lambda'
 LAMBDIFY_DEFAULT_CSE = True
 LAMBDIFY_DEFAULT_LLVM_OPT_LEVEL = 0
 

--- a/pycalphad/core/lower_convex_hull.py
+++ b/pycalphad/core/lower_convex_hull.py
@@ -41,11 +41,11 @@ def lower_convex_hull(global_grid, state_variables, result_array):
     comp_conds = sorted([x for x in sorted(result_array.coords.keys()) if x.startswith('X_')])
     comp_conds_indices = sorted([idx for idx, x in enumerate(sorted(result_array.coords['component']))
                                  if 'X_'+x in comp_conds])
-    comp_conds_indices = np.array(comp_conds_indices, dtype=np.uint64)
+    comp_conds_indices = np.array(comp_conds_indices, dtype=np.uintp)
     pot_conds = sorted([x for x in sorted(result_array.coords.keys()) if x.startswith('MU_')])
     pot_conds_indices = sorted([idx for idx, x in enumerate(sorted(result_array.coords['component']))
                                 if 'MU_'+x in pot_conds])
-    pot_conds_indices = np.array(pot_conds_indices, dtype=np.uint64)
+    pot_conds_indices = np.array(pot_conds_indices, dtype=np.uintp)
 
     if len(set(pot_conds_indices) & set(comp_conds_indices)) > 0:
         raise ValueError('Cannot specify component chemical potential and amount simultaneously')


### PR DESCRIPTION
These are some small fixes which enable compatibility with the WebAssembly-based [pyodide](https://pyodide.org/en/stable/ ) Python distribution. The changes here will only affect environments where (a) SymEngine is compiled without LLVM support (like Pyodide); or (b) the platform is 32-bit.

All officially supported platforms for pycalphad have been 64-bit for a while, so both of these changes are backward compatible. In addition, they are also forward compatible if LLVM support for SymEngine in pyodide is enabled, or (unlikely in the short term) pyodide adds wasm64 support.