### PR TITLE
MAINT: Bump minimum Python version to 3.13, drop 3.9; test and dependency fixes

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.9'
+          python-version: '3.13'
 
       - run: pip install build
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 18
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/ONBOARDING.rst
+++ b/ONBOARDING.rst
@@ -5,15 +5,15 @@ Workplace setup & software tutorials
 ------------------------------------
 
 Unless you already have them, install VSCode (or other IDE for Python), Git, Build Tools for Visual Studio version 14.X, and Miniconda. You can follow a tutorial for all these `downloads <https://beenje.github.io/blog/posts/how-to-setup-a-windows-vm-to-build-conda-packages/#developer-tools-installation>`_. Follow the article up until "Testing", which is not essential but useful if you want to check that you installed everything properly. Make sure to download for the respective operating systems of the computer. Make sure Microsoft Visual C++ Build Tools is installed because it is essential towards installing pycalphad properly.
-After completing those downloads, `click <https://marketplace.visualstudio.com/items?itemName=ms-python.python>`_ to download Microsoft’s Python extension. 
-As well, make sure your computer has `Python`_ 3.7+ (or a more updated version) downloaded. 
+After completing those downloads, `click <https://marketplace.visualstudio.com/items?itemName=ms-python.python>`_ to download Microsoft’s Python extension.
+As well, make sure your computer has `Python`_ 3.7+ (or a more updated version) downloaded.
 Now, you can install the latest development branch of pycalphad. Run this command in Git Bash:
 
 .. code-block:: bash
 
    git clone https://github.com/pycalphad/pycalphad.git
 
-Next, you want to create a conda environment. 
+Next, you want to create a conda environment.
 
 How to create your conda environment
 ------------------------------------
@@ -21,7 +21,7 @@ How to create your conda environment
 Create your conda virtual environment using the application called Anaconda Prompt. You can find this by searching your computer in the bottom left bar.
  After ``-n`` is where we specify our environment name (in this case the name is ‘calphad’), and then the version of Python we want to install.
 
-``conda create -n calphad python=3.9``
+``conda create -n calphad python=3.13``
 
 Activate your conda environment in Anaconda Prompt
 --------------------------------------------------
@@ -56,7 +56,7 @@ Setting your VSCode environment
 
 We want to select the correct interpreter/environment in Visual Studio Code. Click into any file in the pycalphad codebase, and in the bottom right corner, you will be able to click on the Python version.
 
-At the top of Visual Studio, you will see a drop-down menu- click there and select the interpreter that has the name of your environment. In this case, it would be named something like this: Python 3.913 (‘calphad’).
+At the top of Visual Studio, you will see a drop-down menu- click there and select the interpreter that has the name of your environment. In this case, it would be named something like this: Python 3.13 (‘calphad’).
 
 Setting up your fork and remote repositories
 --------------------------------------------
@@ -76,12 +76,12 @@ Like so:
 .. code-block:: bash
 
     user@MT-102934 MINGW64 ~/pycalphad (branch_name)
-    $ git remote -v 
+    $ git remote -v
     origin     https://github.com/username/forkname.git (fetch)
     origin     https://github.com/username/forkname.git (push)
     upstream   https://github.com/pycalphad/pycalphad.git (fetch)
     upstream   https://github.com/pycalphad/pycalphad.git (push)
-    
+
 If either your origin or upstream does not match the above links, use the commands below:
 
 To remove a remote: ``git remote rm <remote-name>``

--- a/pycalphad/tests/test_equilibrium.py
+++ b/pycalphad/tests/test_equilibrium.py
@@ -1065,4 +1065,4 @@ def test_issue_468_gibbs_phase_rule(load_database):
     phases = ['LIQUID', 'FCC_A1', 'BCC_A2', 'GRAPHITE', 'CEMENTITE', 'DIAMOND_A4']
     eq = equilibrium(dbf, components, phases, {v.N:1, v.P:1e5, v.T:1080, v.X('C'):0.0053}, verbose=True)
     assert sorted(eq.Phase.values.squeeze()) == ["", "BCC_A2", "GRAPHITE"]
-    assert np.allclose(sorted(eq.NP.values.squeeze()), [0.00015170798706395827, 0.999848292010574, np.nan], atol=1e-7, equal_nan=True)
+    assert np.allclose(np.sort(eq.NP.values.squeeze()), [0.00015170798706395827, 0.999848292010574, np.nan], atol=1e-7, equal_nan=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "Cython",
-    "numpy>=2; python_version>='3.9'",
+    "numpy>=2; python_version>='3.10'",
     "scipy",
     "setuptools",
     "setuptools_scm[toml]>=6.0",

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         'runtype',
         'scipy',
         'setuptools_scm[toml]>=6.0',
-        'symengine>=0.9.2',  # python-symengine on conda-forge
+        'symengine>=0.9.2,<0.14',  # python-symengine on conda-forge
         'tinydb>=3.8',
         'typing_extensions', # drop when pycalphad drops support for Python<3.13
         'xarray>=0.11.2',

--- a/setup.py
+++ b/setup.py
@@ -90,10 +90,10 @@ setup(
 
         # Supported Python versions
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
 
 )


### PR DESCRIPTION
Dropping 3.9 in accordance with [NEP-29](https://numpy.org/neps/nep-0029-deprecation_policy.html)
