### PR TITLE
BLD: deploy.yaml: PyPI trusted publisher support

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -63,6 +63,11 @@ jobs:
   upload_pypi:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pycalphad/
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     # upload to PyPI when a GitHub Release is created
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
@@ -73,9 +78,3 @@ jobs:
           merge-multiple: true  # download and extract all artifacts in the same directory
 
       - uses: pypa/gh-action-pypi-publish@v1.8.14
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_PYCALPHAD_TOKEN }}
-          # To test, uncomment the following:
-          # password: ${{ secrets.TEST_PYPI_PYCALPHAD_TOKEN }}
-          # repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -75,11 +75,11 @@ jobs:
           pattern: artifact-*
           path: dist
           merge-multiple: true  # download and extract all artifacts in the same directory
-      if: github.event_name == 'release' && github.event.action == 'published'
       - name: [PyPI] Upload artifacts to PyPI (Production)
         uses: pypa/gh-action-pypi-publish@v1.8.14
-      # if: github.event_name != 'release' && github.ref_name == 'develop'
+        if: github.event_name == 'release' && github.event.action == 'published'
       - name: [TestPyPI] Upload Artifacts
         uses: pypa/gh-action-pypi-publish@v1.8.14
+        # if: github.event_name != 'release' && github.ref_name == 'develop'
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -64,8 +64,10 @@ jobs:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     environment:
-      name: pypi
-      url: https://pypi.org/p/pycalphad/
+      - name: pypi
+        if: github.event_name == 'release' && github.event.action == 'published'
+      - name: testpypi
+        if: github.event_name == 'push' && github.ref_name == 'develop'
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     # upload to PyPI when a GitHub Release is created
@@ -80,6 +82,6 @@ jobs:
         if: github.event_name == 'release' && github.event.action == 'published'
       - name: TestPyPI - Upload Artifacts
         uses: pypa/gh-action-pypi-publish@v1.8.14
-        # if: github.event_name != 'release' && github.ref_name == 'develop'
+        if: github.event_name == 'push' && github.ref_name == 'develop'
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -63,11 +63,6 @@ jobs:
   upload_pypi:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    environment:
-      - name: pypi
-        if: github.event_name == 'release' && github.event.action == 'published'
-      - name: testpypi
-        if: github.event_name == 'push' && github.ref_name == 'develop'
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     # upload to PyPI when a GitHub Release is created

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -69,12 +69,17 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     # upload to PyPI when a GitHub Release is created
-    if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v4
         with:
           pattern: artifact-*
           path: dist
           merge-multiple: true  # download and extract all artifacts in the same directory
-
-      - uses: pypa/gh-action-pypi-publish@v1.8.14
+      if: github.event_name == 'release' && github.event.action == 'published'
+      - name: [PyPI] Upload artifacts to PyPI (Production)
+        uses: pypa/gh-action-pypi-publish@v1.8.14
+      # if: github.event_name != 'release' && github.ref_name == 'develop'
+      - name: [TestPyPI] Upload Artifacts
+        uses: pypa/gh-action-pypi-publish@v1.8.14
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -75,6 +75,7 @@ jobs:
           pattern: artifact-*
           path: dist
           merge-multiple: true  # download and extract all artifacts in the same directory
+
       - name: [PyPI] Upload artifacts to PyPI (Production)
         uses: pypa/gh-action-pypi-publish@v1.8.14
         if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -75,11 +75,10 @@ jobs:
           pattern: artifact-*
           path: dist
           merge-multiple: true  # download and extract all artifacts in the same directory
-
-      - name: [PyPI] Upload artifacts to PyPI (Production)
+      - name: PyPI - Upload Artifacts to PyPI (Production)
         uses: pypa/gh-action-pypi-publish@v1.8.14
         if: github.event_name == 'release' && github.event.action == 'published'
-      - name: [TestPyPI] Upload Artifacts
+      - name: TestPyPI - Upload Artifacts
         uses: pypa/gh-action-pypi-publish@v1.8.14
         # if: github.event_name != 'release' && github.ref_name == 'develop'
         with:


### PR DESCRIPTION
This PR adds support for [trusted publishing](https://docs.pypi.org/trusted-publishers/) on PyPI using GitHub Actions as an OpenID Connect provider. I have already performed the setup on the PyPI side to allow for this.

After this is merged, we can revoke the dedicated PyPI upload token for pycalphad and use GitHub Actions as our sole deployment tool. We already do this, but this will prevent a leaked token from being able to manipulate release artifacts out-of-band.