### PR TITLE
High order reciprocal model

### DIFF
--- a/pycalphad/core/phase_rec.pyx
+++ b/pycalphad/core/phase_rec.pyx
@@ -222,8 +222,9 @@ cdef public class PhaseRecord(object)[type PhaseRecordType, object PhaseRecordOb
         cdef int i
         cdef int num_inps = dof.shape[0]
         cdef int num_dof = self.num_statevars + self.phase_dof + self.parameters.shape[0]
+        cdef void* callptr = self.function_factory.get_func(property_name)
         for i in range(num_inps):
-           (<FastFunction>self.function_factory.get_func(property_name)).call(&outp[i], &dof_concat[i * num_dof])
+           (<FastFunction>callptr).call(&outp[i], &dof_concat[i * num_dof])
         if self.parameters.shape[0] > 0:
             free(dof_concat)
 

--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -768,26 +768,18 @@ class Model(object):
                     mixing_term *= Mul(*comp_symbols)
                 # is this a higher-order interaction parameter?
                 if len(comps) == 2 and param['parameter_order'] > 0:
-                    subl_indices = []
-                    comps_list = []
-                    for subl_index_2, comps_2 in enumerate(param['constituent_array']):
-                        if len(comps_2) == 2:
-                            subl_indices.append(subl_index_2)
-                            comps_list.append(comps_2)
-                    if len(comps_list) > 1:
+                    subl_indices, comps_list = list(zip(*[[idx,c] for idx,c in enumerate(param['constituent_array']) if len(c) == 2]))
+                    if len(comps_list) > 2:
+                        raise ValueError("Composition dependent reciprocal parameter is not supported for more than 2 sublattices")
+                    elif len(comps_list) > 1:
                         # only add (yA - yB) if the sublattice corresponds to the parameter order
                         # this is based off the equation from HL Lukas, SG Fries, B Sundman
                         #   Computational Thermodynamics - The Calphad Method, 
                         #   Ch5 Models for the Gibbs Free Energy, Section 5.8.1. Reciprocal solutions
                         #   Equation 5.99
-                        # TODO: check if this generalizes for mixing on more than two sublattices
-                        #       Ex. L_A,B:C,D:E,F
-                        #           1st order -> (yA-yB)
-                        #           2nd order -> (yC-yD)
-                        #           3rd order -> (yE-yF)
-                        #       This may not be necessary since its highly unlikely a parameter
-                        #       of this order would be used, and it should be discouraged anyways
-                        if subl_indices.index(subl_index) == param['parameter_order'] - 1:
+                        # Testing with thermo-calc seems to be that L1 corresponds to the second
+                        # sublattice and L2 corresponds to the first sublattice
+                        if (1-subl_indices.index(subl_index)) == param['parameter_order'] - 1:
                             mixing_term *= (comp_symbols[0] - comp_symbols[1])
                     else:
                         # interacting sublattice, add the interaction polynomial

--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -719,8 +719,6 @@ class Model(object):
             mixing_term = S.One
             param_subl_dof = [len(subl) for subl in param["constituent_array"]]
             mixing_sublattice_indices = [subl_index for subl_index, dof in enumerate(param_subl_dof) if dof > 1]
-            print("if len(mixing_sublattice_indices) > 1 and max(param_subl_dof) > 2:")
-            print(f"{len(mixing_sublattice_indices)} {max(param_subl_dof)}")
             if len(mixing_sublattice_indices) > 1 and max(param_subl_dof) > 2:
                 raise ValueError(f"Parameters with mixing on multiple sublattices cannot include interactions beyond binary. Got mixing on {len(mixing_sublattice_indices)} sublattices with one sublattice having mixing between {max(param_subl_dof)} constituents for parameter {param}.")
             for subl_index, comps in enumerate(param['constituent_array']):

--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -772,6 +772,8 @@ class Model(object):
                     if len(comps_list) > 2:
                         raise ValueError("Composition dependent reciprocal parameter is not supported for more than 2 sublattices")
                     elif len(comps_list) > 1:
+                        if param['parameter_order'] > 2:
+                            raise ValueError("Order of reciprocal parameter is limited to 0, 1 or 2")
                         # only add (yA - yB) if the sublattice corresponds to the parameter order
                         # this is based off the equation from HL Lukas, SG Fries, B Sundman
                         #   Computational Thermodynamics - The Calphad Method, 

--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -768,9 +768,31 @@ class Model(object):
                     mixing_term *= Mul(*comp_symbols)
                 # is this a higher-order interaction parameter?
                 if len(comps) == 2 and param['parameter_order'] > 0:
-                    # interacting sublattice, add the interaction polynomial
-                    mixing_term *= Pow(comp_symbols[0] - \
-                        comp_symbols[1], param['parameter_order'])
+                    subl_indices = []
+                    comps_list = []
+                    for subl_index_2, comps_2 in enumerate(param['constituent_array']):
+                        if len(comps_2) == 2:
+                            subl_indices.append(subl_index_2)
+                            comps_list.append(comps_2)
+                    if len(comps_list) > 1:
+                        # only add (yA - yB) if the sublattice corresponds to the parameter order
+                        # this is based off the equation from HL Lukas, SG Fries, B Sundman
+                        #   Computational Thermodynamics - The Calphad Method, 
+                        #   Ch5 Models for the Gibbs Free Energy, Section 5.8.1. Reciprocal solutions
+                        #   Equation 5.99
+                        # TODO: check if this generalizes for mixing on more than two sublattices
+                        #       Ex. L_A,B:C,D:E,F
+                        #           1st order -> (yA-yB)
+                        #           2nd order -> (yC-yD)
+                        #           3rd order -> (yE-yF)
+                        #       This may not be necessary since its highly unlikely a parameter
+                        #       of this order would be used, and it should be discouraged anyways
+                        if subl_indices.index(subl_index) == param['parameter_order'] - 1:
+                            mixing_term *= (comp_symbols[0] - comp_symbols[1])
+                    else:
+                        # interacting sublattice, add the interaction polynomial
+                        mixing_term *= Pow(comp_symbols[0] - \
+                            comp_symbols[1], param['parameter_order'])
                 if len(comps) == 3:
                     # 'parameter_order' is an index to a variable when
                     # we are in the ternary interaction parameter case

--- a/pycalphad/tests/test_energy.py
+++ b/pycalphad/tests/test_energy.py
@@ -328,7 +328,7 @@ def test_magnetic_reference_energy_is_zero(load_database):
 @pytest.mark.filterwarnings("ignore:shift_reference_state*:DeprecationWarning")
 def test_non_zero_reference_mixing_enthalpy_for_va_interaction():
     """The referenced mixing enthalpy for a Model with a VA interaction parameter is non-zero."""
-    
+
     VA_INTERACTION_TDB = """
     ELEMENT AL   FCC_A1                    26.981539   4577.296    28.3215!
     ELEMENT VA   BLANK                     0.0 0.0 0.0 !
@@ -946,7 +946,7 @@ def test_MQMQA_SUBQ_Q_mixing_Sb_O_S_400K(load_database):
 @select_database("KF-NIF2_switched.dat")
 def test_DAT_coordination_numbers_are_order_invariant(load_database):
     """Coordination number parameters should have the coordinations sorted in the correct order.
-    
+
     This test confirms that if database cation ordering is not alphabetical in
     the source database (in particular, for coordination numbers), the energy
     will be correctly computed.
@@ -1347,7 +1347,7 @@ def test_higher_order_reciprocal_parameter():
     }
     check_output(mod, subs_dict, 'GM', -16195.14703, mode='sympy')
 
