### PR TITLE
ENH: Workspace: Suspend attribute dependency updates during init

### DIFF
--- a/pycalphad/codegen/phase_record_factory.py
+++ b/pycalphad/codegen/phase_record_factory.py
@@ -27,7 +27,7 @@ class PhaseRecordFactory(object):
         if len(new_param_values.shape) > 1:
             new_param_values = new_param_values[0]
         if new_param_symbols != self.param_symbols:
-            raise ValueError('Parameter symbol misatch')
+            raise ValueError('Parameter symbol mismatch')
         self.param_values[:] = new_param_values
 
     @lru_cache()

--- a/pycalphad/core/conditions.py
+++ b/pycalphad/core/conditions.py
@@ -127,7 +127,7 @@ class Conditions:
         if isinstance(prop, (v.MoleFraction, v.MassFraction, v.ChemicalPotential)) and prop.species not in self._wks.components:
             raise ConditionError('{} refers to non-existent component'.format(prop))
 
-        if isinstance(prop, v.SiteFraction) and prop not in self._wks.phase_record_factory[prop.phase_name].variables:
+        if isinstance(prop, v.SiteFraction) and prop not in self._wks.models[prop.phase_name].variables:
             raise ConditionError('{} refers to non-existent constituent'.format(prop))
 
         if (prop == v.N) and np.any(value != Q_(1.0, 'mol')):

