### PR TITLE
IsolatedPhase fix and composition Jansson derivative default change

### DIFF
--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -747,12 +747,12 @@ cpdef fixed_component_differential(SystemSpecification spec, SystemState state, 
     equilibrium_soln[:] = 0
 
     # delta mole fractions must sum to zero; we have degrees of freedom to decide how to distribute
-    # for now, redistribute evenly over all other fixed components
+    # for now, specify one dependent component
     for i in range(spec.prescribed_mole_fraction_coefficients.shape[0]):
         if np.all(np.asarray(spec.prescribed_mole_fraction_coefficients[i]) == comparison_array):
             equilibrium_soln[num_stable_phases + num_fixed_phases + i] = 1
         else:
-            equilibrium_soln[num_stable_phases + num_fixed_phases + i] = -1/(num_fixed_mole_fraction_conditions)
+            equilibrium_soln[num_stable_phases + num_fixed_phases + i] = 0
     lstsq_check_infeasible(equilibrium_matrix, equilibrium_soln, equilibrium_soln)
     for i in range(spec.free_chemical_potential_indices.shape[0]):
         chempot_idx = spec.free_chemical_potential_indices[i]

--- a/pycalphad/property_framework/metaproperties.py
+++ b/pycalphad/property_framework/metaproperties.py
@@ -214,8 +214,9 @@ class IsolatedPhase:
                             chemical_potentials: npt.ArrayLike) -> float:
                 if self._compset is None:
                     return prop.compute_property([], cur_conds, chemical_potentials)
-                self.solver.solve([self._compset], cur_conds)
-                return prop.compute_property([self._compset], cur_conds, chemical_potentials)
+                res = self.solver.solve([self._compset], cur_conds)
+                new_chemical_potentials = res.chemical_potentials
+                return prop.compute_property([self._compset], cur_conds, new_chemical_potentials)
 
             @staticmethod
             def jansson_derivative(compsets, cur_conds, chemical_potentials, deltas):


### PR DESCRIPTION
<!--

Thank you for pull request.

Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.

-->

IsolatedPhase was not constraining chemical potentials to the compset, but was allowing phase separation in miscibility gaps.

Currently, the default for composition Jansson derivatives is to define n-1 dependent components rather than just 1. Defining one dependent component seems more intuitive and applicable.
