### PR TITLE
FIX: Fix lambdifying models that evaluate to have complex numbers

### DIFF
--- a/pycalphad/codegen/sympydiff_utils.py
+++ b/pycalphad/codegen/sympydiff_utils.py
@@ -119,7 +119,7 @@ def build_functions(symengine_graph, variables, parameters=None, wrt=None,
     # to have negligible (1e-16*j) complex parts, which raises runtime errors
     # for the default lambdify(..., real=True).
     # In practice, this is probably a reasonable workaround, but would drop
-    # cases where we have legtimate, non-negligble complex numbers (e.g. negative
+    # cases where we have legitimate, non-negligble complex numbers (e.g. negative
     # bases for non-integer exponents). Although we have been doing this all
     # along internally inside `lambdify`.
     # We have to do this graph.atoms() method to get complex numbers because

--- a/pycalphad/codegen/sympydiff_utils.py
+++ b/pycalphad/codegen/sympydiff_utils.py
@@ -119,7 +119,7 @@ def build_functions(symengine_graph, variables, parameters=None, wrt=None,
     # to have negligible (1e-16*j) complex parts, which raises runtime errors
     # for the default lambdify(..., real=True).
     # In practice, this is probably a reasonable workaround, but would drop
-    # cases where we have bonifide non-negligble complex numbers (e.g. negative
+    # cases where we have legtimate, non-negligble complex numbers (e.g. negative
     # bases for non-integer exponents). Although we have been doing this all
     # along internally inside `lambdify`.
     # We have to do this graph.atoms() method to get complex numbers because

--- a/pycalphad/codegen/sympydiff_utils.py
+++ b/pycalphad/codegen/sympydiff_utils.py
@@ -29,7 +29,7 @@ functions or PhaseRecords. The following issues track this behavior:
 """
 from pycalphad.core.cache import cacheit
 from pycalphad.core.utils import wrap_symbol
-from symengine import sympify, lambdify, zoo, oo, have_llvm
+from symengine import ComplexDouble, sympify, lambdify, I, zoo, oo, have_llvm
 from collections import namedtuple
 
 BuildFunctionsResult = namedtuple('BuildFunctionsResult', ['func', 'grad', 'hess'])
@@ -108,12 +108,25 @@ def build_functions(symengine_graph, variables, parameters=None, wrt=None,
     parameters = tuple(parameters)
     func, grad, hess = None, None, None
     # Replace complex infinity (zoo) with real infinity because SymEngine
-    # cannot lambdify complex infinity. We also replace in the derivatives in
+    # cannot lambdify complex numbers. We also replace in the derivatives in
     # case some differentiation would produce a complex infinity. The
     # replacement is assumed to be cheap enough that it's safer to replace the
     # complex values and pay the minor time penalty.
     inp = sympify(variables + parameters)
     graph = sympify(symengine_graph).xreplace({zoo: oo})
+    # We also replace all complex parts of complex numbers with (real) zero,
+    # to address a bug where integer exponents expressed as doubles can evaluate
+    # to have negligible (1e-16*j) complex parts, which raises runtime errors
+    # for the default lambdify(..., real=True).
+    # In practice, this is probably a reasonable workaround, but would drop
+    # cases where we have bonifide non-negligble complex numbers (e.g. negative
+    # bases for non-integer exponents). Although we have been doing this all
+    # along internally inside `lambdify`.
+    # We have to do this graph.atoms() method to get complex numbers because
+    # just calling xreplace(I, 0.0) doesn't work in SymEngine for some deeply
+    # nested `I`.
+    # We assume that differentiating does create new complex numbers.
+    graph = graph.xreplace({x: x.xreplace({I: 0.0}) for x in graph.atoms(ComplexDouble)})
     func = lambdify(inp, [graph], **_get_lambidfy_options(func_options))
     if include_grad or include_hess:
         grad_graphs = list(graph.diff(w).xreplace({zoo: oo}) for w in wrt)
@@ -164,7 +177,7 @@ def build_constraint_functions(variables, constraints, parameters=None, func_opt
     parameters = tuple(parameters)
     constraint_func, jacobian_func, hessian_func = None, None, None
     # Replace complex infinity (zoo) with real infinity because SymEngine
-    # cannot lambdify complex infinity. We also replace in the derivatives in
+    # cannot lambdify complex numbers. We also replace in the derivatives in
     # case some differentiation would produce a complex infinity. The
     # replacement is assumed to be cheap enough that it's safer to replace the
     # complex values and pay the minor time penalty.


### PR DESCRIPTION
In PyCalphad we eventually represent all our exponents as floating points, even if they are actually integer values. This becomes troublesome because SymEngine evaluates small, negligible imaginary parts, as in the following example:

```python
from sympy import Symbol
x = Symbol("x")
print((x**(2.0)).subs({x: -1})) 
# prints: `1`
from symengine import Symbol
x = Symbol("x")
print((x**(2)).subs({x: -1})) 
# prints: `1`
print((x**(2.0)).subs({x: -1})) 
# prints: `1.0 - 2.44929359829471e-16*I` complex just by using floating point exponent
```

In this case, the imaginary part is not useful and causes an issue when we call `lambdify` in (`build_functions`) with the default argument that `real=True`. We probably haven't run into this before because our bases are typically symbolic (e.g. `T` in power functions) and these are typically not evaluated to a complex number until the function is actually evaluated inside `lambdify` (where the imaginary part gets thrown away because we call `lambdify(..., real=True)` implicitly). Consequently, doing this replacement outside of `lambdify` can't be a source of a regression because `lambdify` has been throwing away any complex parts anyway. 

We end up doing this workaround to find complex numbers by `atoms` and replace the imaginary unit with zero, which is working around SymEngine not having a `re` (real) function and calling `subs` or `xreplace` with `{I: 0.0}` directly on the Model expression doesn't replace arbitrarily nested imaginary numbers.
