### PR TITLE
BLD/CI: Remove local version specifier for TestPyPI uploads

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,7 +29,6 @@ jobs:
           echo "\nlocal_scheme = \"no-local-version\"" >> pyproject.toml
           git diff --color=always
           git update-index --assume-unchanged pyproject.toml
-        # if: github.event_name == 'push' && github.ref_name == 'develop'
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.1
@@ -61,7 +60,6 @@ jobs:
           echo "\nlocal_scheme = \"no-local-version\"" >> pyproject.toml
           git diff --color=always
           git update-index --assume-unchanged pyproject.toml
-        # if: github.event_name == 'push' && github.ref_name == 'develop'
 
       - uses: actions/setup-python@v5
         name: Install Python

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,6 +23,14 @@ jobs:
         with:
           fetch-depth: 0  # fetch the entire repo history, required to guarantee setuptools_scm will pick up the tags
 
+      # setuptools_scm workaround for https://github.com/pypa/setuptools_scm/issues/455
+      - name: Disable local version identifier on develop CI
+        run: |
+          echo "\nlocal_scheme = \"no-local-version\"" >> pyproject.toml
+          git diff --color=always
+          git update-index --assume-unchanged pyproject.toml
+        if: github.event_name == 'push' #  && github.ref_name == 'develop'
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.1
         env:
@@ -46,6 +54,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # fetch the entire repo history, required to guarantee setuptools_scm will pick up the tags
+
+      # setuptools_scm workaround for https://github.com/pypa/setuptools_scm/issues/455
+      - name: Disable local version identifier on develop CI
+        run: |
+          echo "\nlocal_scheme = \"no-local-version\"" >> pyproject.toml
+          git diff --color=always
+          git update-index --assume-unchanged pyproject.toml
+        if: github.event_name == 'push' #  && github.ref_name == 'develop'
 
       - uses: actions/setup-python@v5
         name: Install Python

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,9 +26,10 @@ jobs:
       # setuptools_scm workaround for https://github.com/pypa/setuptools_scm/issues/455
       - name: Disable local version identifier on develop CI
         run: |
-          echo "\nlocal_scheme = \"no-local-version\"" >> pyproject.toml
+          echo -e '\nlocal_scheme = "no-local-version"\n' >> pyproject.toml
           git diff --color=always
           git update-index --assume-unchanged pyproject.toml
+        if: github.event_name == 'push' && github.ref_name == 'develop'
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.1
@@ -60,6 +61,7 @@ jobs:
           echo -e '\nlocal_scheme = "no-local-version"\n' >> pyproject.toml
           git diff --color=always
           git update-index --assume-unchanged pyproject.toml
+        if: github.event_name == 'push' && github.ref_name == 'develop'
 
       - uses: actions/setup-python@v5
         name: Install Python

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,6 +29,7 @@ jobs:
           echo 'local_scheme = "no-local-version"' >> pyproject.toml
           git diff --color=always
           git update-index --assume-unchanged pyproject.toml
+        if: github.event_name == 'push' && github.ref_name == 'develop'
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.1
@@ -57,9 +58,10 @@ jobs:
       # setuptools_scm workaround for https://github.com/pypa/setuptools_scm/issues/455
       - name: Disable local version identifier on develop CI
         run: |
-          echo -e '\nlocal_scheme = "no-local-version"\n' >> pyproject.toml
+          echo 'local_scheme = "no-local-version"\n' >> pyproject.toml
           git diff --color=always
           git update-index --assume-unchanged pyproject.toml
+        if: github.event_name == 'push' && github.ref_name == 'develop'
 
       - uses: actions/setup-python@v5
         name: Install Python

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,7 +26,7 @@ jobs:
       # setuptools_scm workaround for https://github.com/pypa/setuptools_scm/issues/455
       - name: Disable local version identifier on develop CI
         run: |
-          echo -e '\nlocal_scheme = "no-local-version"\n' >> pyproject.toml
+          echo 'local_scheme = "no-local-version"' >> pyproject.toml
           git diff --color=always
           git update-index --assume-unchanged pyproject.toml
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,7 +29,7 @@ jobs:
           echo "\nlocal_scheme = \"no-local-version\"" >> pyproject.toml
           git diff --color=always
           git update-index --assume-unchanged pyproject.toml
-        if: github.event_name == 'push' #  && github.ref_name == 'develop'
+        # if: github.event_name == 'push' && github.ref_name == 'develop'
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.1
@@ -61,7 +61,7 @@ jobs:
           echo "\nlocal_scheme = \"no-local-version\"" >> pyproject.toml
           git diff --color=always
           git update-index --assume-unchanged pyproject.toml
-        if: github.event_name == 'push' #  && github.ref_name == 'develop'
+        # if: github.event_name == 'push' && github.ref_name == 'develop'
 
       - uses: actions/setup-python@v5
         name: Install Python

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,6 +33,7 @@ jobs:
           CIBW_ARCHS_MACOS: x86_64 universal2 arm64
           CIBW_ARCHS_WINDOWS: auto64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          SETUPTOOLS_SCM_LOCAL_SCHEME: no-local-version
 
       - uses: actions/upload-artifact@v4
         with:
@@ -56,6 +57,8 @@ jobs:
 
       - name: Build sdist
         run: python -m build --sdist
+        env:
+          SETUPTOOLS_SCM_LOCAL_SCHEME: no-local-version
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -57,7 +57,7 @@ jobs:
       # setuptools_scm workaround for https://github.com/pypa/setuptools_scm/issues/455
       - name: Disable local version identifier on develop CI
         run: |
