### PR TITLE
ENH: Mapping: Small performance fix

### DIFF
--- a/pycalphad/core/phase_rec.pyx
+++ b/pycalphad/core/phase_rec.pyx
@@ -222,8 +222,9 @@ cdef public class PhaseRecord(object)[type PhaseRecordType, object PhaseRecordOb
         cdef int i
         cdef int num_inps = dof.shape[0]
         cdef int num_dof = self.num_statevars + self.phase_dof + self.parameters.shape[0]
+        cdef void* callptr = self.function_factory.get_func(property_name)
         for i in range(num_inps):
-           (<FastFunction>self.function_factory.get_func(property_name)).call(&outp[i], &dof_concat[i * num_dof])
+           (<FastFunction>callptr).call(&outp[i], &dof_concat[i * num_dof])
         if self.parameters.shape[0] > 0:
             free(dof_concat)
 


### PR DESCRIPTION
This PR moves `FastFunctionFactory.getfunc()` out of a tight loop inside of `PhaseRecord.prop_2d()`. Despite hitting the cache, it seems that `getfunc()` takes appreciable time and, for large numbers of inputs (`num_imps`), it can become as much as 40% of the runtime of that function. For large values of `pdens` (such as the value 500, used by default inside of mapping), this significantly impacts the `calculate` function.

On my laptop, this change shaves a few seconds off the mapping tests.