### PR TITLE
ENH: tdb: ParseException returns correct line numbers

### DIFF
--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -966,14 +966,13 @@ def read_tdb(dbf, fd):
     for command in commands:
         if len(command) == 0:
             continue
-        tokens = None
         try:
             tokens = grammar.parseString(command)
             _TDB_PROCESSOR[tokens[0]](dbf, *tokens[1:])
         except ParseException as e:
             # pyparsing is only given one line at a time, so we modify
             # the exception metadata to correspond with the original input
-            err_char_idx = char_idx + e.column
+            err_char_idx = char_idx + (e.column - 1) # e.column is an index that starts at 1
             joinedlines = "\n".join(splitlines)
             e.pstr = joinedlines
             e.loc = err_char_idx

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -759,7 +759,7 @@ def test_tdb_parser_correct_lineno():
     with pytest.raises(ParseException) as excinfo:
         Database(UNTERMINATED_PARAM_STR)
     assert excinfo.value.lineno == 5
-    assert excinfo.value.column == 11
+    assert excinfo.value.column == 16
 
     # The third line has a ; instead of , character (see "[...]LI,LU;MG,MN[...]")
     INCORRECT_DELIMITER_STR = """PHASE LIQUID % 1 1 !
@@ -771,7 +771,7 @@ def test_tdb_parser_correct_lineno():
     with pytest.raises(ParseException) as excinfo:
         Database(INCORRECT_DELIMITER_STR)
     assert excinfo.value.lineno == 3
-    assert excinfo.value.column == 41
+    assert excinfo.value.column == 45
 
 @select_database("alfe.tdb")
 def test_load_database_when_given_in_lowercase(load_database):

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -745,6 +745,37 @@ def test_tdb_parser_raises_unterminated_parameters():
     with pytest.raises(ParseException):
         Database(UNTERMINATED_PARAM_STR)
 
+def test_tdb_parser_correct_lineno():
+    """Line number is correctly reported during a parser exception."""
+    # The PARAMETER G(BCC,FE:H;0) parameter is not terminated by an `!`.
+    # The parser merges all newlines until the `!`, meaning both parameters
+    # will be joined on one "line". The parser should raise an error.
+    UNTERMINATED_PARAM_STR = """     PARAMETER G(BCC,FE:H;0) 298.15  +GHSERFE+1.5*GHSERHH
+        +258000-3170*T+498*T*LN(T)-0.275*T**2; 1811.00  Y
+        +232264+82*T+1*GHSERFE+1.5*GHSERHH; 6000.00  N
+
+     PARAMETER G(BCC,FE:VA;0)      298.15 +GHSERFE; 6000 N ZIM !
+    """
+    try:
+        Database(UNTERMINATED_PARAM_STR)
+        assert False # should be unreachable because of raised exception
+    except ParseException as e:
+        assert e.lineno == 5
+        assert e.column == 12
+
+    # The third line has a ; instead of , character (see "[...]LI,LU;MG,MN[...]")
+    INCORRECT_DELIMITER_STR = """PHASE LIQUID % 1 1 !
+    CONSTITUENT LIQUID : AG,AL,AM,AS,AU,B,BA,BE,BI,C,CA,CD,CE,CO,CR,CS,CU,DY,ER,
+    EU,FE,GA,GD,GE,HF,HG,HO,IN,IR,K,LA,LI,LU;MG,MN,MO,N,NA,NB,ND,NI,NP,O,OS,P,PA,
+    PB,PD,PR,PT,PU,RB,RE,RH,RU,S,SB,SC,SE,SI,SM,SN,SR,TA,TB,TC,TE,TH,TI,TL,TM,U,V,
+    W,Y,YB,ZN,ZR : !
+    """
+    try:
+        Database(INCORRECT_DELIMITER_STR)
+        assert False # should be unreachable because of raised exception
+    except ParseException as e:
+        assert e.lineno == 3
+        assert e.column == 42
 
 @select_database("alfe.tdb")
 def test_load_database_when_given_in_lowercase(load_database):

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -761,7 +761,7 @@ def test_tdb_parser_correct_lineno():
         assert False # should be unreachable because of raised exception
     except ParseException as e:
         assert e.lineno == 5
-        assert e.column == 12
+        assert e.column == 11
 
     # The third line has a ; instead of , character (see "[...]LI,LU;MG,MN[...]")
     INCORRECT_DELIMITER_STR = """PHASE LIQUID % 1 1 !
