### PR TITLE
FIX: ParseException handling in pyparsing 3.2.0

### DIFF
--- a/pycalphad/codegen/sympydiff_utils.py
+++ b/pycalphad/codegen/sympydiff_utils.py
@@ -56,7 +56,7 @@ def _get_lambidfy_options(user_options):
 def build_functions(symengine_graph, variables, parameters=None, wrt=None,
                     include_obj=True, include_grad=False, include_hess=False,
                     func_options=None, grad_options=None, hess_options=None):
-    """Build function, gradient, and Hessian callables of the symengine_graph.
+    r"""Build function, gradient, and Hessian callables of the symengine_graph.
 
     Parameters
     ----------

--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -978,7 +978,7 @@ def read_tdb(dbf, fd):
             # context variable includes a helpful cursor aligned with the 'error character'
             # this requires being on a newline so it renders correctly in consoles
             e.msg = f'Invalid TDB syntax.\n{context}'
-            # In pyparsing >=3.2.0, e.column and e.line are cached_property's and need to be reset, since pstr and loc were mutated above
+            # In pyparsing >=3.2.0, e.column and e.line are cached_property objects and need to be reset, since pstr and loc were mutated above
             # Details of how this works can be found in https://stackoverflow.com/questions/62662564/how-do-i-clear-the-cache-from-cached-property-decorator
             e.__dict__.pop('column', None)
             e.__dict__.pop('line', None)

--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -978,6 +978,10 @@ def read_tdb(dbf, fd):
             # context variable includes a helpful cursor aligned with the 'error character'
             # this requires being on a newline so it renders correctly in consoles
             e.msg = f'Invalid TDB syntax.\n{context}'
+            # In pyparsing >=3.2.0, e.column and e.line are cached_property's and need to be reset, since pstr and loc were mutated above
+            # Details of how this works can be found in https://stackoverflow.com/questions/62662564/how-do-i-clear-the-cache-from-cached-property-decorator
+            e.__dict__.pop('column', None)
+            e.__dict__.pop('line', None)
             raise e
         # Add 1 for removed '!' delimiter
         char_idx += len(command) + 1

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -750,7 +750,7 @@ def test_tdb_parser_correct_lineno():
     # The PARAMETER G(BCC,FE:H;0) parameter is not terminated by an `!`.
     # The parser merges all newlines until the `!`, meaning both parameters
     # will be joined on one "line". The parser should raise an error.
-    UNTERMINATED_PARAM_STR = """     PARAMETER G(BCC,FE:H;0) 298.15  +GHSERFE+1.5*GHSERHH
+    UNTERMINATED_PARAM_STR = r"""     PARAMETER G(BCC,FE:H;0) 298.15  +GHSERFE+1.5*GHSERHH
         +258000-3170*T+498*T*LN(T)-0.275*T**2; 1811.00  Y
         +232264+82*T+1*GHSERFE+1.5*GHSERHH; 6000.00  N
 

--- a/pycalphad/tests/test_database.py
+++ b/pycalphad/tests/test_database.py
@@ -750,7 +750,7 @@ def test_tdb_parser_correct_lineno():
     # The PARAMETER G(BCC,FE:H;0) parameter is not terminated by an `!`.
     # The parser merges all newlines until the `!`, meaning both parameters
     # will be joined on one "line". The parser should raise an error.
-    UNTERMINATED_PARAM_STR = r"""     PARAMETER G(BCC,FE:H;0) 298.15  +GHSERFE+1.5*GHSERHH
+    UNTERMINATED_PARAM_STR = """     PARAMETER G(BCC,FE:H;0) 298.15  +GHSERFE+1.5*GHSERHH
         +258000-3170*T+498*T*LN(T)-0.275*T**2; 1811.00  Y
         +232264+82*T+1*GHSERFE+1.5*GHSERHH; 6000.00  N
 


### PR DESCRIPTION
A recent [change in pyparsing ](https://github.com/pyparsing/pyparsing/pull/571) added caching to attributes on ParseException objects using the `cached_property` decorator. Those caches are not invalidated when the `pstr` and `loc` for the ParseException objects are modified (as we do, to provide more accurate line numbers, since #550 ).

The caches for these properties are stored as attributes on the instances with the same name as the property, so it is easy to clear the cache using `obj.__dict__.pop('property_name', None)`. This is backwards-compatible since it's a no-op on previous versions of pyparsing, where only the `property` decorator is present. Details of how this works can be found in the [answers to this StackOverflow question](https://stackoverflow.com/questions/62662564/how-do-i-clear-the-cache-from-cached-property-decorator).