### PR TITLE
ENH/BLD: Drop dedicated macOS universal wheel builds

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,7 +38,7 @@ jobs:
           CIBW_BUILD: cp3*-*
           CIBW_SKIP: cp36-* cp37-* *-musllinux_*
           CIBW_ARCHS_LINUX: auto64
-          CIBW_ARCHS_MACOS: x86_64 universal2 arm64
+          CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_ARCHS_WINDOWS: auto64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
 


### PR DESCRIPTION
This PR drops dedicated macOS `universal2` wheel building in cibuildwheel. (We continue to build `x86_64` and `arm64` wheels for macOS.) The reasons for this are:
1. Our [upstream](https://github.com/numpy/numpy/pull/20787) isn't building them, so users will never automatically select this wheel during installation.
2. It is straightforward for downstream packagers (using `py2app` or other solutions) to fuse single-arch wheels into universal wheels themselves: ` pip install delocate ; delocate-fuse $amd64_wheel $arm64_wheel -w .`
3. The consensus seems to be that shipping single-arch wheels and letting downstream manually fuse them is the way to go. ( e.g. https://github.com/pypa/cibuildwheel/issues/705 and https://github.com/python-pillow/pillow-wheels/issues/359 ).
4. On pycalphad CI, Windows and Linux wheels take 6-8 minutes to build, while for macOS building all three arches (both single-arches and `universal2`) takes 16-20 minutes and is usually the last job to finish. It is expected that dropping dedicated universal wheel building will cut the latter time nearly in half, putting it more in family with the other OS build jobs.