### PR TITLE
MAINT/BLD: NumPy 2.0 Support

### DIFF
--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -193,7 +193,7 @@ def _sample_phase_constitution(model, sampler, fixed_grid, pdens):
     # Issues with this appear to be platform-dependent
     points = points[~np.isnan(points).any(axis=-1)]
     # Ensure that points has the correct dimensions and dtype
-    points = np.atleast_2d(np.asarray(points, dtype=np.float_))
+    points = np.atleast_2d(np.asarray(points, dtype=np.float64))
     return points
 
 
@@ -285,12 +285,12 @@ def _compute_phase_values(components, statevar_dict,
         phase_output = broadcast_to(phase_output, points.shape[:-1])
     if isinstance(phase_compositions, (float, int)):
         phase_compositions = broadcast_to(phase_output, points.shape[:-1] + (len(pure_elements),))
-    phase_output = np.asarray(phase_output, dtype=np.float_)
+    phase_output = np.asarray(phase_output, dtype=np.float64)
     if parameter_array_length <= 1:
         phase_output.shape = points.shape[:-1]
     else:
         phase_output.shape = points.shape[:-1] + (parameter_array_length,)
-    phase_compositions = np.asarray(phase_compositions, dtype=np.float_)
+    phase_compositions = np.asarray(phase_compositions, dtype=np.float64)
     phase_compositions.shape = points.shape[:-1] + (len(pure_elements),)
     if fake_points:
         output_shape = points.shape[:-2] + (max_tieline_vertices,)

--- a/pycalphad/core/eqsolver.pyx
+++ b/pycalphad/core/eqsolver.pyx
@@ -187,7 +187,7 @@ def _solve_eq_at_conditions(properties, phase_records, grid, conds_keys, state_v
         converged = False
         changed_phases = False
         cur_conds = OrderedDict(zip(conds_keys,
-                                    [np.asarray(properties.coords[b][a], dtype=np.float_)
+                                    [np.asarray(properties.coords[b][a], dtype=np.float64)
                                      for a, b in zip(it.multi_index, conds_keys)]))
         # assume 'points' and other dimensions (internal dof, etc.) always follow
         curr_idx = [it.multi_index[i] for i, key in enumerate(conds_keys) if key in str_state_variables]

--- a/pycalphad/core/halton.py
+++ b/pycalphad/core/halton.py
@@ -108,8 +108,8 @@ def halton(dim, nbpts, primes=None, scramble=True):
                          'calculated when \'primes\' is only of length {1}. '
                          'Use the \'primes\' parameter to pass additional '
                          'primes.'.format(dim, len(primes)))
-    result = np.empty((nbpts, dim), dtype=np.float_)
-    dim_primes = np.asarray(primes[0:dim], dtype=np.float_)
+    result = np.empty((nbpts, dim), dtype=np.float64)
+    dim_primes = np.asarray(primes[0:dim], dtype=np.float64)
     for i in np.arange(dim_primes.size):
         num_powers = np.ceil(np.log(nbpts + 1) / np.log(dim_primes[i])).astype(np.int_)
         # need to be careful about precision errors here
@@ -117,7 +117,7 @@ def halton(dim, nbpts, primes=None, scramble=True):
         powers = np.power(dim_primes[i], -np.arange(1, num_powers+1, dtype=np.longdouble))
         radix_vector = np.power(dim_primes[i], -np.arange(num_powers, dtype=np.longdouble))
         # we can drop precision after the outer product for a speedup
-        sum_matrix = np.outer(np.arange(1, nbpts+1), radix_vector).astype(np.float_)
+        sum_matrix = np.outer(np.arange(1, nbpts+1), radix_vector).astype(np.float64)
         mod_matrix = np.mod(scrambler[dim_primes[i]] * np.floor(sum_matrix + 1e-15), dim_primes[i])
         result[:, i] = np.dot(mod_matrix, powers)
     return result

--- a/pycalphad/core/utils.py
+++ b/pycalphad/core/utils.py
@@ -88,9 +88,9 @@ def unpack_condition(tup):
         if len(tup) == 1:
             return [float(tup[0])]
         elif len(tup) == 2:
-            return np.arange(tup[0], tup[1], dtype=np.float_)
+            return np.arange(tup[0], tup[1], dtype=np.float64)
         elif len(tup) == 3:
-            return np.arange(tup[0], tup[1], tup[2], dtype=np.float_)
+            return np.arange(tup[0], tup[1], tup[2], dtype=np.float64)
         else:
             raise ValueError('Condition tuple is length {}'.format(len(tup)))
     elif isinstance(tup, Iterable):
@@ -147,7 +147,7 @@ def endmember_matrix(dof, vacancy_indices=None):
     >>> endmember_matrix([3,3,1], vacancy_indices=[[2], [2], [0]])
     """
     total_endmembers = functools.reduce(operator.mul, dof, 1)
-    res_matrix = np.empty((total_endmembers, sum(dof)), dtype=np.float_)
+    res_matrix = np.empty((total_endmembers, sum(dof)), dtype=np.float64)
     dof_arrays = [np.eye(d).tolist() for d in dof]
     row_idx = 0
     for row in itertools.product(*dof_arrays):

--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -1527,8 +1527,8 @@ class TestModel(Model):
         self.solution = dict(list(zip(variables, solution)))
         kmax = kmax if kmax is not None else 2
         scale_factor = 1e4 * len(self.components)
-        ampl_scale = 1e3 * np.ones(kmax, dtype=np.float_)
-        freq_scale = 10 * np.ones(kmax, dtype=np.float_)
+        ampl_scale = 1e3 * np.ones(kmax, dtype=np.float64)
+        freq_scale = 10 * np.ones(kmax, dtype=np.float64)
         polys = Add(*[ampl_scale[i] * sin(freq_scale[i] * Add(*[Add(*[(varname - sol)**(j+1)
                                                                       for varname, sol in self.solution.items()])
                                                                 for j in range(kmax)]))**2

--- a/pycalphad/tests/test_energy.py
+++ b/pycalphad/tests/test_energy.py
@@ -55,8 +55,8 @@ def calculate_output(model, variables, output, mode='sympy'):
 def check_output(model, variables, output, known_value, mode='sympy'):
     "Check that our calculated quantity matches the known value."
     desired = calculate_output(model, variables, output, mode)
-    known_value = np.array(known_value, dtype=np.complex_)
-    desired = np.array(desired, dtype=np.complex_)
+    known_value = np.array(known_value, dtype=np.complex128)
+    desired = np.array(desired, dtype=np.complex128)
     # atol defaults to zero here, but it cannot be zero if desired is zero
     # we set it to a reasonably small number for energies and derivatives (in Joules)
     # An example where expected = 0, but known != 0 is for ideal mix xlogx terms
@@ -479,7 +479,7 @@ def test_ionic_liquid_energy_anion_sublattice(load_database):
         v.Y('IONIC_LIQ', 1, v.Species('VA')): 1e-12,
         v.Y('IONIC_LIQ', 1, v.Species('S', {'S': 1.0})): 1e-12,
     }
-    out = np.array(mod.ast.subs({**potentials, **em_FE_Sneg2}).n(real=True), dtype=np.complex_)
+    out = np.array(mod.ast.subs({**potentials, **em_FE_Sneg2}).n(real=True), dtype=np.complex128)
     assert np.isclose(out, -148395.0, atol=0.1)
 
     em_FE_VA = {
@@ -488,7 +488,7 @@ def test_ionic_liquid_energy_anion_sublattice(load_database):
         v.Y('IONIC_LIQ', 1, v.Species('VA')): 1.0,
         v.Y('IONIC_LIQ', 1, v.Species('S', {'S': 1.0})): 1e-12,
     }
-    out = np.array(mod.ast.subs({**potentials, **em_FE_VA}).n(real=True), dtype=np.complex_)
+    out = np.array(mod.ast.subs({**potentials, **em_FE_VA}).n(real=True), dtype=np.complex128)
     assert np.isclose(out, -87735.077, atol=0.1)
 
     em_FE_S = {
@@ -497,7 +497,7 @@ def test_ionic_liquid_energy_anion_sublattice(load_database):
         v.Y('IONIC_LIQ', 1, v.Species('VA')): 1e-12,
         v.Y('IONIC_LIQ', 1, v.Species('S', {'S': 1.0})): 1.0,
     }
-    out = np.array(mod.ast.subs({**potentials, **em_FE_S}).n(real=True), dtype=np.complex_)
+    out = np.array(mod.ast.subs({**potentials, **em_FE_S}).n(real=True), dtype=np.complex128)
     assert np.isclose(out, -102463.52, atol=0.1)
 
     # Test some ficticious "nice" mixing cases
@@ -507,7 +507,7 @@ def test_ionic_liquid_energy_anion_sublattice(load_database):
         v.Y('IONIC_LIQ', 1, v.Species('VA')): 0.33333333,
         v.Y('IONIC_LIQ', 1, v.Species('S', {'S': 1.0})): 0.33333333,
     }
-    out = np.array(mod.ast.subs({**potentials, **mix_equal}).n(real=True), dtype=np.complex_)
+    out = np.array(mod.ast.subs({**potentials, **mix_equal}).n(real=True), dtype=np.complex128)
     assert np.isclose(out, -130358.2, atol=0.1)
 
     mix_unequal = {
@@ -516,7 +516,7 @@ def test_ionic_liquid_energy_anion_sublattice(load_database):
         v.Y('IONIC_LIQ', 1, v.Species('VA')): 0.25,
         v.Y('IONIC_LIQ', 1, v.Species('S', {'S': 1.0})): 0.25,
     }
-    out = np.array(mod.ast.subs({**potentials, **mix_unequal}).n(real=True), dtype=np.complex_)
+    out = np.array(mod.ast.subs({**potentials, **mix_unequal}).n(real=True), dtype=np.complex128)
     assert np.isclose(out, -138484.11, atol=0.1)
 
     # Test the energies for the two equilibrium internal DOF for the conditions
@@ -526,7 +526,7 @@ def test_ionic_liquid_energy_anion_sublattice(load_database):
         v.Y('IONIC_LIQ', 1, v.Species('VA')): 1.00545E-04,
         v.Y('IONIC_LIQ', 1, v.Species('S-2', {'S': 1.0}, charge=-2)): 6.00994E-01,
     }
-    out = np.array(mod.ast.subs({**potentials, **eq_sf_1}).n(real=True), dtype=np.complex_)
+    out = np.array(mod.ast.subs({**potentials, **eq_sf_1}).n(real=True), dtype=np.complex128)
     assert np.isclose(out, -141545.37, atol=0.1)
 
     eq_sf_2 = {
@@ -535,7 +535,7 @@ def test_ionic_liquid_energy_anion_sublattice(load_database):
         v.Y('IONIC_LIQ', 1, v.Species('VA')): 1.45273E-04,
         v.Y('IONIC_LIQ', 1, v.Species('S')): 9.84476E-01,
     }
-    out = np.array(mod.ast.subs({**potentials, **eq_sf_2}).n(real=True), dtype=np.complex_)
+    out = np.array(mod.ast.subs({**potentials, **eq_sf_2}).n(real=True), dtype=np.complex128)
     assert np.isclose(out, -104229.18, atol=0.1)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 requires = [
     "Cython",
     # numpy ABI compatibility for different Python versions
-    "oldest-supported-numpy",
+    "oldest-supported-numpy; python_version=='3.8'",
+    "numpy>=2; python_version>='3.9'",
     "scipy",
     "setuptools",
     "setuptools_scm[toml]>=6.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Build requirements, matching pyproject.toml[build-system][requires]
 Cython
-oldest-supported-numpy
+numpy>=2
 scipy
 setuptools
 setuptools_scm[toml]>=6.0


### PR DESCRIPTION
Adds build-time and runtime support for NumPy 2.0. This version is C-API compatible with NumPy 1.x, so we set a build-time requirement for >=2.0 while retaining support for 1.x. This compatibility guarantee allows us to deprecate the usage of `oldest-supported-numpy` per the recommendation of those authors.

NumPy 2.0 does not support Python 3.8, but these changes do not directly impact our ability to support py38 on NumPy 1.x. (It is probably overdue for pycalphad to drop py38 support, but that can be done separately from here.)

Two minor and backwards-compatible fixes for runtime are needed and also added here: `np.float_` is renamed to `np.float64` and `np.complex_` is renamed to `np.complex128`. (Complex number arrays are used for certain tests.)

See also:
- https://numpy.org/devdocs/dev/depending_on_numpy.html#adding-a-dependency-on-numpy
- https://github.com/scipy/oldest-supported-numpy?tab=readme-ov-file#deprecation-notice-for-numpy-20

Checklist
* [x] If any dependencies have changed, the changes are reflected in the
  * [x] `setup.py` (runtime requirements)
  * [x] `pyproject.toml` (build requirements)
  * [x] `requirements-dev.txt` (build and development requirements)

