### PR TITLE
MAINT: Database object typing

### DIFF
--- a/pycalphad/io/database.py
+++ b/pycalphad/io/database.py
@@ -63,21 +63,6 @@ class Database(object): #pylint: disable=R0902
     """
     Structured thermodynamic and/or kinetic data.
 
-    Attributes
-    ----------
-    elements : set[str]
-        Set of elements in database.
-    species : set[Species]
-        Set of species in database.
-    phases : dict[str, Phase]
-        Phase objects indexed by their system-local name.
-    symbols : dict[str, Expr]
-        SymEngine objects indexed by their name (FUNCTIONs in Thermo-Calc).
-    refstates: dict[str, ElementReferenceData]
-        Mapping of elements to their reference data
-    references : dict[str, Any]
-        Reference objects indexed by their system-local identifier.
-
     Examples
     --------
     >>> mydb = Database(open('crfeni_mie.tdb'))
@@ -87,11 +72,17 @@ class Database(object): #pylint: disable=R0902
     """
 
     elements: set[str]
+    """Set of elements in database."""
     species: set[Species]
+    """Set of species in database."""
     phases: dict[str, Phase]
+    """Phase objects indexed by their system-local name."""
     symbols: dict[str, Expr]
+    """SymEngine objects indexed by their name (FUNCTIONs in Thermo-Calc)."""
     refstates: dict[str, ElementReferenceData]
+    """Mapping of elements to their reference data"""
     references: dict[str, Any]
+    """Reference objects indexed by their system-local identifier."""
     _structure_dict: dict[str, Any]
 
     def __new__(cls, *args):

--- a/pycalphad/io/database.py
+++ b/pycalphad/io/database.py
@@ -2,12 +2,14 @@
 The database module provides support for reading and writing data types
 associated with structured thermodynamic/kinetic data.
 """
+from typing import Any, TypedDict
 from io import StringIO
 from tinydb import TinyDB
 from tinydb.storages import MemoryStorage
 from datetime import datetime
 from collections import namedtuple
 import os
+from symengine import Expr
 from pycalphad.variables import Species
 from pycalphad.core.cache import fhash
 from pycalphad.core.utils import recursive_tuplify
@@ -52,6 +54,7 @@ class Phase(object): #pylint: disable=R0903
         return hash((self.name, self.constituents, tuple(self.sublattices),
                      tuple(sorted(recursive_tuplify(self.model_hints.items())))))
 
+ElementReferenceData = TypedDict('ElementReferenceData', {'phase': str, 'mass': float, "H298": float, "S298": float})
 DatabaseFormat = namedtuple('DatabaseFormat', ['read', 'write'])
 format_registry = {}
 
@@ -62,15 +65,17 @@ class Database(object): #pylint: disable=R0902
 
     Attributes
     ----------
-    elements : set
+    elements : set[str]
         Set of elements in database.
-    species : set
+    species : set[Species]
         Set of species in database.
-    phases : dict
+    phases : dict[str, Phase]
         Phase objects indexed by their system-local name.
-    symbols : dict
+    symbols : dict[str, Expr]
         SymEngine objects indexed by their name (FUNCTIONs in Thermo-Calc).
-    references : dict
+    refstates: dict[str, ElementReferenceData]
+        Mapping of elements to their reference data
+    references : dict[str, Any]
         Reference objects indexed by their system-local identifier.
 
     Examples
@@ -80,6 +85,15 @@ class Database(object): #pylint: disable=R0902
     >>> f = StringIO(u'$a complete TDB file as a string\\n')
     >>> mydb = Database(f)
     """
+
+    elements: set[str]
+    species: set[Species]
+    phases: dict[str, Phase]
+    symbols: dict[str, Expr]
+    refstates: dict[str, ElementReferenceData]
+    references: dict[str, Any]
+    _structure_dict: dict[str, Any]
+
     def __new__(cls, *args):
         if len(args) == 0:
             obj = super(Database, cls).__new__(cls, *args)


### PR DESCRIPTION
Add typing information for Database objects.

We have to switch around how we do the documentation here to make all the tooling happy.
- language servers weren't detecting the types or the documentation properly. It seems like they expect attributes on `__init__`, but we use `__new__`.
- For sphinx, autodoc was detecting multiple definitions of our attributes, e.g. "elements". This fixes it and also improves how objects are seen by language servers
- for sphinx, there are apparently two sets of annotation documentation types allowed, either comment above `#: <doc>` or docstrings below `"""<doc>"""`. I think the comments above look much better, but the language server implementations (e.g. pylance) seems to like the docstring version better.