### PR TITLE
MAINT/BLD: Bump OS versions for wheel build/deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-11]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -28,7 +28,7 @@ jobs:
         env:
           # PyPy wheels not allowed because SciPy (build requirement) is not available
           CIBW_BUILD: cp3*-*
-          CIBW_SKIP: cp35-* cp36-* cp37-* *-musllinux_*
+          CIBW_SKIP: cp36-* cp37-* *-musllinux_*
           CIBW_ARCHS_LINUX: auto64
           CIBW_ARCHS_MACOS: x86_64 universal2 arm64
           CIBW_ARCHS_WINDOWS: auto64


### PR DESCRIPTION
<!--

Thank you for pull request.

Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.

-->
`macos-11` is deprecated in GHA so this is probably a good time to bump all the OS versions for the `deploy.yaml` workflow. I've also removed a now-unused cibuildwheel version from `CIBW_SKIP` for good measure.

Checklist
* [x] If any dependencies have changed, the changes are reflected in the
  * [x] `setup.py` (runtime requirements)
  * [x] `pyproject.toml` (build requirements)
  * [x] `requirements-dev.txt` (build and development requirements)
