### PR TITLE
Fix float exponents when writing a TDB file (TC ERROR DatabaseUtils)

### DIFF
--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -486,7 +486,7 @@ class TCPrinter(object):
     def _print_Piecewise(self, expr):
         # Filter out default zeros since they are implicit in a TDB
         filtered_args = [(x, cond) for x, cond in zip(*[iter(expr.args)]*2) if not ((cond == S.true) and (x == S.Zero))]
-        exprs = [self._stringify_expr(x) for x, cond in filtered_args]
+        exprs = [re.sub(r'\*\*\(([+-]?[0-9]+)\.0\)', r'**(\1)', self._stringify_expr(x)) for x, cond in filtered_args]
         # Only a small subset of piecewise functions can be represented
         # Need to verify that each cond's highlim equals the next cond's lowlim
         # to_interval() is used because symengine does not implement as_set()


### PR DESCRIPTION
Hi, this is a small fix to '_print_Piecewise' function in the io.tdb module to improve compatibility with TC. I'm using this module to parse some of my tdbs and TC complains about float exponents (A constant integer must be used as the exponent in exponential TDB expressions). Thank you.

<!--

Thank you for pull request.

Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.

-->


Checklist
* [N/A] If any dependencies have changed, the changes are reflected in the
  * [N/A] `setup.py` (runtime requirements)
  * [N/A] `pyproject.toml` (build requirements)
  * [N/A] `requirements-dev.txt` (build and development requirements)