@@ -775,7 +775,7 @@ def test_tdb_parser_correct_lineno():
         assert False # should be unreachable because of raised exception
     except ParseException as e:
         assert e.lineno == 3
-        assert e.column == 42
+        assert e.column == 41
 
 @select_database("alfe.tdb")
 def test_load_database_when_given_in_lowercase(load_database):

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -756,12 +756,10 @@ def test_tdb_parser_correct_lineno():
 
      PARAMETER G(BCC,FE:VA;0)      298.15 +GHSERFE; 6000 N ZIM !
     """
-    try:
+    with pytest.raises(ParseException) as excinfo:
         Database(UNTERMINATED_PARAM_STR)
-        assert False # should be unreachable because of raised exception
-    except ParseException as e:
-        assert e.lineno == 5
-        assert e.column == 11
+    assert excinfo.value.lineno == 5
+    assert excinfo.value.column == 11
 
     # The third line has a ; instead of , character (see "[...]LI,LU;MG,MN[...]")
     INCORRECT_DELIMITER_STR = """PHASE LIQUID % 1 1 !
@@ -770,12 +768,10 @@ def test_tdb_parser_correct_lineno():
     PB,PD,PR,PT,PU,RB,RE,RH,RU,S,SB,SC,SE,SI,SM,SN,SR,TA,TB,TC,TE,TH,TI,TL,TM,U,V,
     W,Y,YB,ZN,ZR : !
     """
-    try:
+    with pytest.raises(ParseException) as excinfo:
         Database(INCORRECT_DELIMITER_STR)
-        assert False # should be unreachable because of raised exception
-    except ParseException as e:
-        assert e.lineno == 3
-        assert e.column == 41
+    assert excinfo.value.lineno == 3
+    assert excinfo.value.column == 41
 
 @select_database("alfe.tdb")
 def test_load_database_when_given_in_lowercase(load_database):


### PR DESCRIPTION
In the TDB parser, the pyparsing grammar only sees one command-delimited (`!`-delimited) line at a time. In the event of a parser exception, the error reporting metadata incorrectly returns a line number of 1.

This PR modifies the `ParseException` object raised by the parser to refer to the (almost) original input text. We also take the opportunity to shorten the error message returned by the string representation of the object. To ensure the column number printed in the error message aligns with the input text, we remove some pre-processing of the text where whitespace was stripped (the pyparsing grammar for TDB already skips whitespace).

### Example
```python
from pycalphad import Database
Database("""     PARAMETER G(BCC,FE:H;0) 298.15  +GHSERFE+1.5*GHSERHH
        +258000-3170*T+498*T*LN(T)-0.275*T**2; 1811.00  Y
        +232264+82*T+1*GHSERFE+1.5*GHSERHH; 6000.00  N

     PARAMETER G(BCC,FE:VA;0)      298.15 +GHSERFE; 6000 N ZIM !
