### PR TITLE
ENH: Improve error message for ordering models having mismatched constituents

### DIFF
--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -1248,12 +1248,21 @@ class Model(object):
         num_ordered_interstitial_subls = len(ordered_phase.sublattices) - num_substitutional_sublattice_idxs
         num_disordered_interstitial_subls = len(disordered_phase.sublattices) - 1
         if num_ordered_interstitial_subls != num_disordered_interstitial_subls:
+            import textwrap
             raise ValueError(
-                f'Number of interstitial sublattices for the disordered phase '
-                f'({num_disordered_interstitial_subls}) and the ordered phase '
-                f'({num_ordered_interstitial_subls}) do not match. Got '
-                f'substitutional sublattice indices of {substitutional_sublattice_idxs}.'
-                )
+                textwrap.dedent(
+                f"""
+                Number of interstitial sublattices for the disordered phase
+                 {disordered_phase_name} ({num_disordered_interstitial_subls})
+                 and the ordered phase {ordered_phase_name}
+                 ({num_ordered_interstitial_subls}) do not match. Found substitutional
+                 sublattices in the ordered phase with indices of
+                 {substitutional_sublattice_idxs}. Ensure that all the constituents in
+                 the substitutional sublattices for the disordered and ordered phase
+                 match exactly and the constituents in the interstitial sublattices for
+                 the disordered and ordered phase match exactly.
+                """
+                ).replace("\n", ""))
         # We also validate that no physical properties have ordered
         # contributions because the underlying physical property needs to
         # paritioned and substituted for the physical property in the disordered


### PR DESCRIPTION
Changes the error message for mismatched disordered and ordered sublattices from this:

```
ValueError: Number of interstitial sublattices for the disordered phase (1) and the ordered phase (5) do not match. Got substitutional sublattice indices of [].
```

to this:

```
ValueError: Number of interstitial sublattices for the disordered phase FCC_A1 (1) and the ordered phase GP_MAT (5) do not match. Found substitutional sublattices in the ordered phase with indices of []. Ensure that all the constituents in the substitutional sublattices for the disordered and ordered phase match exactly and the constituents in the interstitial sublattices for the disordered and ordered phase match exactly.
```