### PR TITLE
ENH: Molar volume

### DIFF
--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -1419,17 +1419,17 @@ class Model(object):
         V_mag = G_mag.diff(v.P)
 
         self.MV = self.molar_volume = V_p0 + V_mag
-        self.volume_energy = S.Zero
+        volume_energy = S.Zero
 
         if VK == 0:
-            self.volume_energy = V_p0*(v.P-101325)
+            volume_energy = V_p0*(v.P-101325)
         else:
             warnings.warn(
                     f"The database for \"{self.phase_name}\" contains a term for the isothermal compressibility"
                     f"however the pressure dependence has not been fully incorporated into the molar volume or"
                     f"Gibbs free energy models. THE GIBBS ENERGY AND MOLAR VOLUME CALCULATIONS MAY BE INCORRECT.")
 
-        return self.volume_energy
+        return volume_energy
 
 
 class TestModel(Model):

--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -1416,8 +1416,7 @@ class Model(object):
 
         # magnetic contribution to volume
         G_mag = self.models.get('mag')
-        tau_curie = v.T/self.TC
-        V_mag = G_mag.diff(tau_curie)*tau_curie.diff(v.P)
+        V_mag = G_mag.diff(v.P)
 
         self.MV = self.molar_volume = V_p0 + V_mag
         self.volume_energy = S.Zero

--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -1426,7 +1426,7 @@ class Model(object):
         else:
             warnings.warn(
                     f"The database for \"{self.phase_name}\" contains a term for the isothermal compressibility"
-                    f"however the pressure dependence has not been incorporated into the molar volume or"
+                    f"however the pressure dependence has not been fully incorporated into the molar volume or"
                     f"Gibbs free energy models. THE GIBBS ENERGY AND MOLAR VOLUME CALCULATIONS MAY BE INCORRECT.")
 
         return self.volume_energy

--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -152,7 +152,7 @@ class Model(object):
     contributions = [('ref', 'reference_energy'), ('idmix', 'ideal_mixing_energy'),
                      ('xsmix', 'excess_mixing_energy'), ('mag', 'magnetic_energy'),
                      ('2st', 'twostate_energy'), ('ein', 'einstein_energy'),
-                     ('ord', 'atomic_ordering_energy')]
+                     ('vol', 'volume_energy'), ('ord', 'atomic_ordering_energy')]
 
     def __new__(cls, *args, **kwargs):
         target_cls = cls._dispatch_on(*args, **kwargs)
@@ -1358,6 +1358,79 @@ class Model(object):
             reference_contrib = Add(*terms)
             referenced_value = getattr(self, out) - reference_contrib
             setattr(self, fmt_str.format(out), referenced_value)
+    
+    def volume_energy(self, dbe):
+        """
+        Return the volumetric contribution in symbolic form. Follows the approach by Lu, Selleby, and Sundman [1].
+
+        Parameters
+        ----------
+        dbe : Database
+            Database containing the relevant parameters.
+        
+        Notes
+        -----
+        The high-pressure portion of the model is not currently implemented.
+        The parameters needed for it are queried from the database; however, calculations
+        are reserved for future implementation.
+
+        References
+        ----------
+        [1] Lu, Selleby, and Sundman, Calphad, Vol. 29, No. 1, 2005, doi:10.1016/j.calphad.2005.04.001.
+        """
+
+        phase = dbe.phases[self.phase_name]
+        param_search = dbe.search
+
+        V0_param_query = (
+            (where('phase_name') == phase.name) & \
+            (where('parameter_type') == 'V0') & \
+            (where('constituent_array').test(self._array_validity))
+        )
+
+        VA_param_query = (
+            (where('phase_name') == phase.name) & \
+            (where('parameter_type') == 'VA') & \
+            (where('constituent_array').test(self._array_validity))
+        )
+
+        VK_param_query = (
+            (where('phase_name') == phase.name) & \
+            (where('parameter_type') == 'VK') & \
+            (where('constituent_array').test(self._array_validity))
+        )
+
+        VC_param_query = (
+            (where('phase_name') == phase.name) & \
+            (where('parameter_type') == 'VC') & \
+            (where('constituent_array').test(self._array_validity))
+        )
+
+        V0 = self.redlich_kister_sum(phase, param_search, V0_param_query)
+        VA = self.redlich_kister_sum(phase, param_search, VA_param_query)
+        VK = self.redlich_kister_sum(phase, param_search, VK_param_query)
+        VC = self.redlich_kister_sum(phase, param_search, VC_param_query)
+
+        # nonmagnetic contribution to volume
+        V_p0 = V0*exp(VA)
+
+        # magnetic contribution to volume
+        G_mag = self.models.get('mag')
+        tau_curie = v.T/self.TC
+        V_mag = G_mag.diff(tau_curie)*tau_curie.diff(v.P)
+
+        self.MV = self.molar_volume = V_p0 + V_mag
+        self.volume_energy = S.Zero
+
+        if VK == 0:
+            self.volume_energy = V_p0*(v.P-101325)
+        else:
+            warnings.warn(
+                    f"The database for \"{self.phase_name}\" contains a term for the isothermal compressibility"
+                    f"however the pressure dependence has not been incorporated into the molar volume or"
+                    f"Gibbs free energy models. THE GIBBS ENERGY AND MOLAR VOLUME CALCULATIONS MAY BE INCORRECT.")
+
+        return self.volume_energy
 
 
 class TestModel(Model):

--- a/pycalphad/tests/test_calculate.py
+++ b/pycalphad/tests/test_calculate.py
@@ -285,10 +285,13 @@ def test_volume_energy():
     """
 
     db = Database(TDB)
-    energy = 1e-6*np.exp(1e-6*300)*(10e9-101325)
-    result = calculate(db, ['FE'], 'BCC_A2', T=300, P=10E9, N=1, output='volume_energy')
+    energy_hp = 1e-6*np.exp(1e-6*300)*(10e9-101325)
+    
+    result_atm = calculate(db, ['FE'], 'BCC_A2', T=300, P=101325, N=1)
+    result_hp = calculate(db, ['FE'], 'BCC_A2', T=300, P=10E9, N=1)
+    vol_energy_contrib = np.squeeze(result_hp['GM']).values - np.squeeze(result_atm['GM']).values
 
-    assert np.allclose(np.squeeze(result['volume_energy']).values, energy)
+    assert np.allclose(vol_energy_contrib, energy_hp)
 
 
 def test_magnetic_volume_contribution():


### PR DESCRIPTION
This PR is a partial implementation of the molar volume model from [Lu, Selleby, and Sundman (2005)](https://doi.org/10.1016/j.calphad.2005.04.001). It includes the nonmagnetic thermal expansion, magnetic contribution to molar volume, and the contribution to the Gibbs free energy in cases where the molar volume is independent of pressure. Tests for these terms are also included. There are no required changes to the dependencies of pycalphad. This PR is inclusive of PR #423.

The pressure dependence of the molar volume can be implemented in the future via VC and VK parameters and Equations 9, 10, and 12 of the reference paper. It will require the exponential integral to be implemented into symengine.