### PR TITLE
FIX: misleading __repr__ for Species(None) and Species('*')

### DIFF
--- a/pycalphad/variables.py
+++ b/pycalphad/variables.py
@@ -93,9 +93,9 @@ class Species(object):
 
     def __repr__(self):
         if self.name == '*':
-            return '*'
+            return str(self.__class__.__name__)+'(\'*\')'
         if self.name == '':
-            return 'None'
+            return str(self.__class__.__name__)+"(None)"
         species_constituents = ''.join(
             ['{}{}'.format(el, val) for el, val in sorted(self.constituents.items(), key=lambda t: t[0])])
         if self.charge == 0:


### PR DESCRIPTION
The [README](https://github.com/pycalphad/pycalphad/tree/d4dd6c91e4215c0dc84bc2e89af00cd92210a708#readme) states "Unsolicited pull requests are _happily_ accepted!"

Here's an unsolicited pull request that fixes issue #319 

```python
>>> import pycalphad.variables as v
>>> repr(v.Species(None))
'Species(None)'
>>> repr(v.Species('*'))
"Species('*')"
```