### PR TITLE
MAINT/BLD: Python CI support and docs build fixes 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 18
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 18
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,7 +64,7 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -77,7 +77,7 @@ language = None
 exclude_patterns = ['_build', '_autosummary']
 
 extlinks = {'issue': ('https://github.com/pycalphad/pycalphad/issues/%s',
-                      'issue ')}
+                      'issue %s')}
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/pycalphad/__init__.py
+++ b/pycalphad/__init__.py
@@ -25,12 +25,7 @@ try:
     __version__ = get_version(root='..', relative_to=__file__)
     del get_version
 except ImportError:
-    # Fall back on the metadata of the installed package
-    try:
-        from importlib.metadata import version
-    except ImportError:
-        # backport for Python<3.8
-        from importlib_metadata import version
+    from importlib.metadata import version
     __version__ = version("pycalphad")
     del version
 

--- a/pycalphad/__init__.py
+++ b/pycalphad/__init__.py
@@ -25,6 +25,7 @@ try:
     __version__ = get_version(root='..', relative_to=__file__)
     del get_version
 except ImportError:
+    # Fall back on the metadata of the installed package
     from importlib.metadata import version
     __version__ = version("pycalphad")
     del version

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ setuptools
 setuptools_scm[toml]>=6.0
 wheel
 # Development dependencies
-furo<=2021.10.09  # TODO: >2021.11.16 when available
+furo>=2021.11.16
 ipython  # for pygments syntax highlighting
 pytest-cov
 sphinx

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,8 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 
 )

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ setup(
         # gives the C++ SymEngine library, while conda-forge/python-symengine
         # provides the Python package called `symengine`.
         'Cython' if os.getenv('CYTHON_COVERAGE', False) else '', # required for Cython test coverage
-        'importlib_metadata',  # drop when pycalphad drops support for Python<3.8
         'importlib_resources',  # drop when pycalphad drops support for Python<3.9
         'matplotlib>=3.3',
         'numpy>=1.13',

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,6 @@ setup(
 
         # Supported Python versions
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
- Add support in CI for Python 3.12
- Drop support for Python 3.7 as it's EOL as of June 2023 https://devguide.python.org/versions/
- Drop a really old pin on furo because we can upgrade now (pin was forcing old sphinx versions to be installed, which is what was breaking our docs builds in CI)
- Fixes for new versions of sphix:
  1. Language is no longer allowed to be `None`, set to `'en'` which is the default
  2. Fix extlinks that requires a `%s` in the caption (added support for that in v4.0, removed support for deprecated way without the `%s` in v6.0 https://github.com/sphinx-doc/sphinx/pull/10471)