""")
```

### Current Behavior (`develop`)
```
Failed while parsing: PARAMETER G(BCC,FE:H;0) 298.15 +GHSERFE+1.5*GHSERHH +258000-3170*T+498*T*LN(T)-0.275*T**2; 1811.00 Y +232264+82*T+1*GHSERFE+1.5*GHSERHH; 6000.00 N  PARAMETER G(BCC,FE:VA;0) 298.15 +GHSERFE; 6000 N ZIM 
Tokens: None
[omit full traceback]
pyparsing.exceptions.ParseException: Expected {{'ELEMENT' W:(-/A-Za-z){1,2} W:(()-/-:A-Z_a-z) Re:('[-+]?([0-9]+\.(?!([0-9]|[eE])))|([0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)') Re:('[-+]?([0-9]+\.(?!([0-9]|[eE])))|([0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)') Re:('[-+]?([0-9]+\.(?!([0-9]|[eE])))|([0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)') LineEnd} | {'SPECIES' W:(*+--9A-Z_a-z) [Suppress:('%')] Group:({{W:(A-Za-z){1,2} [Re:('[-+]?([0-9]+\.(?!([0-9]|[eE])))|([0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)')]}}...) [Suppress:('/') W:(+-0-9)] LineEnd} | {'TYPE_DEFINITION' Suppress:(<SP><TAB><CR><LF>) !W:( !) SkipTo:(LineEnd)} | {'FUNCTION' W:(()-/-:A-Z_a-z) {{Re:('[-+]?([0-9]+\.(?!([0-9]|[eE])))|([0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)') | [',']...} {{SkipTo:(';') Suppress:(';') [Suppress:(',')]... [Re:('[-+]?([0-9]+\.(?!([0-9]|[eE])))|([0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)')] Suppress:([(Yy)])}}... Suppress:([(Nn)])} [Suppress:(W:(-0-:A-Z_a-z))] LineEnd} | {'ASSESSED_SYSTEMS' SkipTo:(LineEnd)} | {'DEFINE_SYSTEM_DEFAULT' SkipTo:(LineEnd)} | {'DEFAULT_COMMAND' SkipTo:(LineEnd)} | {'DATABASE_INFO' SkipTo:(LineEnd)} | {'VERSION_DATE' SkipTo:(LineEnd)} | {'REFERENCE_FILE' SkipTo:(LineEnd)} | {'ADD_REFERENCES' SkipTo:(LineEnd)} | {'LIST_OF_REFERENCES' SkipTo:(LineEnd)} | {'TEMPERATURE_LIMITS' SkipTo:(LineEnd)} | {'PHASE' W:(()-/-:A-Z_a-z) Suppress:(<SP><TAB><CR><LF>) !W:( !) Suppress:(<SP><TAB><CR><LF>) Suppress:(W:(0-9)) Group:({Re:('[-+]?([0-9]+\.(?!([0-9]|[eE])))|([0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)')}...) Suppress:(SkipTo:(LineEnd))} | {'CONSTITUENT' W:(()-/-:A-Z_a-z) Suppress:(<SP><TAB><CR><LF>) Suppress:(':') Group:(Group:({{[Suppress:(',')] W:(*+--9A-Z_a-z) [Suppress:('%')]}}...) [: Group:({{[Suppress:(',')] W:(*+--9A-Z_a-z) [Suppress:('%')]}}...)]...) Suppress:(':') LineEnd} | {'PARAMETER' {'BMAGN' | 'DF' | 'DQ' | 'ELRS' | 'G' | 'GD' | 'L' | 'MF' | 'MQ' | 'NT' | 'SIGM' | 'TC' | 'THCD' | 'THETA' | 'V0' | 'VA' | 'VC' | 'VISC' | 'VK' | 'VS' | 'XI'} Suppress:('(') W:(()-/-:A-Z_a-z) [Suppress:('&') W:(-/A-Za-z){1,2}] Suppress:(',') Group:(Group:({{[Suppress:(',')] W:(*+--9A-Z_a-z) [Suppress:('%')]}}...) [: Group:({{[Suppress:(',')] W:(*+--9A-Z_a-z) [Suppress:('%')]}}...)]...) [Suppress:(';') W:(0-9)] Suppress:(')') {{Re:('[-+]?([0-9]+\.(?!([0-9]|[eE])))|([0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)') | [',']...} {{SkipTo:(';') Suppress:(';') [Suppress:(',')]... [Re:('[-+]?([0-9]+\.(?!([0-9]|[eE])))|([0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)')] Suppress:([(Yy)])}}... Suppress:([(Nn)])} [Suppress:(W:(-0-:A-Z_a-z))] LineEnd} | {'ZEROVOLUME_SPECIES' SkipTo:(LineEnd)} | {'DIFFUSION' SkipTo:(LineEnd)}}, found 'G'  (at char 158), (line:1, col:159)

```

### New Behavior
```
[omit full traceback]
pyparsing.exceptions.ParseException: Invalid TDB syntax.
     PARAMETER G(BCC,FE:H;0) 298.15  +GHSERFE+1.5*GHSERHH         +258000-3170*T+498*T*LN(T)-0.275*T**2; 1811.00  Y         +232264+82*T+1*GHSERFE+1.5*GHSERHH; 6000.00  N       PARAMETER G(BCC,FE:VA;0)      298.15 +GHSERFE; 6000 N ZIM 
                                                                                                                                                                                           ^, found 'G'  (at char 187), (line:5, col:16)
```

Note for this example we might say that returning an error at the end of line 3 would be more intuitive for the user, and that would be correct; for this case the parser cannot distinguish between a missing command delimiter and a reference key designation until encountering the `G` character (after the space) in the next full line. If we improve the grammar to distinguish these cases, the error message will automatically become more useful.