### PR TITLE
ENH: Add Component implementation in variables

### DIFF
--- a/pycalphad/codegen/phase_record_factory.py
+++ b/pycalphad/codegen/phase_record_factory.py
@@ -1,6 +1,6 @@
 import pycalphad.variables as v
 from pycalphad.codegen.sympydiff_utils import build_functions
-from pycalphad.core.utils import get_pure_elements, unpack_components, \
+from pycalphad.core.utils import get_pure_elements, unpack_species, \
     extract_parameters, get_state_variables
 from pycalphad.core.phase_rec import PhaseRecord
 from pycalphad.core.constraints import build_constraints
@@ -10,7 +10,7 @@ import numpy as np
 
 class PhaseRecordFactory(object):
     def __init__(self, dbf, comps, state_variables, models, parameters=None):
-        self.comps = sorted(unpack_components(dbf, comps))
+        self.comps = sorted(unpack_species(dbf, comps))
         self.pure_elements = get_pure_elements(dbf, comps)
         self.nonvacant_elements = sorted([x for x in self.pure_elements if x != 'VA'])
         self.molar_masses = np.array([dbf.refstates[x]['mass'] for x in self.nonvacant_elements], dtype='float')

--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -18,7 +18,7 @@ from pycalphad.core.polytope import sample
 from pycalphad.model import Model
 from pycalphad.core.utils import endmember_matrix, extract_parameters, \
     get_pure_elements, filter_phases, instantiate_models, point_sample, \
-    unpack_components, unpack_condition, unpack_kwarg
+    unpack_species, unpack_condition, unpack_kwarg
 from pycalphad.core.constants import MIN_SITE_FRACTION, MAX_ENDMEMBER_PAIRS, MAX_EXTRA_POINTS
 
 
