### PR TITLE
MAINT/FIX: Relax version pin for symengine

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         'pytest-cov',
         'scipy',
         'setuptools_scm[toml]>=6.0',
-        'symengine==0.9.2',  # python-symengine on conda-forge
+        'symengine>=0.11.0',  # python-symengine on conda-forge
         'tinydb>=3.8',
         'xarray>=0.11.2',
     ],

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         'pytest-cov',
         'scipy',
         'setuptools_scm[toml]>=6.0',
-        'symengine>=0.11.0',  # python-symengine on conda-forge
+        'symengine>=0.9.2',  # python-symengine on conda-forge
         'tinydb>=3.8',
         'xarray>=0.11.2',
     ],


### PR DESCRIPTION
Relaxes the symengine version pin so that future symengine releases also satisfy the dependency requirement. SymEngine release cadence has increased and we're also seeing fewer regressions, so I think it's safe and advisable for pycalphad to relax the hard pin. Also, this will fix #497.

<!--

Thank you for pull request.

Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.

-->


Checklist
* [x] If any dependencies have changed, the changes are reflected in the
  * [x] `setup.py` (runtime requirements)
  * [x] `pyproject.toml` (build requirements)
  * [x] `requirements-dev.txt` (build and development requirements)
