### PR TITLE
FIX: Workspace: Allow empty object creation

### DIFF
--- a/pycalphad/core/workspace.py
+++ b/pycalphad/core/workspace.py
@@ -299,7 +299,7 @@ ModelType = TypeVar('ModelType', bound=Model)
 
 class Workspace:
     _callbacks = defaultdict(lambda: [])
-    database: Database = TypedField(lambda _: None)
+    database: Database = TypedField(lambda _: Database())
     components: ComponentList = ComponentsField(depends_on=['database'])
     constituents: ConstituentsList = ConstituentsField(depends_on=['database', 'components'])
     phases: PhaseList = PhasesField(depends_on=['database', 'components'])

--- a/pycalphad/tests/test_workspace.py
+++ b/pycalphad/tests/test_workspace.py
@@ -13,6 +13,7 @@ from collections import Counter
 @select_database("alzn_mey.tdb")
 def test_workspace_creation(load_database):
     dbf = load_database()
+    Workspace() # test empty workspace creation
     wks = Workspace(database=dbf, components=['AL', 'ZN', 'VA'], phases=['FCC_A1', 'HCP_A3', 'LIQUID'],
                     conditions={v.N: 1, v.P: 1e5, v.T: (300, 1000, 10), v.X('ZN'): 0.3})
     wks2 = Workspace(dbf, ['AL', 'ZN', 'VA'], ['FCC_A1', 'HCP_A3', 'LIQUID'],


### PR DESCRIPTION
Adds a default constructor for `Workspace.database`, which fixes assumptions other attribute code is making about `wks.database` not being None.