@@ -422,7 +422,7 @@ def calculate(dbf, comps, phases, mode=None, output='GM', fake_points=False, bro
         phases = [phases]
     if isinstance(comps, (str, v.Species)):
         comps = [comps]
-    comps = sorted(unpack_components(dbf, comps))
+    comps = sorted(unpack_species(dbf, comps))
     if points_dict is None and broadcast is False:
         raise ValueError('The \'points\' keyword argument must be specified if broadcast=False is also given.')
     nonvacant_components = [x for x in sorted(comps) if x.number_of_atoms > 0]

--- a/pycalphad/core/utils.py
+++ b/pycalphad/core/utils.py
@@ -310,9 +310,10 @@ def filter_phases(dbf, comps, candidate_phases=None):
         candidate_phases = dbf.phases.keys()
     else:
         candidate_phases = set(candidate_phases).intersection(dbf.phases.keys())
+    species = unpack_species(dbf, comps)
     disordered_phases = [dbf.phases[phase].model_hints.get('disordered_phase') for phase in candidate_phases]
     phases = [phase for phase in candidate_phases if
-                all_sublattices_active(comps, dbf.phases[phase]) and
+                all_sublattices_active(species, dbf.phases[phase]) and
                 (phase not in disordered_phases or (phase in disordered_phases and
                 dbf.phases[phase].model_hints.get('ordered_phase') not in candidate_phases))]
     return sorted(phases)

--- a/pycalphad/core/utils.py
+++ b/pycalphad/core/utils.py
@@ -227,7 +227,7 @@ def unpack_kwarg(kwarg_obj, default_arg=None):
     return new_dict
 
 
-def unpack_components(dbf, comps):
+def unpack_species(dbf, comps):
     """
 
     Parameters
@@ -272,7 +272,7 @@ def get_pure_elements(dbf, comps):
     list
         A list of pure elements in the Database
     """
-    comps = sorted(unpack_components(dbf, comps))
+    comps = sorted(unpack_species(dbf, comps))
     components = [x for x in comps]
     desired_active_pure_elements = [list(x.constituents.keys()) for x in components]
     desired_active_pure_elements = [el.upper() for constituents in desired_active_pure_elements for el in constituents]
@@ -536,4 +536,3 @@ def generate_symmetric_group(configuration, symmetry):
             new_config.insert(fixed_idx, configuration[fixed_idx])
         symmetrically_distinct_configurations.add(tuple(new_config))
     return sorted(symmetrically_distinct_configurations, key=canonical_sort_key)
-

--- a/pycalphad/core/workspace.py
+++ b/pycalphad/core/workspace.py
@@ -382,14 +382,7 @@ class Workspace:
                 phase_names = sorted(self.phase_record_factory.keys())
                 additional_args = args[i].expand_wildcard(phase_names=phase_names)
                 args.extend(additional_args)
-            elif hasattr(args[i], 'sublattice_index') and args[i].sublattice_index == '*':
-                # We need to resolve sublattice_index before species to ensure we
-                # get the correct set of phase constituents for each sublattice
-                indices_to_delete.append(i)
-                sublattice_indices = sorted(set([x.sublattice_index for x in self.phase_record_factory[args[i].phase_name].variables]))
-                additional_args = args[i].expand_wildcard(sublattice_indices=sublattice_indices)
-                args.extend(additional_args)
-            elif hasattr(args[i], 'species') and args[i].species == v.Species('*'):
+            elif hasattr(args[i], 'species') and args[i].species.name == '*':
                 indices_to_delete.append(i)
                 internal_to_phase = hasattr(args[i], 'sublattice_index')
                 if internal_to_phase:
@@ -400,6 +393,8 @@ class Workspace:
                     components = [comp for comp in self.phase_record_factory.nonvacant_elements]
                 additional_args = args[i].expand_wildcard(components=components)
                 args.extend(additional_args)
+            elif hasattr(args[i], 'sublattice_index') and args[i].sublattice_index == '*':
+                raise ValueError('Wildcard not yet supported in sublattice index')
             elif isinstance(args[i], JanssonDerivative):
                 numerator_args = [args[i].numerator]
                 self._expand_property_arguments(numerator_args)

--- a/pycalphad/core/workspace.py
+++ b/pycalphad/core/workspace.py
@@ -49,28 +49,10 @@ def _adjust_conditions(conds) -> OrderedDict[StateVariable, List[float]]:
     return new_conds
 
 class ComponentList:
-    _wks: "Workspace"
-    _components: List[v.Component]
-
     @classmethod
     def cast_from(cls, s: Sequence[SumType([str, v.Component])]) -> "ComponentList":
         # no Database, so we don't get Species lookup support here, it's implemented in ComponentsField
         return v.unpack_components(s)
-
-    def __init__(self, wks: Optional["Workspace"] = None):
-        self._wks = wks
-        self._components = []
-
-    def __len__(self):
-        return len(self._components)
-
-    def __iter__(self):
-        yield from self._components
-
-    def __str__(self):
-        return str(self._components)
-
-    __repr__ = __str__
 
 class ConstituentsList:
     @classmethod

--- a/pycalphad/core/workspace.py
+++ b/pycalphad/core/workspace.py
@@ -3,7 +3,7 @@ from collections import OrderedDict, Counter, defaultdict
 from copy import copy
 from pycalphad.property_framework.computed_property import JanssonDerivative
 import pycalphad.variables as v
-from pycalphad.core.utils import unpack_components, unpack_condition, unpack_phases, filter_phases, instantiate_models
+from pycalphad.core.utils import unpack_species, unpack_condition, unpack_phases, filter_phases, instantiate_models
 from pycalphad import calculate
 from pycalphad.core.starting_point import starting_point
 from pycalphad.codegen.phase_record_factory import PhaseRecordFactory
@@ -128,15 +128,15 @@ class TypedField:
 
 class ComponentsField(TypedField):
     def __init__(self, depends_on=None):
-        super().__init__(default_factory=lambda obj: unpack_components(obj.database, sorted(x.name for x in obj.database.species if x.name != '/-')),
+        super().__init__(default_factory=lambda obj: unpack_species(obj.database, sorted(x.name for x in obj.database.species if x.name != '/-')),
                          depends_on=depends_on)
     def __set__(self, obj, value):
-        comps = sorted(unpack_components(obj.database, value))
+        comps = sorted(unpack_species(obj.database, value))
         super().__set__(obj, comps)
 
     def __get__(self, obj, objtype=None):
         getobj = super().__get__(obj, objtype=objtype)
-        return sorted(unpack_components(obj.database, getobj))
+        return sorted(unpack_species(obj.database, getobj))
 
 class PhasesField(TypedField):
     def __init__(self, depends_on=None):

--- a/pycalphad/core/workspace.py
+++ b/pycalphad/core/workspace.py
@@ -165,7 +165,7 @@ class ConstituentsField(TypedField):
     def on_dependency_update(self, obj, updated_attribute, old_val, new_val):
         if obj._suspend_dependency_updates:
             return
-        self.__set__(obj, self.default_factory(obj))
+        self.__set__(obj, unpack_species(obj.database, obj.components))
 
 class PhasesField(TypedField):
     def __init__(self, depends_on=None):

--- a/pycalphad/mapping/strategy/strategy_base.py
+++ b/pycalphad/mapping/strategy/strategy_base.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from pycalphad import Database, variables as v
 from pycalphad.codegen.phase_record_factory import PhaseRecordFactory
-from pycalphad.core.utils import instantiate_models, unpack_components, filter_phases, get_pure_elements, get_state_variables
+from pycalphad.core.utils import instantiate_models, filter_phases, get_pure_elements, get_state_variables
 from pycalphad.core.composition_set import CompositionSet
 
 
@@ -45,14 +45,14 @@ class MapStrategy:
         # Don't add vacancies to components in case user needs to restrict non-stoichiometric phases
         self.components = sorted(components)
         self.elements = get_pure_elements(self.dbf, self.components)
-        self.phases = filter_phases(self.dbf, unpack_components(self.dbf, self.components), phases)
+        self.phases = filter_phases(self.dbf, v.unpack_components(self.dbf, self.components), phases)
         self.conditions = copy.deepcopy(conditions)
 
         # Add v.N to conditions. Mapping assumes that v.N is in conditions
         if v.N not in self.conditions:
             self.conditions[v.N] = 1
 
-        
+
         self.axis_vars = [key for key, val in self.conditions.items() if len(np.atleast_1d(val)) > 1]
 
         composition_sum = sum([conditions[var] for var in conditions if (isinstance(var, v.MoleFraction) and var not in self.axis_vars)])
@@ -255,7 +255,7 @@ class MapStrategy:
                 curr_point = zpf_line.points[-1]
                 prev_point = zpf_line.points[-2]
                 dv = [(curr_point.get_property(av) - prev_point.get_property(av))/self.normalize_factor(av) for av in self.axis_vars]
-                
+
                 # We want to step in the axis variable that changes the most (that way the change in the other variable will be minimal)
                 # We also can get the direction from the change in variable
                 index = np.argmax(np.abs(dv))

--- a/pycalphad/mapping/strategy/strategy_base.py
+++ b/pycalphad/mapping/strategy/strategy_base.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from pycalphad import Database, variables as v
 from pycalphad.codegen.phase_record_factory import PhaseRecordFactory
-from pycalphad.core.utils import instantiate_models, filter_phases, get_pure_elements, get_state_variables
+from pycalphad.core.utils import instantiate_models, filter_phases, unpack_species, get_pure_elements, get_state_variables
 from pycalphad.core.composition_set import CompositionSet
 
 
@@ -45,7 +45,7 @@ class MapStrategy:
         # Don't add vacancies to components in case user needs to restrict non-stoichiometric phases
         self.components = sorted(components)
         self.elements = get_pure_elements(self.dbf, self.components)
-        self.phases = filter_phases(self.dbf, v.unpack_components(self.dbf, self.components), phases)
+        self.phases = filter_phases(self.dbf, unpack_species(self.dbf, self.components), phases)
         self.conditions = copy.deepcopy(conditions)
 
         # Add v.N to conditions. Mapping assumes that v.N is in conditions

--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -9,7 +9,7 @@ from tinydb import where
 import pycalphad.variables as v
 from pycalphad.core.errors import DofError
 from pycalphad.core.constants import MIN_SITE_FRACTION
-from pycalphad.core.utils import unpack_components, get_pure_elements, wrap_symbol
+from pycalphad.core.utils import unpack_species, get_pure_elements, wrap_symbol
 from pycalphad.io.tdb import get_supported_variables
 import numpy as np
 from collections import OrderedDict
@@ -198,7 +198,7 @@ class Model(object):
         self.phase_name = phase_name.upper()
         phase = dbe.phases[self.phase_name]
         self.site_ratios = list(phase.sublattices)
-        active_species = unpack_components(dbe, comps)
+        active_species = unpack_species(dbe, comps)
         for idx, sublattice in enumerate(phase.constituents):
             subl_comps = set(sublattice).intersection(active_species)
             self.components |= subl_comps

--- a/pycalphad/models/model_mqmqa.py
+++ b/pycalphad/models/model_mqmqa.py
@@ -6,7 +6,7 @@ from symengine import log, S, Symbol
 from tinydb import where
 from pycalphad.model import _MAX_PARAM_NESTING
 import pycalphad.variables as v
-from pycalphad.core.utils import unpack_components, wrap_symbol
+from pycalphad.core.utils import unpack_species, wrap_symbol
 from pycalphad import Model
 from pycalphad.core.errors import DofError
 
@@ -79,7 +79,7 @@ class ModelMQMQA(Model):
         phase = dbe.phases[self.phase_name]
         self.site_ratios = tuple(list(phase.sublattices))
 
-        active_species = unpack_components(dbe, comps)
+        active_species = unpack_species(dbe, comps)
         constituents = []
         for sublattice in dbe.phases[phase_name].constituents:
             sublattice_comps = set(sublattice).intersection(active_species)

--- a/pycalphad/plot/binary/map.py
+++ b/pycalphad/plot/binary/map.py
@@ -9,7 +9,7 @@ from pycalphad.core.eqsolver import _solve_eq_at_conditions
 from pycalphad.core.workspace import _adjust_conditions
 from pycalphad.core.starting_point import starting_point
 from pycalphad.core.utils import instantiate_models, get_state_variables, \
-    unpack_components, unpack_condition, filter_phases, get_pure_elements
+    unpack_species, unpack_condition, filter_phases, get_pure_elements
 from pycalphad.property_framework.units import Q_
 from pycalphad.property_framework import as_quantity
 from .compsets import get_compsets, find_two_phase_region_compsets
@@ -62,7 +62,7 @@ def map_binary(dbf, comps, phases, conds, eq_kwargs=None, calc_kwargs=None,
     if 'pdens' not in calc_kwargs:
         calc_kwargs['pdens'] = 50
 
-    species = unpack_components(dbf, comps)
+    species = unpack_species(dbf, comps)
     phases = filter_phases(dbf, species, phases)
     parameters = eq_kwargs.get('parameters', {})
     models = eq_kwargs.get('model')

--- a/pycalphad/tests/test_utils.py
+++ b/pycalphad/tests/test_utils.py
@@ -5,7 +5,7 @@ The utils test module contains tests for pycalphad utilities.
 import pytest
 from importlib.resources import files
 from pycalphad import Database, Model
-from pycalphad.core.utils import filter_phases, unpack_components, instantiate_models, generate_symmetric_group
+from pycalphad.core.utils import filter_phases, unpack_species, instantiate_models, generate_symmetric_group
 import pycalphad.tests.databases
 from pycalphad.tests.fixtures import select_database, load_database
 
@@ -18,9 +18,9 @@ def test_filter_phases_removes_disordered_phases_from_order_disorder(load_databa
     ALNIPT_DBF = Database(str(files(pycalphad.tests.databases).joinpath("alnipt.tdb")))
     ALCRNI_DBF = Database(str(files(pycalphad.tests.databases).joinpath("alcrni.tdb")))
     all_phases = set(ALNIPT_DBF.phases.keys())
-    filtered_phases = set(filter_phases(ALNIPT_DBF, unpack_components(ALNIPT_DBF, ['AL', 'NI', 'PT', 'VA'])))
+    filtered_phases = set(filter_phases(ALNIPT_DBF, unpack_species(ALNIPT_DBF, ['AL', 'NI', 'PT', 'VA'])))
     assert all_phases.difference(filtered_phases) == {'FCC_A1'}
-    comps = unpack_components(ALCRNI_DBF, ['NI', 'AL', 'CR', 'VA'])
+    comps = unpack_species(ALCRNI_DBF, ['NI', 'AL', 'CR', 'VA'])
     filtered_phases = set(filter_phases(ALCRNI_DBF, comps, ['FCC_A1', 'L12_FCC', 'LIQUID', 'BCC_A2']))
     assert filtered_phases == {'L12_FCC', 'LIQUID', 'BCC_A2'}
     filtered_phases = set(filter_phases(ALCRNI_DBF, comps, ['FCC_A1', 'LIQUID', 'BCC_A2']))
@@ -28,7 +28,7 @@ def test_filter_phases_removes_disordered_phases_from_order_disorder(load_databa
     filtered_phases = set(filter_phases(ALCRNI_DBF, comps, ['FCC_A1']))
     assert filtered_phases == {'FCC_A1'}
     # Test that phases are removed if there are no ordered/disorder model hints on the disordered configuration
-    filtered_phases = set(filter_phases(dbf, unpack_components(dbf, ['AL', 'NI', 'VA']), ['BCC_A2', 'BCC_B2']))
+    filtered_phases = set(filter_phases(dbf, unpack_species(dbf, ['AL', 'NI', 'VA']), ['BCC_A2', 'BCC_B2']))
     assert filtered_phases == {'BCC_B2'}
 
 
@@ -37,7 +37,7 @@ def test_filter_phases_removes_phases_with_inactive_sublattices(load_database):
     """Phases that have no active components in any sublattice should be filtered"""
     dbf = load_database()
     all_phases = set(dbf.phases.keys())
-    filtered_phases = set(filter_phases(dbf, unpack_components(dbf, ['AL', 'NI', 'VA'])))
+    filtered_phases = set(filter_phases(dbf, unpack_species(dbf, ['AL', 'NI', 'VA'])))
     assert all_phases.difference(filtered_phases) == {'FCC_A1', 'PT8AL21', 'PT5AL21', 'PT2AL', 'PT2AL3', 'PT5AL3', 'ALPT2'}
 
 

--- a/pycalphad/tests/test_variables.py
+++ b/pycalphad/tests/test_variables.py
@@ -46,6 +46,10 @@ def test_component_and_species_repr_str_methods():
     assert repr(comp) == "Component('*')"
     assert str(comp) == "*"
 
+    comp = v.Component(None)
+    assert repr(comp) == "Component(None)"
+    assert str(comp) == ""
+
     sp = v.Species("O2-4", {"O": 2}, charge=-4)
     assert repr(sp) == "Species('O2-4', 'O2', charge=-4)"
     assert str(sp) == "O2-4"
@@ -53,3 +57,7 @@ def test_component_and_species_repr_str_methods():
     sp = v.Species("*", {})
     assert repr(sp) == "Species('*')"
     assert str(sp) == "*"
+
+    sp = v.Species(None)
+    assert repr(sp) == "Species(None)"
+    assert str(sp) == ""

--- a/pycalphad/tests/test_variables.py
+++ b/pycalphad/tests/test_variables.py
@@ -42,6 +42,14 @@ def test_component_and_species_repr_str_methods():
     assert repr(comp) == "Component('O2', 'O2')"
     assert str(comp) == "O2"
 
+    comp = v.Component("*", {})
+    assert repr(comp) == "Component('*')"
+    assert str(comp) == "*"
+
     sp = v.Species("O2-4", {"O": 2}, charge=-4)
     assert repr(sp) == "Species('O2-4', 'O2', charge=-4)"
     assert str(sp) == "O2-4"
+
+    sp = v.Species("*", {})
+    assert repr(sp) == "Species('*')"
+    assert str(sp) == "*"

--- a/pycalphad/tests/test_variables.py
+++ b/pycalphad/tests/test_variables.py
@@ -35,3 +35,13 @@ def test_mole_and_mass_fraction_conversions(load_database):
     # Conversion back works
     round_trip_mass_fracs = v.get_mass_fractions(mole_fracs, v.Species('O'), md)
     assert all(np.isclose(round_trip_mass_fracs[mf], mass_fracs[mf]) for mf in round_trip_mass_fracs.keys())
+
+
+def test_component_and_species_repr_str_methods():
+    comp = v.Component("O2", {"O": 2})
+    assert repr(comp) == "Component('O2', 'O2')"
+    assert str(comp) == "O2"
+
+    sp = v.Species("O2-4", {"O": 2}, charge=-4)
+    assert repr(sp) == "Species('O2-4', 'O2', charge=-4)"
+    assert str(sp) == "O2-4"

--- a/pycalphad/tests/test_workspace.py
+++ b/pycalphad/tests/test_workspace.py
@@ -1,6 +1,6 @@
 from numpy.testing import assert_allclose
 import numpy as np
-from pycalphad import Workspace, variables as v
+from pycalphad import Database, Workspace, variables as v
 from pycalphad.core.conditions import ConditionError
 from pycalphad.core.composition_set import CompositionSet
 from pycalphad.property_framework import as_property, ComputableProperty, T0, IsolatedPhase, DormantPhase
@@ -366,6 +366,19 @@ def test_workspace_convergence_failures(load_database):
     phase_fractions = wks.get("NP(*)")
     assert np.asarray(phase_fractions).shape == (len(phases),)
     assert np.all(np.isnan(phase_fractions))
+
+
+@select_database("al2o3_nd2o3_zro2.tdb")
+def test_components_are_updated_when_database_changes(load_database):
+    dbf = load_database()
+    phases = list(set(dbf.phases.keys()) - {"I_LIQUID"})
+    wks = Workspace(dbf, phases=phases)
+    # by default: all pure elements
+    assert set(wks.components) == set({v.Component("AL"), v.Component("ND"), v.Component("ZR"), v.Component("O"), v.Component("VA")})
+    wks.database = Database()
+    assert set(wks.components) == set()
+    wks.database = dbf
+    assert set(wks.components) == set({v.Component("AL"), v.Component("ND"), v.Component("ZR"), v.Component("O"), v.Component("VA")})
 
 
 @select_database("al2o3_nd2o3_zro2.tdb")

--- a/pycalphad/variables.py
+++ b/pycalphad/variables.py
@@ -3,6 +3,7 @@
 Classes and constants for representing thermodynamic variables.
 """
 
+from typing import Optional
 from symengine import Float, Symbol
 from pycalphad.io.grammar import parse_chemical_formula
 from pycalphad.property_framework.types import JanssonDerivativeDeltas
@@ -199,7 +200,7 @@ class Species(object):
         return hash(self.name)
 
 
-def unpack_components(dbf: "Database", components: "Sequence[Component | Species | str]"):
+def unpack_components(components: "Sequence[Component | Species | str]", dbf: Optional["Database"] = None):
     """
     Build a set of Components from ones provided by the caller.
 
@@ -212,10 +213,12 @@ def unpack_components(dbf: "Database", components: "Sequence[Component | Species
 
     Parameters
     ----------
-    dbf : Database
-        Thermodynamic database containing elements and species.
     comps : Sequence[Component | Species | str]
         Names of components to consider in the calculation.
+    dbf : Optional[Database]
+        Thermodynamic database containing elements and species. If no database is
+        passed, constructing Component objects via pattern matching to Species defined
+        in the Database (3a) will not be possible.
 
     Returns
     -------
@@ -228,10 +231,13 @@ def unpack_components(dbf: "Database", components: "Sequence[Component | Species
     >>> dbf = Database()
     >>> dbf.species.add(v.Species("WCL4", {"W": 1, "CL": 4}))
     >>> dbf.species.add(v.Species("H+", {"H": 1.0}, charge=1.0))
-    >>> unpack_components(dbf, [v.Component("NACL"), v.Species("H2O"), "SIO2", "K1CL1", "WCL4", "H+"])
+    >>> unpack_components([v.Component("NACL"), v.Species("H2O"), "SIO2", "K1CL1", "WCL4", "H+"], dbf)
     """
     desired_components = set()
-    known_species = {sp.name: sp for sp in dbf.species}
+    if dbf is not None:
+        known_species = {sp.name: sp for sp in dbf.species}
+    else:
+        known_species = {}
     for c in components:
         if isinstance(c, Component):
             desired_components.add(c)

--- a/pycalphad/variables.py
+++ b/pycalphad/variables.py
@@ -532,7 +532,6 @@ class MoleFraction(StateVariable):
         result = np.atleast_1d(np.zeros(self.shape))
         result[:] = np.nan
         for _, compset in self.filtered(compsets):
-            print(compset.phase_record.phase_name, compset.phase_record.nonvacant_elements)
             el_idx = compset.phase_record.nonvacant_elements.index(str(self.species))
             if np.isnan(result[0]):
                 result[0] = 0

--- a/pycalphad/variables.py
+++ b/pycalphad/variables.py
@@ -223,6 +223,7 @@ def unpack_components(components: "Sequence[Component | Species | str]", dbf: Op
     1. Component objects, which are directly used
     2. Species objects, which will be converted to Component objects
     3. str objects, which will be resolved to a Component by:
+
         a) matching with the name of a Species object present in the Database, or
         b) by parsing the string via the Component constructor
 


### PR DESCRIPTION
This PR sets the groundwork for more formally distinguishing a `Component` from a `Species`. It is breaking for the public API of Workspace, and consumers of the private API for `pycalphad.core.utils.unpack_components`. We are making these breaking changes now, so future changes that implement generalized (non-pure-element) component support can be non-breaking or minimally breaking in public APIs.

The following changes are made:
1. Add `v.Component` class. This is similar to `Species`, but distinct because 1) `Species` are reserved to refer to phase constituents, and 2) `Species` are allowed to have charges
2. Rename `pycalphad.core.utils.unpack_components` to `unpack_species` to be more accurate
3. Add a `v.unpack_components` function to process components following documented rules comparable to those in commercial software packages
4. Modify `Workspace` API:
  4.1. Rename `Workspace.components`, which is a container of `Species`, objects to `Workspace.constituents`. `Workspace.constituents` automatically update when `Workspace.components` change. Currently the constituents are not used in the `Workspace` implementation and changes from users don't affect any calculations, but it might be possible to use this to suspend certain species. 
  4.2. Add `ComponentsList` and `ComponentsField` implementations `Workspace`, as a container of `Component` objects in `Workspace.components` with the ability to auto-populate from `Database` pure elements and update when the database changes.

What is _not_ in this PR is explicit support for non-pure element components as a basis for use in conditions, properties, etc. Non-pure element components is a driver for the `Component` object to exist, but support is not added here.