### PR TITLE
MAINT: Upgrade to pyparsing v3 pep-8 API

### DIFF
--- a/pycalphad/io/grammar.py
+++ b/pycalphad/io/grammar.py
@@ -4,11 +4,11 @@ from pyparsing import alphas, nums
 from pyparsing import Group, OneOrMore, Optional, Regex, Suppress, Word
 import re
 
-pos_neg_int_number = Word('+-' + nums).setParseAction(lambda t: [int(t[0])])  # '+3' or '-2' are examples
+pos_neg_int_number = Word('+-' + nums).set_parse_action(lambda t: [int(t[0])])  # '+3' or '-2' are examples
 # matching float w/ regex is ugly but is recommended by pyparsing
 regex_after_decimal = r'([0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)'
 float_number = Regex(r'[-+]?([0-9]+\.(?!([0-9]|[eE])))|{0}'.format(regex_after_decimal)) \
-    .setParseAction(lambda t: [float(t[0])])
+    .set_parse_action(lambda t: [float(t[0])])
 
 chemical_formula = Group(OneOrMore(Word(alphas, min=1, max=2) + Optional(float_number, default=1.0))) + \
                    Optional(Suppress('/') + pos_neg_int_number, default=0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "matplotlib>=3.3",
     "numpy>=1.13",
     "pint",
-    "pyparsing>=2.4",
+    "pyparsing>=3.0",
     "pytest",
     "pytest-cov",
     "runtype",


### PR DESCRIPTION
Upgraded via pyparsing tooling as suggested by the version 3.3 release logs. Release should be backwards compatible to pyparsing v3.0

<!--

Thank you for pull request.

Below are a few things we ask you kindly to self-check before getting a review.

-->


Checklist
* [x] Include a plain language description of your changes.
* [x] Any dependency changes are reflected in the `pyproject.toml`.
