### PR TITLE
TST: Revise ambiguous test description and conditions

### DIFF
--- a/pycalphad/tests/test_equilibrium.py
+++ b/pycalphad/tests/test_equilibrium.py
@@ -1015,7 +1015,7 @@ def test_eq_charge_ndzro(load_database):
                                 6.61821340e-03, 1.00000000e+00, 1.39970285e-03, 9.98600297e-01], rtol=5e-4)
 
 @pytest.mark.solver
-def test_issue_503_charged_infeasible_subsystem():
+def test_issue_503_suspend_pure_vacancy_configuration():
     "equilibrium suspends a phase with a pure-vacancy endmember as the only feasible configuration (gh-503)"
     tdb = """
  ELEMENT /-   ELECTRON_GAS              0.0000E+00  0.0000E+00  0.0000E+00!

--- a/pycalphad/tests/test_equilibrium.py
+++ b/pycalphad/tests/test_equilibrium.py
@@ -1016,7 +1016,7 @@ def test_eq_charge_ndzro(load_database):
 
 @pytest.mark.solver
 def test_issue_503_charged_infeasible_subsystem():
-    "equilibrium suspends a phase with zero feasible points due to internal constraints"
+    "equilibrium suspends a phase with a pure-vacancy endmember as the only feasible configuration (gh-503)"
     tdb = """
  ELEMENT /-   ELECTRON_GAS              0.0000E+00  0.0000E+00  0.0000E+00!
  ELEMENT VA   VACUUM                    0.0000E+00  0.0000E+00  0.0000E+00!

--- a/pycalphad/tests/test_workspace.py
+++ b/pycalphad/tests/test_workspace.py
@@ -325,8 +325,8 @@ def test_jansson_derivative_chempot_condition(load_database):
     np.testing.assert_almost_equal(molefrac1, 0.3)
     np.testing.assert_almost_equal(result2, (molefrac2 - molefrac1) / 1.0, decimal=2)
 
-def test_suspend_phase_infeasible_internal_constraints():
-    "Phases that cannot satisfy internal constraints are correctly suspended"
+def test_issue_503_suspend_phase_infeasible_internal_constraints():
+    "Phases that cannot satisfy internal constraints are correctly suspended (gh-503)"
     TDB = """
     ELEMENT /-   ELECTRON_GAS              0.0000E+00  0.0000E+00  0.0000E+00!
     ELEMENT VA   VACUUM                    0.0000E+00  0.0000E+00  0.0000E+00!

--- a/pycalphad/tests/test_workspace.py
+++ b/pycalphad/tests/test_workspace.py
@@ -325,8 +325,8 @@ def test_jansson_derivative_chempot_condition(load_database):
     np.testing.assert_almost_equal(molefrac1, 0.3)
     np.testing.assert_almost_equal(result2, (molefrac2 - molefrac1) / 1.0, decimal=2)
 
-def test_issue_503_pure_vacancy_charge_balance():
-    "Pure vacancy phases are correctly suspended (gh-503)"
+def test_suspend_phase_infeasible_internal_constraints():
+    "Phases that cannot satisfy internal constraints are correctly suspended"
     TDB = """
     ELEMENT /-   ELECTRON_GAS              0.0000E+00  0.0000E+00  0.0000E+00!
     ELEMENT VA   VACUUM                    0.0000E+00  0.0000E+00  0.0000E+00!
@@ -339,7 +339,8 @@ def test_issue_503_pure_vacancy_charge_balance():
     PHASE GAS:G %  1  1.0  !
     CONSTITUENT GAS:G :O,ZR :  !
     """
-    wks = Workspace(TDB, ['O', 'ZR', 'VA'], ['SPINEL', 'GAS'], {v.P: 1e5, v.X('O'): 1, v.T: 1000})
+    # SPINEL phase cannot charge balance, so even though it contains ZR, O, and VA, it must be suspended
+    wks = Workspace(TDB, ['O', 'ZR', 'VA'], ['SPINEL', 'GAS'], {v.P: 1e5, v.X('O'): 0.5, v.T: 1000})
     assert np.isnan(wks.get('NP(SPINEL)'))
     np.testing.assert_almost_equal(wks.get('NP(GAS)'), 1.0)
 


### PR DESCRIPTION
- Fixes the test names and descriptions of two tests related to #503 
- For [`test_issue_503_suspend_phase_infeasible_internal_constraints`](https://github.com/pycalphad/pycalphad/pull/561/files#diff-31e23fd0f866a3d4f331e4bd2bfa4840923e1f047fb204497622e549367b0cbcR328-R329): The behavior we are testing for does not require that we set a mole fraction to 1, so we change that as well. There's still an issue with the minimizer non-deterministically failing near the edge of composition space, but this test does not capture that behavior consistently enough to be useful, so we side-step the issue for now.

For that issue we ended up adding two sets of fixes because there were really two issues:
1. In [`test_issue_503_charged_infeasible_subsystem`](https://github.com/pycalphad/pycalphad/pull/561/files#diff-fb922ec5bc8777718fa5d38feb4e4392df16cad9db8084449ede5308916e4b69L1018-L1019), we needed to suspend HALITE because there was no vanadium entered into the list of components to allow for charge-balancing the oxygen, but the phase still had a pure-vacancy endmember that was feasible in the sampler (but un-physical).
2. In [`test_issue_503_pure_vacancy_charge_balance`](https://github.com/pycalphad/pycalphad/pull/561/files#diff-31e23fd0f866a3d4f331e4bd2bfa4840923e1f047fb204497622e549367b0cbcL328-L329), we had ZR, O, and VA all entered, but the SPINEL phase is defined as stoichiometric with non-zero charge, so it can never be entered and will always have zero feasible points from the sampler. Contrary to the test name and description, the pure-vacancy sublattices in the SPINEL phase aren't playing a role here.