-          echo "\nlocal_scheme = \"no-local-version\"" >> pyproject.toml
+          echo "\nlocal_scheme = \"no-local-version\"\n" >> pyproject.toml
           git diff --color=always
           git update-index --assume-unchanged pyproject.toml
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,7 +33,6 @@ jobs:
           CIBW_ARCHS_MACOS: x86_64 universal2 arm64
           CIBW_ARCHS_WINDOWS: auto64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          SETUPTOOLS_SCM_LOCAL_SCHEME: no-local-version
 
       - uses: actions/upload-artifact@v4
         with:
@@ -57,8 +56,6 @@ jobs:
 
       - name: Build sdist
         run: python -m build --sdist
-        env:
-          SETUPTOOLS_SCM_LOCAL_SCHEME: no-local-version
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -57,7 +57,7 @@ jobs:
       # setuptools_scm workaround for https://github.com/pypa/setuptools_scm/issues/455
       - name: Disable local version identifier on develop CI
         run: |
-          echo "\nlocal_scheme = \"no-local-version\"\n" >> pyproject.toml
+          echo -e '\nlocal_scheme = "no-local-version"\n' >> pyproject.toml
           git diff --color=always
           git update-index --assume-unchanged pyproject.toml
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,7 +29,6 @@ jobs:
           echo -e '\nlocal_scheme = "no-local-version"\n' >> pyproject.toml
           git diff --color=always
           git update-index --assume-unchanged pyproject.toml
-        if: github.event_name == 'push' && github.ref_name == 'develop'
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.1
@@ -61,7 +60,6 @@ jobs:
           echo -e '\nlocal_scheme = "no-local-version"\n' >> pyproject.toml
           git diff --color=always
           git update-index --assume-unchanged pyproject.toml
-        if: github.event_name == 'push' && github.ref_name == 'develop'
 
       - uses: actions/setup-python@v5
         name: Install Python

--- a/pycalphad/_dev/__init__.py
+++ b/pycalphad/_dev/__init__.py
@@ -12,3 +12,24 @@ https://stackoverflow.com/questions/43348746/how-to-detect-if-module-is-installe
 
 # Provide a mechanism for getting the version from the source control management system
 from setuptools_scm import get_version
+from functools import partial
+import os
+
+# https://github.com/pypa/setuptools_scm/issues/455#issuecomment-1268134018
+# setuptools_scm config local_scheme via env var SETUPTOOLS_SCM_LOCAL_SCHEME
+# Needed for TestPyPI uploads, to remove unsupported local version identifier
+scm_local_scheme = "node-and-date"
+
+if "SETUPTOOLS_SCM_LOCAL_SCHEME" in os.environ:
+    local_scheme_values = [
+        "node-and-date",
+        "node-and-timestamp",
+        "dirty-tag",
+        "no-local-version",
+    ]
+    if os.environ["SETUPTOOLS_SCM_LOCAL_SCHEME"] in local_scheme_values:
+        scm_local_scheme = os.environ["SETUPTOOLS_SCM_LOCAL_SCHEME"]
+    else:
+        raise ValueError(f'SETUPTOOLS_SCM_LOCAL_SCHEME is none of {local_scheme_values} - Got: {os.environ["SETUPTOOLS_SCM_LOCAL_SCHEME"]}')
+
+get_version = partial(get_version, local_scheme=scm_local_scheme)

--- a/pycalphad/_dev/__init__.py
+++ b/pycalphad/_dev/__init__.py
@@ -12,24 +12,3 @@ https://stackoverflow.com/questions/43348746/how-to-detect-if-module-is-installe
 
 # Provide a mechanism for getting the version from the source control management system
 from setuptools_scm import get_version
-from functools import partial
-import os
-
-# https://github.com/pypa/setuptools_scm/issues/455#issuecomment-1268134018
-# setuptools_scm config local_scheme via env var SETUPTOOLS_SCM_LOCAL_SCHEME
-# Needed for TestPyPI uploads, to remove unsupported local version identifier
-scm_local_scheme = "node-and-date"
-
-if "SETUPTOOLS_SCM_LOCAL_SCHEME" in os.environ:
-    local_scheme_values = [
-        "node-and-date",
-        "node-and-timestamp",
-        "dirty-tag",
-        "no-local-version",
-    ]
-    if os.environ["SETUPTOOLS_SCM_LOCAL_SCHEME"] in local_scheme_values:
-        scm_local_scheme = os.environ["SETUPTOOLS_SCM_LOCAL_SCHEME"]
-    else:
-        raise ValueError(f'SETUPTOOLS_SCM_LOCAL_SCHEME is none of {local_scheme_values} - Got: {os.environ["SETUPTOOLS_SCM_LOCAL_SCHEME"]}')
-
-get_version = partial(get_version, local_scheme=scm_local_scheme)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,6 @@ omit = [
 [tool.coverage.report]
 ignore_errors = true # workaround for https://github.com/cython/cython/issues/5581
 
-# '[tool.setuptools.scm]' needs to be the last line because
+# '[tool.setuptools.scm]\n' needs to be the last line because
 # we do an append operation in the deploy.yaml GitHub Actions workflow
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,4 +42,6 @@ omit = [
 [tool.coverage.report]
 ignore_errors = true # workaround for https://github.com/cython/cython/issues/5581
 
+# '[tool.setuptools.scm]' needs to be the last line because
+# we do an append operation in the deploy.yaml GitHub Actions workflow
 [tool.setuptools_scm]


### PR DESCRIPTION
Removes local version specifier (`+hash`) from CI builds to allow for upload of artifacts to TestPyPI. Follows the strategy outlined in https://github.com/pypa/setuptools_scm/issues/455#issue-634969642


Checklist
* [x] If any dependencies have changed, the changes are reflected in the
  * [x] `setup.py` (runtime requirements)
  * [x] `pyproject.toml` (build requirements)
  * [x] `requirements-dev.txt` (build and development requirements)