--- a/pycalphad/core/eqsolver.pyx
+++ b/pycalphad/core/eqsolver.pyx
@@ -111,7 +111,7 @@ def add_nearly_stable(object composition_sets, object phase_records,
         if phase_name in entered_phases:
             continue
         phase_record = phase_records[phase_name]
-        phase_indices = grid.attrs['phase_indices'][phase_name]
+        phase_indices = grid.attrs['phase_indices'].get(phase_name, slice(0,0))
         if phase_indices.start == phase_indices.stop:
             # Phase has zero feasible grid points to consider
             continue

--- a/pycalphad/core/lower_convex_hull.py
+++ b/pycalphad/core/lower_convex_hull.py
@@ -166,7 +166,8 @@ def lower_convex_hull(global_grid, state_variables, conds_keys, phase_record_fac
         points = result_array_points_values[it.multi_index]
         result_array_Phase_values[it.multi_index][:num_comps] = global_grid_Phase_values[grid_index].take(points, axis=0)[:num_comps]
         result_array_X_values[it.multi_index][:num_comps] = global_grid_X_values[grid_index].take(points, axis=0)[:num_comps]
-        result_array_Y_values[it.multi_index][:num_comps] = global_grid_Y_values[grid_index].take(points, axis=0)[:num_comps]
+        result_array_Y_values[it.multi_index][:num_comps,:global_grid_Y_values.shape[-1]] = \
+            global_grid_Y_values[grid_index].take(points, axis=0)[:num_comps]
         # Special case: Sometimes fictitious points slip into the result
         if '_FAKE_' in result_array_Phase_values[it.multi_index]:
             new_energy = 0.

--- a/pycalphad/core/solver.py
+++ b/pycalphad/core/solver.py
@@ -64,7 +64,8 @@ class Solver(SolverBase):
         for compset in compsets:
             phase_local_conditions = {key: value for key, value in local_conditions.items()
                                       if compset.phase_record.phase_name == key.phase_name}
-            compset.set_local_conditions(phase_local_conditions)
+            if len(phase_local_conditions) > 0:
+                compset.set_local_conditions(phase_local_conditions)
         for cond, value in conditions.items():
             if isinstance(cond, MoleFraction) and cond.phase_name is None:
                 el = str(cond)[2:]

--- a/pycalphad/core/utils.py
+++ b/pycalphad/core/utils.py
@@ -332,7 +332,12 @@ def extract_parameters(parameters):
     tuple
         Tuple of parameter symbols (list) and parameter values (parameter_array_length, # parameters)
     """
-    parameter_array_lengths = set(np.atleast_1d(val).size for val in parameters.values())
+    parameter_array_lengths = set()
+    for val in parameters.values():
+        if isinstance(val, (float, int)):
+            parameter_array_lengths.add(1)
+        else:
+            parameter_array_lengths.add(len(val))
     if len(parameter_array_lengths) > 1:
         raise ValueError('parameters kwarg does not contain arrays of equal length')
     if len(parameters) > 0:

--- a/pycalphad/core/workspace.py
+++ b/pycalphad/core/workspace.py
@@ -280,7 +280,7 @@ class Workspace:
     # eq is set by a callback in the EquilibriumCalculationField (TypedField)
     eq: Optional[LightDataset] = EquilibriumCalculationField(depends_on=['phase_record_factory', 'conditions', 'calc_opts', 'solver'])
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, database=None, components=None, phases=None, conditions=None, *, **kwargs):
         self._suspend_dependency_updates = True
         self._eq = None # manually initialized since we don't initialize the public name 'eq' (see below)
         # Assume positional arguments are specified in class typed-attribute definition order

--- a/pycalphad/core/workspace.py
+++ b/pycalphad/core/workspace.py
@@ -231,6 +231,13 @@ class PRFField(TypedField):
     def on_dependency_update(self, obj, updated_attribute, old_val, new_val):
         if obj._suspend_dependency_updates:
             return
+        # changes in conditions values (as opposed to keys) do not affect the PhaseRecordFactory
+        if updated_attribute == 'conditions' and (old_val is not None) and \
+            (set(old_val.keys()) == set(new_val.keys())):
+            # call the 'conditions' callbacks because we won't trigger our own __set__ to do it
+            for cb in obj._callbacks[updated_attribute]:
+                cb(obj, self.public_name, old_val, new_val)
+            return
         self.__set__(obj, self.default_factory(obj))
 
 class SolverField(TypedField):

--- a/pycalphad/core/workspace.py
+++ b/pycalphad/core/workspace.py
@@ -280,7 +280,7 @@ class Workspace:
     # eq is set by a callback in the EquilibriumCalculationField (TypedField)
     eq: Optional[LightDataset] = EquilibriumCalculationField(depends_on=['phase_record_factory', 'conditions', 'calc_opts', 'solver'])
 
-    def __init__(self, database=None, components=None, phases=None, conditions=None, *, **kwargs):
+    def __init__(self, *args, **kwargs):
         self._suspend_dependency_updates = True
         self._eq = None # manually initialized since we don't initialize the public name 'eq' (see below)
         # Assume positional arguments are specified in class typed-attribute definition order

--- a/pycalphad/property_framework/metaproperties.py
+++ b/pycalphad/property_framework/metaproperties.py
@@ -11,7 +11,15 @@ import numpy as np
 from copy import copy
 
 def find_first_compset(phase_name: str, wks: "Workspace"):
-    for _, compsets in wks.enumerate_composition_sets():
+    if phase_name in wks.phases:
+        for _, compsets in wks.enumerate_composition_sets():
+            for compset in compsets:
+                if compset.phase_record.phase_name == phase_name:
+                    return compset
+    # couldn't find one in the existing workspace; create a single-phase calculation and try again
+    copy_wks = wks.copy()
+    copy_wks.phases = [phase_name]
+    for _, compsets in copy_wks.enumerate_composition_sets():
         for compset in compsets:
             if compset.phase_record.phase_name == phase_name:
                 return compset

--- a/pycalphad/tests/test_workspace.py
+++ b/pycalphad/tests/test_workspace.py
@@ -97,6 +97,16 @@ def test_tzero_property(load_database):
     assert_allclose(t0_composition, 0.86119, atol=my_tzero.residual_tol)
 
 @select_database("alzn_mey.tdb")
+def test_isolated_phase_with_suspended_parent(load_database):
+    dbf = load_database()
+    wks = Workspace(database=dbf, components=['AL', 'ZN', 'VA'], phases=['FCC_A1'],
+                    conditions={v.N: 1, v.P: 1e5, v.T: 600, v.X('ZN'): 0.3})
+    # liquid is not entered in the parent workspace
+    iph = IsolatedPhase('LIQUID', wks=wks)
+    energy = wks.get(iph('GM'))
+    assert not np.any(np.isnan(energy))
+
+@select_database("alzn_mey.tdb")
 def test_jansson_derivative_binary_temperature(load_database):
     dbf = load_database()
     wks = Workspace(database=dbf, components=['AL', 'ZN', 'VA'], phases=['FCC_A1', 'HCP_A3', 'LIQUID'],

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         # gives the C++ SymEngine library, while conda-forge/python-symengine
         # provides the Python package called `symengine`.
         'Cython' if os.getenv('CYTHON_COVERAGE', False) else '', # required for Cython test coverage
-        'matplotlib>=3.3',
+        'matplotlib>=3.3,!=3.9.1', # https://github.com/matplotlib/matplotlib/issues/28551#issuecomment-2267563049
         'numpy>=1.13',
         'pint',
         'pyparsing>=2.4',

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         # gives the C++ SymEngine library, while conda-forge/python-symengine
         # provides the Python package called `symengine`.
         'Cython' if os.getenv('CYTHON_COVERAGE', False) else '', # required for Cython test coverage
-        'matplotlib>=3.3,!=3.9.1', # https://github.com/matplotlib/matplotlib/issues/28551#issuecomment-2267563049
+        'matplotlib>=3.3',
         'numpy>=1.13',
         'pint',
         'pyparsing>=2.4',


### PR DESCRIPTION
This PR changes how Workspace objects are initialized, to ensure that each attribute is initialized after its dependencies (`database` before `models`, `parameters` before `phase_record_factory`, etc). It also suspends dependency callbacks inside of `Workspace.__init__` to avoid calls to the `default_factory` of attributes that will be overwritten again later in initialization.

For the worst case of a user passing in fully-initialized attributes to the constructor of a Workspace object, with pre-computed `models` and `phase_record_factory` (a common case inside of ESPEI and any other software calling pycalphad in a high-throughput loop), this PR should substantially improve performance.

We can be a little smarter still, by eliding dependency updates for cases where the change in the dependency doesn't actually affect the dependent object; for example, `phase_record_factory` only really depends on the keys of `conditions`, not the values, so we check for that in `PRFField.on_dependency_update` and avoid rebuilding it if they haven't changed.