-    # Since thermo-calc seems to flip the composition dependent reciprocal parameters
+    # Since Thermo-Calc seems to flip the composition-dependent reciprocal parameters
     # This is a test on a phase with no VA to check if the order of the reciprocal
     # parameters was dependent on whether a sublattice has VA or not
     yMO, yNB, yC, yAL = 0.75, 0.25, 0.1, 0.9
@@ -1368,7 +1368,7 @@ def test_higher_order_reciprocal_parameter():
     #       with a message: Only 2 interacting constituents on 2 sublattices are supported for reciprocal parameters
     #       However, it will still give the same value as here
     #       For higher order parameters such as PARAMETER G(PHASE_THREE,MO,NB:CR,TA:C,VA;1), equilibrium in TC will
-    #       fail is a message: Illegal composition dependency, but this behavior is addressed in 
+    #       fail is a message: Illegal composition dependency, but this behavior is addressed in
     #       test_model.py::test_error_raised_for_higher_order_reciprocal_parameter
     yMO, yNB, yCR, yTA, yC, yVA = 0.3, 0.7, 0.2, 0.8, 0.4, 0.6
     T = 1000
@@ -1400,4 +1400,3 @@ def test_higher_order_reciprocal_parameter():
         v.T: T
     }
     check_output(mod, subs_dict, 'GM', -12817.416, mode='sympy')
-

--- a/pycalphad/tests/test_energy.py
+++ b/pycalphad/tests/test_energy.py
@@ -1350,10 +1350,3 @@ def test_higher_order_reciprocal_parameter():
         v.T: T
     }
     check_output(mod, subs_dict, 'GM', -7739.223, mode='sympy')
-
-def test_error_raised_for_reciprocal_parameter_with_three_sublattices():
-    """
-    The composition dependent reciprocal parameter on more than two sublattices
-    should not be supported and should raise an error if a database has these parameters
-    """
-    return

