### PR TITLE
ENH: minimizer performance improvements

### DIFF
--- a/pycalphad/core/minimizer.pxd
+++ b/pycalphad/core/minimizer.pxd
@@ -23,6 +23,7 @@ cdef class SystemState:
 cdef class SystemSpecification:
     cdef int num_statevars, num_components, max_num_free_stable_phases
     cdef double prescribed_system_amount
+    cdef double ALLOWED_MASS_RESIDUAL
     cdef double[::1] initial_chemical_potentials, prescribed_elemental_amounts
     cdef int[::1] prescribed_element_indices
     cdef int[::1] free_chemical_potential_indices, free_statevar_indices


### PR DESCRIPTION
Profiling-guided removal of (relatively) expensive NumPy calls


With a couple ternary benchmark systems, I'm seeing a consistent 2x speedup in the `run_loop` time and almost all the profiled code that drops back into Python (from Cython) is gone.

Summary of changes:

1. Don't recompute ALLOWED_MASS_RESIDUAL on the hot loop. We can compute it in the initializer if we assume the prescribed elemental amounts is constant
2. Replace `np.sum` with manually computed phase composition sums in SystemState initializer and recompute()
3. Replace `np.all` call in consolidation check for remove_and_consolidate_phases
4. Replace `np.take`, `np.nonzero`, `np.argsort` with loopy equivalents (this is less of a speedup, but we probably just hit this code path less in the benchmark and in practice)

The intent was to preserve exactly the current functionality and just be pure performance improvements (any differences detected in review are not intentional).


## Benchmarks

### ebcfbdb4 (develop)

![bm-2022-07-18-ebcfbdb4-Cr-Ti-V-profile](https://user-images.githubusercontent.com/7681751/179636042-3a7ba351-6e84-4077-8a63-90ff28c416ab.png)


### b3668f40
![bm-2022-07-18-b3668f40-Cr-Ti-V-profile](https://user-images.githubusercontent.com/7681751/179636045-a2be94ae-13ca-429c-9485-a633b7b226e9.png)

