### PR TITLE
FIX: Molar volume model fixes

### DIFF
--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -1411,7 +1411,7 @@ class Model(object):
             reference_contrib = Add(*terms)
             referenced_value = getattr(self, out) - reference_contrib
             setattr(self, fmt_str.format(out), referenced_value)
-    
+
     def volume_energy(self, dbe):
         """
         Return the volumetric contribution in symbolic form. Follows the approach by Lu, Selleby, and Sundman [1].
@@ -1420,7 +1420,7 @@ class Model(object):
         ----------
         dbe : Database
             Database containing the relevant parameters.
-        
+
         Notes
         -----
         The high-pressure portion of the model is not currently implemented.
@@ -1459,10 +1459,10 @@ class Model(object):
             (where('constituent_array').test(self._array_validity))
         )
 
-        V0 = self.redlich_kister_sum(phase, param_search, V0_param_query)
-        VA = self.redlich_kister_sum(phase, param_search, VA_param_query)
-        VK = self.redlich_kister_sum(phase, param_search, VK_param_query)
-        VC = self.redlich_kister_sum(phase, param_search, VC_param_query)
+        self.V0 = V0 = self.redlich_kister_sum(phase, param_search, V0_param_query) / self._site_ratio_normalization
+        self.VA = VA = self.redlich_kister_sum(phase, param_search, VA_param_query) / self._site_ratio_normalization
+        self.VK = VK = self.redlich_kister_sum(phase, param_search, VK_param_query) / self._site_ratio_normalization
+        self.VC = VC = self.redlich_kister_sum(phase, param_search, VC_param_query) / self._site_ratio_normalization
 
         # nonmagnetic contribution to volume
         V_p0 = V0*exp(VA)
@@ -1471,7 +1471,7 @@ class Model(object):
         G_mag = self.models.get('mag')
         V_mag = G_mag.diff(v.P)
 
-        self.MV = self.molar_volume = V_p0 + V_mag
+        self.VM = self.molar_volume = V_p0 + V_mag
         volume_energy = S.Zero
 
         if VK == 0:

--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -1460,12 +1460,12 @@ class Model(object):
         )
 
         # V0 is given in databases per mole of formula, so we should normalize it
-        self.V0 = V0 = self.redlich_kister_sum(phase, param_search, V0_param_query) / self._site_ratio_normalization
+        self.V0 = V0 = self.symbol_replace(self.redlich_kister_sum(phase, param_search, V0_param_query) / self._site_ratio_normalization, self._symbols)
         # VA is given in databases per mole of atoms, so we should not normalize it
-        self.VA = VA = self.redlich_kister_sum(phase, param_search, VA_param_query)
+        self.VA = VA = self.symbol_replace(self.redlich_kister_sum(phase, param_search, VA_param_query), self._symbols)
         # TODO: unsure about the normalization of VK and VC parameters
-        self.VK = VK = self.redlich_kister_sum(phase, param_search, VK_param_query)
-        self.VC = VC = self.redlich_kister_sum(phase, param_search, VC_param_query)
+        self.VK = VK = self.symbol_replace(self.redlich_kister_sum(phase, param_search, VK_param_query), self._symbols)
+        self.VC = VC = self.symbol_replace(self.redlich_kister_sum(phase, param_search, VC_param_query), self._symbols)
 
         # nonmagnetic contribution to volume
         V_p0 = V0*exp(VA)

--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -1459,10 +1459,13 @@ class Model(object):
             (where('constituent_array').test(self._array_validity))
         )
 
+        # V0 is given in databases per mole of formula, so we should normalize it
         self.V0 = V0 = self.redlich_kister_sum(phase, param_search, V0_param_query) / self._site_ratio_normalization
-        self.VA = VA = self.redlich_kister_sum(phase, param_search, VA_param_query) / self._site_ratio_normalization
-        self.VK = VK = self.redlich_kister_sum(phase, param_search, VK_param_query) / self._site_ratio_normalization
-        self.VC = VC = self.redlich_kister_sum(phase, param_search, VC_param_query) / self._site_ratio_normalization
+        # VA is given in databases per mole of atoms, so we should not normalize it
+        self.VA = VA = self.redlich_kister_sum(phase, param_search, VA_param_query)
+        # TODO: unsure about the normalization of VK and VC parameters
+        self.VK = VK = self.redlich_kister_sum(phase, param_search, VK_param_query)
+        self.VC = VC = self.redlich_kister_sum(phase, param_search, VC_param_query)
 
         # nonmagnetic contribution to volume
         V_p0 = V0*exp(VA)


### PR DESCRIPTION
- Fix normalization of molar volume energy and properties to be per mole of atoms
- Set molar volume properties (`V0`, `VA`, `VK`, `VC`) as attributes of `Model`. Not sure about `VK` and `VC` parameter normalization, but for now I'm assuming they are the same normalization `VA` (parameters stored per mole of atoms, rather than the usual per mole of formula)
- Set the property name of molar volume to be `VM`, rather than `MV`, which is more consistent with commercial software and handling molar quantities
- Replace molar volume property expressions with symbols in the database. If we don't do this, any `FUNCTION` TDB keywords (which become symbols) get set to zero when computing in `calculate` or `equilibrium`