### PR TITLE
FIX: Suppress pint unit redefinition warnings

### DIFF
--- a/pycalphad/property_framework/units.py
+++ b/pycalphad/property_framework/units.py
@@ -5,7 +5,12 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from pycalphad.property_framework import ComputableProperty
 
-ureg = pint.UnitRegistry(preprocessors=[lambda s: s.replace('%', ' percent ')])
+ureg = pint.UnitRegistry(
+    preprocessors=[lambda s: s.replace('%', ' percent ')],
+    # Suppress warnings when redefining 'percent', '%', and 'ppm' units.
+    # We intentionally redefine these relative to our custom 'fraction' unit.
+    on_redefinition='ignore',
+)
 ureg.define('atom = 1/avogadro_number * mol')
 ureg.define('fraction = []')
 ureg.define('percent = 1e-2 fraction = %')


### PR DESCRIPTION
Add on_redefinition='ignore' to UnitRegistry constructor to suppress warnings when redefining 'percent', '%', and 'ppm' units relative to our custom 'fraction' unit.

## The issue

When importing `pycalphad`, it is common to see warning messages from `pint` about redefining units:

```
WARNING:pint.util:Redefining 'percent' (<class 'pint.delegates.txt_defparser.plain.UnitDefinition'>)
WARNING:pint.util:Redefining '%' (<class 'pint.delegates.txt_defparser.plain.UnitDefinition'>)
WARNING:pint.util:Redefining 'ppm' (<class 'pint.delegates.txt_defparser.plain.UnitDefinition'>)
```

These warnings occur because `pycalphad` intentionally redefines `percent`, `%`, and `ppm` relative to a custom `fraction` unit, but pint already has default definitions for these units.

## Solution

Add `on_redefinition='ignore'` to the `UnitRegistry` constructor in `pycalphad/property_framework/units.py`. This tells pint to silently accept the intentional redefinitions.

## Minimal Working Example

**Before (warnings appear):**
```python
import logging
logging.basicConfig(level=logging.DEBUG)

import pint

ureg = pint.UnitRegistry(preprocessors=[lambda s: s.replace('%', ' percent ')])
ureg.define('fraction = []')
ureg.define('percent = 1e-2 fraction = %')
ureg.define('ppm = 1e-6 fraction')
```

Output:
```text
WARNING:pint.util:Redefining 'percent' (<class 'pint.delegates.txt_defparser.plain.UnitDefinition'>)
WARNING:pint.util:Redefining '%' (<class 'pint.delegates.txt_defparser.plain.UnitDefinition'>)
WARNING:pint.util:Redefining 'ppm' (<class 'pint.delegates.txt_defparser.plain.UnitDefinition'>)
```

**After (no warnings):**

```python
import logging
logging.basicConfig(level=logging.DEBUG)

import pint

ureg = pint.UnitRegistry(
    preprocessors=[lambda s: s.replace('%', ' percent ')],
    on_redefinition='ignore',
)
ureg.define('fraction = []')
ureg.define('percent = 1e-2 fraction = %')
ureg.define('ppm = 1e-6 fraction')
```

Output: 
```
# (no warnings)
```