### PR TITLE
FIX: avoid ZeroDivisionError on converting units

### DIFF
--- a/pycalphad/property_framework/units.py
+++ b/pycalphad/property_framework/units.py
@@ -68,7 +68,7 @@ def unit_conversion_context(compsets, prop):
     context.add_transformation(
         per_moles,
         per_mass,
-        lambda ureg, x: (x / molar_weight).to_reduced_units()
+        lambda ureg, x: np.true_divide(x, molar_weight).to_reduced_units(),
     )
     context.add_transformation(
         per_mass,

--- a/pycalphad/tests/test_workspace.py
+++ b/pycalphad/tests/test_workspace.py
@@ -442,3 +442,12 @@ def test_multicomponent_jansson_derivative_dependent_component(load_database):
     # dGM / dX(Ti) = MU(Ti) - MU(Cr)
     np.testing.assert_allclose(dGM_dXTi, wks.get("MU(TI)") - wks.get("MU(CR)"))
     np.testing.assert_allclose(dGM_dXTi, -26856.725962)
+
+@select_database("cfe_broshe.tdb")
+def test_unit_conversion(load_database):
+    dbf = load_database()
+    conds = {v.P: 101325, v.T: (1530, 1570, 10), v.N: 1, v.W("C"): 0.02}
+    wks = Workspace(dbf, ["FE", "C", "VA"], ["LIQUID", "FCC_A1"], conditions=conds)
+
+    # Test that it did not raise any exception (gh-609)
+    wks.get(v.T, as_property("enthalpy")["J/g"])

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
-import os, sys
-from setuptools import setup, Extension
-from Cython.Build import cythonize
+import os
+
 import numpy as np
+from Cython.Build import cythonize
+from setuptools import Extension, setup
+from setuptools.command.build_ext import build_ext
 
 
 # Utility function to read the README file.
@@ -28,6 +30,22 @@ CYTHON_EXTENSION_MODULES = [
     Extension('pycalphad.core.minimizer', sources=['pycalphad/core/minimizer.pyx'], define_macros=CYTHON_DEFINE_MACROS),
 ]
 
+# https://cython.readthedocs.io/en/latest/src/tutorial/appendix.html
+mingw32_link_args = [
+    "-static-libgcc",
+    "-static-libstdc++",
+    "-Wl,-Bstatic,--whole-archive",
+    "-lwinpthread",
+    "-Wl,--no-whole-archive",
+]
+
+class Build(build_ext):
+    def build_extensions(self):
+        if self.compiler.compiler_type == "mingw32":
+            for ext in self.extensions:
+                ext.extra_link_args = mingw32_link_args
+        return super().build_extensions()
+
 setup(
     name='pycalphad',
     author='Richard Otis',
@@ -40,6 +58,7 @@ setup(
         include_path=CYTHON_EXTENSION_INCLUDES,
         compiler_directives=CYTHON_COMPILER_DIRECTIVES,
     ),
+    cmdclass={"build_ext": Build},
     package_data={
         'pycalphad.core': ['*.pxd'] + (['*.pyx', '*.c', '*.h', '*.cpp', '*.hpp'] if os.getenv('CYTHON_COVERAGE', False) else []),
         'pycalphad.tests.databases': ['*'],


### PR DESCRIPTION
Fixes #609

Also fixed a runtime issue on Windows + MinGW (missing static libs), in a separate commit -- feel free to drop it.  
https://cython.readthedocs.io/en/latest/src/tutorial/appendix.html#python-3-8