### PR TITLE
FIX: fix wildcard support

### DIFF
--- a/pycalphad/core/workspace.py
+++ b/pycalphad/core/workspace.py
@@ -326,7 +326,8 @@ class Workspace:
                 additional_args = args[i].expand_wildcard(phase_names=phase_names)
                 args.extend(additional_args)
             elif hasattr(args[i], 'sublattice_index') and args[i].sublattice_index == '*':
-                # We need to resolve sublattice_index before species to ensure we get the correct set of components
+                # We need to resolve sublattice_index before species to ensure we
+                # get the correct set of phase constituents for each sublattice
                 indices_to_delete.append(i)
                 sublattice_indices = sorted(set([x.sublattice_index for x in self.phase_record_factory[args[i].phase_name].variables]))
                 additional_args = args[i].expand_wildcard(sublattice_indices=sublattice_indices)

--- a/pycalphad/core/workspace.py
+++ b/pycalphad/core/workspace.py
@@ -325,6 +325,12 @@ class Workspace:
                 phase_names = sorted(self.phase_record_factory.keys())
                 additional_args = args[i].expand_wildcard(phase_names=phase_names)
                 args.extend(additional_args)
+            elif hasattr(args[i], 'sublattice_index') and args[i].sublattice_index == '*':
+                # We need to resolve sublattice_index before species to ensure we get the correct set of components
+                indices_to_delete.append(i)
+                sublattice_indices = sorted(set([x.sublattice_index for x in self.phase_record_factory[args[i].phase_name].variables]))
+                additional_args = args[i].expand_wildcard(sublattice_indices=sublattice_indices)
+                args.extend(additional_args)
             elif hasattr(args[i], 'species') and args[i].species == v.Species('*'):
                 indices_to_delete.append(i)
                 internal_to_phase = hasattr(args[i], 'sublattice_index')
@@ -336,8 +342,6 @@ class Workspace:
                     components = [comp for comp in self.phase_record_factory.nonvacant_elements]
                 additional_args = args[i].expand_wildcard(components=components)
                 args.extend(additional_args)
-            elif hasattr(args[i], 'sublattice_index') and args[i].sublattice_index == v.Species('*'):
-                raise ValueError('Wildcard not yet supported in sublattice index')
             elif isinstance(args[i], JanssonDerivative):
                 numerator_args = [args[i].numerator]
                 self._expand_property_arguments(numerator_args)

--- a/pycalphad/core/workspace.py
+++ b/pycalphad/core/workspace.py
@@ -332,7 +332,8 @@ class Workspace:
                     components = [x for x in self.phase_record_factory[args[i].phase_name].variables
                                   if x.sublattice_index == args[i].sublattice_index]
                 else:
-                    components = self.components
+                    # TODO: self.components with proper Components support
+                    components = [comp for comp in self.phase_record_factory.nonvacant_elements]
                 additional_args = args[i].expand_wildcard(components=components)
                 args.extend(additional_args)
             elif hasattr(args[i], 'sublattice_index') and args[i].sublattice_index == v.Species('*'):
@@ -358,7 +359,7 @@ class Workspace:
                     additional_args = args[i].expand_wildcard(phase_names=additional_phase_names)
                     args.extend(additional_args)
             i += 1
-        
+
         # Watch deletion order! Indices will change as items are deleted
         for deletion_index in reversed(indices_to_delete):
             del args[deletion_index]
@@ -440,7 +441,7 @@ class Workspace:
                                         [np.asarray(self.eq.coords[b][a], dtype=np.float64)
                                         for a, b in zip(index, str_conds_keys)]))
             chemical_potentials = prop_MU_values[index]
-            
+
             for arg in args:
                 prop_implementation_units, prop_display_units = arg_units[arg]
                 context = unit_conversion_context(composition_sets, arg)
@@ -467,5 +468,3 @@ class Workspace:
 
     def copy(self):
         return copy(self)
-
-

--- a/pycalphad/core/workspace.py
+++ b/pycalphad/core/workspace.py
@@ -329,7 +329,7 @@ class Workspace:
                 indices_to_delete.append(i)
                 internal_to_phase = hasattr(args[i], 'sublattice_index')
                 if internal_to_phase:
-                    components = [x for x in self.phase_record_factory[args[i].phase_name].variables
+                    components = [x.species for x in self.phase_record_factory[args[i].phase_name].variables
                                   if x.sublattice_index == args[i].sublattice_index]
                 else:
                     # TODO: self.components with proper Components support

--- a/pycalphad/tests/test_workspace.py
+++ b/pycalphad/tests/test_workspace.py
@@ -241,10 +241,18 @@ def test_component_wildcards(load_database):
     chempots = wks.get("MU(*)")
     np.testing.assert_almost_equal([-9949.7314137, -43634.7588925], chempots)
     # site fraction expansions _should_ have species
-    Y0_fracs = wks.get("Y(FCC_A1,0,*)")  # CU,MG
-    Y1_fracs = wks.get("Y(FCC_A1,1,*)")  # VA
-    np.testing.assert_almost_equal([0.998168, 0.001832], Y0_fracs)
-    np.testing.assert_almost_equal([1.0], Y1_fracs)
+    Y_fracs = wks.get("Y(FCC_A1,0,*)")  # FCC CU,MG
+    np.testing.assert_almost_equal([0.998168, 0.001832], Y_fracs)
+    Y_fracs = wks.get("Y(FCC_A1,*,*)")  # FCC CU,MG,VA
+    np.testing.assert_almost_equal([0.998168, 0.001832, 1.0], Y_fracs)
+    # change phases to simplify phase expansion
+    wks.phases = ["FCC_A1", "LIQUID", "CU2MG"]
+    Y_fracs = wks.get("Y(*,*,*)")
+    np.testing.assert_almost_equal([
+        1.0, 1.6126622e-12, 1.1836675e-06, 9.9999882e-01,  # CU2MG CU,MG:CU,MG
+        0.998168, 0.001832, 1.0,                           # FCC_A1 CU,MG:VA
+        np.nan, np.nan,                                           # LIQUID CU,MG
+        ], Y_fracs)
 
 @pytest.mark.solver
 @select_database("cumg.tdb")

--- a/pycalphad/tests/test_workspace.py
+++ b/pycalphad/tests/test_workspace.py
@@ -235,10 +235,16 @@ def test_component_wildcards(load_database):
     components = ["CU", "MG", "VA"]
     phases = list(dbf.phases.keys())
     wks = Workspace(dbf, components, phases, {v.N:1, v.P:1e5, v.T:300, v.X("MG"): 0.25})
+    # expansions for component properties
     X_fracs = wks.get("X(*)")
     np.testing.assert_almost_equal([0.75, 0.25], X_fracs)
     chempots = wks.get("MU(*)")
     np.testing.assert_almost_equal([-9949.7314137, -43634.7588925], chempots)
+    # site fraction expansions _should_ have species
+    Y0_fracs = wks.get("Y(FCC_A1,0,*)")  # CU,MG
+    Y1_fracs = wks.get("Y(FCC_A1,1,*)")  # VA
+    np.testing.assert_almost_equal([0.998168, 0.001832], Y0_fracs)
+    np.testing.assert_almost_equal([1.0], Y1_fracs)
 
 @pytest.mark.solver
 @select_database("cumg.tdb")

--- a/pycalphad/tests/test_workspace.py
+++ b/pycalphad/tests/test_workspace.py
@@ -228,6 +228,18 @@ def test_miscibility_gap_cpf_specifier(load_database):
     fcc_3 = wks.get('X(FCC_A1#3,ZN)')
     assert np.isnan(fcc_3)
 
+@select_database("cumg.tdb")
+def test_component_wildcards(load_database):
+    """Wildcards of properties that depend on components should expand without phase constituent Species like vacancies"""
+    dbf = load_database()
+    components = ["CU", "MG", "VA"]
+    phases = list(dbf.phases.keys())
+    wks = Workspace(dbf, components, phases, {v.N:1, v.P:1e5, v.T:300, v.X("MG"): 0.25})
+    X_fracs = wks.get("X(*)")
+    np.testing.assert_almost_equal([0.75, 0.25], X_fracs)
+    chempots = wks.get("MU(*)")
+    np.testing.assert_almost_equal([-9949.7314137, -43634.7588925], chempots)
+
 @pytest.mark.solver
 @select_database("cumg.tdb")
 def test_site_fraction_conditions(load_database):

--- a/pycalphad/variables.py
+++ b/pycalphad/variables.py
@@ -350,7 +350,7 @@ class MoleFraction(StateVariable):
         super().__init__(varname)
         self.phase_name = phase_name
         self.species = species
-    
+
     def expand_wildcard(self, phase_names=None, components=None):
         if phase_names is not None:
             return [self.__class__(phase_name, self.species) for phase_name in phase_names]
@@ -361,7 +361,7 @@ class MoleFraction(StateVariable):
                 return [self.__class__(self.phase_name, comp) for comp in components]
         else:
             raise ValueError('Both phase_names and components are None')
-    
+
     def compute_property(self, compsets, cur_conds, chemical_potentials):
         result = np.atleast_1d(np.zeros(self.shape))
         result[:] = np.nan

--- a/pycalphad/variables.py
+++ b/pycalphad/variables.py
@@ -233,7 +233,10 @@ class SiteFraction(StateVariable):
         #pylint: disable=E1121
         super().__init__(varname)
         self.phase_name = phase_name.upper()
-        self.sublattice_index = int(subl_index)
+        if subl_index == '*':
+            self.sublattice_index = '*'
+        else:
+            self.sublattice_index = int(subl_index)
         self.species = Species(species)
         if '#' in phase_name:
             self._self_without_suffix = self.__class__(self.phase_name_without_suffix, subl_index, species)
@@ -242,8 +245,11 @@ class SiteFraction(StateVariable):
 
     def compute_property(self, compsets, cur_conds, chemical_potentials):
         state_variables = compsets[0].phase_record.state_variables
-        result = np.atleast_1d(np.zeros(self.shape))
+        result = np.atleast_1d(np.full(self.shape, fill_value=np.nan))
         for _, compset in self.filtered(compsets):
+            # we'll only hit this code path if this phase is in the stable set
+            if np.all(np.isnan(result)):
+                result[0] = 0.0
             site_fractions = compset.phase_record.variables
             sitefrac_idx = site_fractions.index(self._self_without_suffix)
             result[0] += compset.dof[len(state_variables)+sitefrac_idx]
@@ -270,20 +276,24 @@ class SiteFraction(StateVariable):
             return [self.__class__(phase_name, self.sublattice_index, self.species) for phase_name in phase_names]
         elif components is not None:
             return [self.__class__(self.phase_name, self.sublattice_index, comp) for comp in components]
+        elif sublattice_indices is not None:
+            return [self.__class__(self.phase_name, idx, self.species) for idx in sublattice_indices]
         else:
             raise ValueError('All arguments are None')
 
     def _latex(self, printer=None):
         "LaTeX representation."
-        #pylint: disable=E1101
         return r'y^{\mathrm{'+self.phase_name.replace('_', '-') + \
             '}}_{'+str(self.sublattice_index)+r',\mathrm{'+self.species.escaped_name+'}}'
 
     def __str__(self):
         "String representation."
-        #pylint: disable=E1101
-        return 'Y(%s,%d,%s)' % \
-            (self.phase_name, self.sublattice_index, self.species.escaped_name)
+        if self.sublattice_index == '*':
+            return 'Y(%s,%s,%s)' % \
+                (self.phase_name, self.sublattice_index, self.species.escaped_name)
+        else:
+            return 'Y(%s,%d,%s)' % \
+                (self.phase_name, self.sublattice_index, self.species.escaped_name)
 
 class PhaseFraction(StateVariable):
     """

--- a/pycalphad/variables.py
+++ b/pycalphad/variables.py
@@ -627,6 +627,9 @@ class ChemicalPotential(StateVariable):
         super().__init__(varname)
         self.species = species
 
+    def expand_wildcard(self, components):
+        return [self.__class__(comp) for comp in components]
+
     def compute_property(self, compsets, cur_conds, chemical_potentials):
         phase_record = compsets[0].phase_record
         el_indices = [(phase_record.nonvacant_elements.index(k), v)

--- a/pycalphad/variables.py
+++ b/pycalphad/variables.py
@@ -247,7 +247,7 @@ class SiteFraction(StateVariable):
         state_variables = compsets[0].phase_record.state_variables
         result = np.atleast_1d(np.full(self.shape, fill_value=np.nan))
         for _, compset in self.filtered(compsets):
-            # we'll only hit this code path if this phase is in the stable set
+            # we'll only hit this code path if this phase is present in the list of compsets
             if np.all(np.isnan(result)):
                 result[0] = 0.0
             site_fractions = compset.phase_record.variables


### PR DESCRIPTION
Fixes the following cases with a test:
- Fixes wildcard expansion on components (for properties without a sublattice index) to expand on non-vacant pure elements. With proper component support, we would go back to using `self.components`, but currently `self.components` contain all phase constituents, including, for example, vacancies
- Adds `expand_wildcard` on components for chemical potentials
- Fixes wildcard expansion for properties where expansions are on phase constituents, such as site fractions
- Adds support for wildcard expansion on sublattice indices (required adding `sublattice index = '*'` as valid).
- Change behavior of compute_property for site fractions to return NaN if the phase is not stable (previously we were returning zero)