### PR TITLE
FIX: ignoring IF/THEN statements in TYPE_DEFINITION keywords

### DIFF
--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -283,6 +283,10 @@ def _process_typedef(targetdb, typechar, line):
     tokens = line.replace(',', '').split()
     if len(tokens) < 4:
         return
+    #Don't process IF-THEN type definitions for now
+    if 'IF' in tokens or 'THEN' in tokens:
+        warnings.warn("Type definitions using IF/THEN logic is not supported")
+        return
     keyword = expand_keyword(['DISORDERED_PART', 'MAGNETIC'], tokens[3].upper())[0]
     if len(keyword) == 0:
         raise ValueError('Unknown type definition keyword: {}'.format(tokens[3]))


### PR DESCRIPTION
In ThermoCalc, the IF/THEN keywords in the TYPE_DEFINITION provides a way to run commands during database loading based off the elements selected. This typically is used for adding a composition set to help with miscibility gap detection or rejecting/restoring phases (though adding composition sets seems more common). Pycalphad detects miscibility gaps based off the sampling strategy and the rejecting/restoring phases may reduce transparency of the database to the users.

In pycalphad, the tdb parser assumes that the TYPE_DEFINITION command is used for disordered or magnetic contributions, in which the parser can fail if the command is not one of those two. This pull request will ignore any TYPE_DEFINITION that has an IF/THEN keyword and give a warning that parsing these keywords is currently not supported. This will allow for users to load tdb files that may contain the IF/THEN keywords without having to worry about fixing the tdb file and will also allow for the same tdb file to be used between pycalphad and ThermoCalc if a user(s) decides to do so.
