### PR TITLE
FIX: tdb: Export TDB with nested powers and non-integer exponents

### DIFF
--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -470,6 +470,12 @@ class TCPrinter(object):
     """
     Prints Thermo-Calc style function expressions.
     """
+
+    def __init__(self, if_incompatible='warn'):
+        if if_incompatible not in ('warn', 'raise', 'ignore', 'fix'):
+            raise ValueError('Incorrect options passed to \'if_incompatible\'. Valid args are \'raise\', \'warn\', or \'fix\'.')
+        self.if_incompatible = if_incompatible
+
     def doprint(self, expr):
         return self._print_Piecewise(expr)
 
@@ -511,7 +517,16 @@ class TCPrinter(object):
                     exponent = float(expr.args[1])
                     if exponent == int(exponent):
                         exponent = int(exponent)
+                    else:
+                        if self.if_incompatible in ('fix', 'raise'):
+                            raise DatabaseExportError(f'Non-integer exponents cannot be represented in TDB compatibility mode. Got: {expr}')
+                        elif self.if_incompatible == 'warn':
+                            warnings.warn(f'Ignoring that non-integer exponents cannot be represented in TDB compatibility mode. Got: {expr}')
                 except (TypeError, RuntimeError):
+                    if self.if_incompatible in ('fix', 'raise'):
+                        raise DatabaseExportError(f'Non-integer exponents cannot be represented in TDB compatibility mode. Got: {expr}')
+                    elif self.if_incompatible == 'warn':
+                        warnings.warn(f'Ignoring that non-integer exponents cannot be represented in TDB compatibility mode. Got: {expr}')
                     exponent = expr.args[1]
                 terms = argument + '**' + '(' + self._stringify_expr(exponent) + ')'
             return terms
@@ -692,8 +707,8 @@ def write_tdb(dbf, fd, groupby='subsystem', if_incompatible='warn'):
         The 'fix' option will rectify the incompatibilities e.g. through name mangling.
     """
     # Before writing anything, check that the TDB is valid and take the appropriate action if not
-    if if_incompatible not in ['warn', 'raise', 'ignore', 'fix']:
-        raise ValueError('Incorrect options passed to \'if_invalid\'. Valid args are \'raise\', \'warn\', or \'fix\'.')
+    if if_incompatible not in ('warn', 'raise', 'ignore', 'fix'):
+        raise ValueError('Incorrect options passed to \'if_incompatible\'. Valid args are \'raise\', \'warn\', or \'fix\'.')
     # Handle function names > 8 characters
     long_function_names = {k for k in dbf.symbols.keys() if len(k) > 8}
     if len(long_function_names) > 0:
@@ -863,7 +878,7 @@ def write_tdb(dbf, fd, groupby='subsystem', if_incompatible='warn'):
             # Non-piecewise parameters need to be wrapped to print correctly
             # Otherwise TC's TDB parser will fail
             paramx = Piecewise((paramx, And(v.T >= 1, v.T < 10000)))
-        exprx = TCPrinter().doprint(paramx).upper()
+        exprx = TCPrinter(if_incompatible=if_incompatible).doprint(paramx).upper()
         if ';' not in exprx:
             exprx += '; N'
         if param_to_write.diffusing_species != Species(None):

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -95,6 +95,20 @@ def test_export_import(load_database):
     test_dbf = load_database()
     assert Database.from_string(test_dbf.to_string(fmt='tdb'), fmt='tdb') == test_dbf
 
+def test_roundtrip_nested_powers():
+    "Round-trip with nested powers expression."
+    TDB = """
+    ELEMENT A FCC_A1 0 0 0 !
+
+    PHASE FCC_A1 % 1 1 !
+    CONSTITUENT FCC_A1 : A : !
+
+    PARAMETER G(FCC_A1,A;0) 1 ((3.49 * (1373 * T**(-1)))**(1.778 * (1473 * T**(-1))))**(0.926); 10000 N !
+    """
+    test_dbf = Database(TDB)
+    roundtrip_dbf = Database.from_string(test_dbf.to_string(fmt='tdb'), fmt='tdb')
+    assert roundtrip_dbf == test_dbf
+
 def test_incompatible_db_warns_by_default():
     "Symbol names too long for Thermo-Calc warn and write the database as given by default."
     test_dbf = Database.from_string(INVALID_TDB_STR, fmt='tdb')

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -95,6 +95,11 @@ def test_export_import(load_database):
     test_dbf = load_database()
     assert Database.from_string(test_dbf.to_string(fmt='tdb'), fmt='tdb') == test_dbf
 
+def test_bad_kwarg_raises():
+    "An invalid keyword argument passed to database export function will raise an exception."
+    with pytest.raises(ValueError):
+        Database().to_string(fmt='tdb', if_incompatible='invalid_keyword_argument')
+
 def test_roundtrip_nested_powers():
     "Round-trip with nested powers expression."
     TDB = """
@@ -887,6 +892,16 @@ def test_tc_printer_exp():
     test_expr = S('exp(-300T**(-1.0))')
     result = TCPrinter()._stringify_expr(test_expr)
     assert result == 'exp(-300*T**(-1))'
+
+def test_tc_printer_bad_kwarg():
+    "TCPrinter will raise if passed bad keyword arguments."
+    with pytest.raises(ValueError):
+        TCPrinter(if_incompatible='invalid_keyword')
+
+def test_tc_printer_raise_noninteger_exponent():
+    "TCPrinter will raise for non-integer exponents in compatibility mode."
+    with pytest.raises(DatabaseExportError):
+        TCPrinter(if_incompatible='raise')._stringify_expr(S('T**0.42'))
 
 @pytest.mark.filterwarnings("ignore:Ignoring that non-integer exponents*:UserWarning")
 def test_tc_printer_nested_mul_add():


### PR DESCRIPTION
This PR will make TDBs correctly export when expressions with nested powers (e.g., `a**x**y`) are in the TDB.

Example:
```python
from pycalphad import Database
dbf = Database("""
ELEMENT A FCC_A1 0 0 0 !

PHASE FCC_A1 % 1 1 !
CONSTITUENT FCC_A1 : A : !

PARAMETER G(FCC_A1,A;0) 1 ((3.49 * (1373 * T**(-1)))**(1.778 * (1473 * T**(-1))))**(0.926); 10000 N !
"""
)
print(dbf.to_string(fmt='tdb'))
```

Current Behavior (Wrong, truncating the non-integer exponent):
```
$ [snip]
PARAMETER G(FCC_A1,A;0) 1.0 ( 4791.77*T**(-1) )**(2618.994*T**(-1))**(0);
   10000.0 N !
```

New Behavior (Correct):
```
$ [snip]
PARAMETER G(FCC_A1,A;0) 1.0 ( ( 4791.77*T**(-1) )**(2618.994*T**(-1))
   )**(0.926); 10000.0 N !

```

In addition, the behavior for non-integer exponents is now controllable via the `if_incompatible` keyword argument, e.g., `Database.to_file(..., fmt='tdb', if_incompatible=...)`. If set to `ignore`, the new behavior is produced. If set to `warn` (still the default), the new behavior is produced but a warning is emitted. If set to `raise` or `fix`, a `DatabaseExportError` is raised (since `fix` cannot do anything for this incompatibility).