--- a/pycalphad/tests/test_model.py
+++ b/pycalphad/tests/test_model.py
@@ -222,3 +222,42 @@ def test_model_extrapolate_temperature():
                v.Y('ORDERED', 2, 'VA'): 1.0}
     assert mod.GM.subs(dof).subs({v.T: 200}).n(real=True) == -9900.
     assert mod.GM.subs(dof).subs({v.T: 50000}).n(real=True) == -43000.
+
+def test_error_raised_for_higher_order_reciprocal_parameter():
+    """
+    The composition dependent reciprocal parameter on more than two sublattices
+    should not be supported and should raise an error if a database has these parameters
+    """
+    test_tdb = """
+    ELEMENT VA   VACUUM                    0.0000E+00  0.0000E+00  0.0000E+00!
+    ELEMENT C    GRAPHITE                  1.2011E+01  1.0540E+03  5.7423E+00!
+    ELEMENT MO   BCC_A2                    9.5940E+01  4.5890E+03  2.8560E+01!
+    ELEMENT NB   BCC_A2                    9.2906E+01  5.2200E+03  3.6270E+01!
+    ELEMENT AL   BCC_A2                    9.2906E+01  5.2200E+03  3.6270E+01!
+
+    PHASE PHASE_CORRECT % 3 1 1 1 !
+    CONSTITUENT PHASE_CORRECT : MO,NB : NB,AL : C,VA : !
+
+    PARAMETER G(PHASE_CORRECT,MO,NB:NB,AL:C,VA;0) 298.15 -300000; 6000 N !
+
+    PHASE PHASE_SUBLATTICE % 3 1 1 1 !
+    CONSTITUENT PHASE_SUBLATTICE : MO,NB : NB,AL : C,VA : !
+
+    PARAMETER G(PHASE_SUBLATTICE,MO,NB:NB,AL:C,VA;1) 298.15 -300000; 6000 N !
+
+    PHASE PHASE_HIGH_ORDER % 3 1 1 1 !
+    CONSTITUENT PHASE_HIGH_ORDER : MO,NB : C,VA : !
+
+    PARAMETER G(PHASE_HIGH_ORDER,MO,NB:C,VA;3) 298.15 -300000; 6000 N !
+    """
+    dbf = Database(test_tdb)
+    # Check that a model with 0th order reciprocal parameter loads correctly
+    mod = Model(dbf, ["AL", "MO", "NB", "C", "VA"], "PHASE_CORRECT")
+
+    # Check that a model with a higher order reciprocal parameter on three sublattices throws an error
+    with pytest.raises(ValueError):
+        mod = Model(dbf, ["AL", "MO", "NB", "C", "VA"], "PHASE_SUBLATTICE")
+
+    # Check that a model with a higher order reciprocal parameter > 2 throws an error
+    with pytest.raises(ValueError):
+        mod = Model(dbf, ["MO", "NB", "C", "VA"], "PHASE_HIGH_ORDER")


### PR DESCRIPTION
This pull request implements the composition dependent reciprocal parameter as defined in eq 5.99 in:
H.L. Lukas, S.G. Fries, B. Sundman, "Computational Thermodynamics - The Calphad Method, Ch 5. Models for the Gibbs Free Energy, 5.8 Modeling using sublattices, 5.8.1. Reciprocal solutions, 5.8.1.1. Excess Gibbs energy for the reciprocal solution" Cambridge University Press 2007. ISBN: 978-0-521-86811-2

For excess mixing in a reciprocal solution:
```math
^E G_m = y_A^0 y_B^0 y_C^1 L_{AB:C} + y_A^0 y_B^0 y_D^1 L_{AB:D} + y_A^0 y_C^1 y_D^1 L_{A:CD} + y_B^0 y_C^1 y_D^1 L_{B:CD} + y_A^0 y_B^0 y_C^1 y_D^1 L_{AB:CD}
```

The ternary terms are defined by with a Redlich-Kister polynomial, but the reciprocal parameter can be defined as the following the include composition dependency:
```math
L_{AB:CD} = ^0L_{AB:CD} + (y_A^0 - y_B^0) ^1L_{AB:CD} + (y_C^1 - y_D^1) ^2L_{AB:CD}
```
This is an example assessment that used these higher order parameters: C. Zhang, Y. Peng, P. Zhou, W. Zhang, Y. Du, Calphad 51 (2015) 104-110, [DOI: 10.1016/j.calphad.2015.09.001](https://doi.org/10.1016/j.calphad.2015.09.001). 

Unit tests are added for the following behaviors:
- Accuracy of mixing energy with respect to Thermo-Calc behavior
- Model will raise error if reciprocal parameter with an order > 2 is used (e.g. `PARAM G(PHASE,A,B:C,D;3)`)
- Model will raise error if reciprocal parameter with order > 0 is used for mixing on 3 or more sublattices (e.g. `PARAM G(PHASE,A,B:C,D:E,F;1)`)