### PR TITLE
ENH: Support never disorder model

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -40,7 +40,6 @@ jobs:
           CIBW_ARCHS_LINUX: auto64
           CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_ARCHS_WINDOWS: auto64
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
 
       - uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,7 +36,7 @@ jobs:
         env:
           # PyPy wheels not allowed because SciPy (build requirement) is not available
           CIBW_BUILD: cp3*-*
-          CIBW_SKIP: cp36-* cp37-* cp38-* *-musllinux_*
+          CIBW_SKIP: cp38-* *-musllinux_*
           CIBW_ARCHS_LINUX: auto64
           CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_ARCHS_WINDOWS: auto64

--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -136,6 +136,11 @@ def _sample_phase_constitution(model, sampler, fixed_grid, pdens, phase_local_co
             x = - Q[neg_em_idx] / (Q[pos_em_idx] - Q[neg_em_idx])
             em_pts.append(endmembers[pos_em_idx] * x + endmembers[neg_em_idx] * (1-x))
 
+        if len(em_pts) == 0:
+            # There are no endmembers of linear combination endmembers pairs that can charge balance.
+            # This phase cannot form. Return a size zero array of the correct shape
+            return np.full((0, sum(sublattice_dof)), np.nan)
+
         # Charge neutral endmembers and mixed pseudo-endmembers
         points = np.asarray(em_pts)
 

--- a/pycalphad/io/tdb.py
+++ b/pycalphad/io/tdb.py
@@ -286,7 +286,7 @@ def _process_typedef(targetdb, typechar, line):
     if 'IF' in tokens or 'THEN' in tokens:
         warnings.warn("Type definitions using IF/THEN logic is not supported")
         return
-    keyword = expand_keyword(['DISORDERED_PART', 'MAGNETIC'], tokens[3].upper())[0]
+    keyword = expand_keyword(['DISORDERED_PART', 'MAGNETIC', 'NEVER_DISORDER'], tokens[3].upper())[0]
     if len(keyword) == 0:
         raise ValueError('Unknown type definition keyword: {}'.format(tokens[3]))
     if len(matching_phases) == 0:
@@ -312,6 +312,28 @@ def _process_typedef(targetdb, typechar, line):
         hint = {
             'ordered_phase': ordered_phase,
             'disordered_phase': disordered_phase,
+        }
+        if ordered_phase in targetdb.phases:
+            targetdb.phases[ordered_phase].model_hints.update(hint)
+        else:
+            raise ValueError(f"The {ordered_phase} phase is not in the database, but is defined by: `TYPE_DEFINTION {typechar} {line}`")
+        if disordered_phase in targetdb.phases:
+            targetdb.phases[disordered_phase].model_hints.update(hint)
+        else:
+            raise ValueError(f"The {disordered_phase} phase is not in the database, but is defined by: `TYPE_DEFINTION {typechar} {line}`")
+
+    # GES A_P_D SIGMA_D8B NEVER_DIS SIGMA_DIS
+    if keyword == 'NEVER_DISORDER':
+        # never disorder model: since we need to add model_hints to both the
+        # ordered and disorderd phase, we special case to update the phase
+        # names defined by the TYPE_DEF, rather than the updating the phases
+        # with matching typechars.
+        ordered_phase = tokens[2].upper()
+        disordered_phase = tokens[4].upper()
+        hint = {
+            'ordered_phase': ordered_phase,
+            'disordered_phase': disordered_phase,
+            'never_disorder': True,
         }
         if ordered_phase in targetdb.phases:
             targetdb.phases[ordered_phase].model_hints.update(hint)
@@ -498,7 +520,7 @@ class TCPrinter(object):
             #    Pow will explicitly add parenthesis (in the next elif block)
             #    Other functions such as Log, Sin, etc should
             #        include the parenthesis when converting to string
-            
+
             #All the arguments in Mul should be tested and they're all combined to a single expression by '*'
             #    So we could stringify each argument as a list and join them together is '*'
             term_list = ['(' + self._stringify_expr(arg) + ')' if isinstance(arg,Add) else self._stringify_expr(arg) for arg in expr.args]

--- a/pycalphad/model.py
+++ b/pycalphad/model.py
@@ -1220,6 +1220,13 @@ class Model(object):
            3. Physical properties are partitioned in the same way as the
            energy. See Section 5.8.6 of Lukas, Fries and Sundman [2]_.
 
+           4. There is a variant of the partitioning model for phases that never
+           undergo disordering. See Section 5.8.5 of Lukas, Fries and
+           Sundman [2]_. In this variant, the entropy from the disordered phase
+           does not contribute to the energy and the ordering energies does not
+           have to go to zero, i.e.
+           :math:`\Delta G^\mathrm{ord}(y_i) = G^\mathrm{ord}(y_i)`.
+
         Notes
         -----
         .. caution::
@@ -1244,12 +1251,16 @@ class Model(object):
         phase = dbe.phases[self.phase_name]
         ordered_phase_name = phase.model_hints.get('ordered_phase', None)
         disordered_phase_name = phase.model_hints.get('disordered_phase', None)
+        never_disorder = phase.model_hints.get('never_disorder', False)
         if phase.name != ordered_phase_name:
             return S.Zero
         ordered_phase = dbe.phases[ordered_phase_name]
         constituents = [sorted(set(c).intersection(self.components)) for c in ordered_phase.constituents]
         disordered_phase = dbe.phases[disordered_phase_name]
         disordered_model = self.__class__(dbe, sorted(self.components), disordered_phase_name)
+        if never_disorder:
+            # Take configurational entropy from the ordered phase only
+            disordered_model.models["idmix"] = S.Zero
 
         # Get substitutional sublattice indices (for the ordered phase) and
         # validate that the number of interstitial sublattices is consistent
@@ -1352,7 +1363,13 @@ class Model(object):
         # contributions. There's no technical reason for doing it this way
         # compared to setting the AST to the _partitioned_expr for the total
         # energy - this is more for bookkeeping of the model contributions.
-        ordering_energy = self._partitioned_expr(S.Zero, ordered_energy, {}, molefraction_dict)
+        if never_disorder:
+            # Models that never disorder don't need to subtract out the
+            # ordering energy at disordered site fractions.
+            # See Lukas, Fries, Sundman Eq. 5.162
+            ordering_energy = ordered_energy
+        else:
+            ordering_energy = self._partitioned_expr(S.Zero, ordered_energy, {}, molefraction_dict)
 
         # 2: Replace the ordered energy contributions with the disordered contributions
         self.models.clear()

--- a/pycalphad/tests/databases/CoV-20Wan.tdb
+++ b/pycalphad/tests/databases/CoV-20Wan.tdb
@@ -1,0 +1,237 @@
+$
+$ Database for Co-V from P. Wang et al. 2020.
+$
+$ P. Wang, T. Hammerschmidt, U.R. Kattner, G.B. Olson,
+$ Calphad, 68, 101729(2020).
+$
+$ Dataset created 2020.07.25 by Bengt Hallstedt.
+$
+$ Sigma is modelled with an add-on model. In the paper the model is fractional
+$ which is converted to integer in this dataset.
+$
+$ There is no hcp interaction included in the paper. Using the same interaction
+$ as for fcc makes hcp stable above Co3V. The hcp interaction was set to
+$ 10 kJ/mol less than the fcc interaction.
+$
+$ The parameters for CoV3 are misprinted in the paper.
+$
+$ ------------------------------------------------------------------------------
+ TEMP-LIM 298.15 6000.00 !
+$
+$ELEMENT NAME  REF. STATE               ATOMIC MASS H298-H0    S298    !
+$
+ ELEMENT VA   VACUUM                      0.0          0.0      0.0    !
+ ELEMENT CO   HCP_A3                     58.9332    4765.567   30.0400 !
+ ELEMENT V    BCC_A2                     50.9415    4507.0     30.89   !
+$ ------------------------------------------------------------------------------
+$ Phase definitions
+$
+ PHASE LIQUID:L % 1 1 !
+ CONST LIQUID:L : CO V : !
+$
+$ Fcc (cF4, Fm-3m) and MeX (cF8, Fm-3m)
+$
+ PHASE FCC_A1 %A 2 1 1 !
+ CONST FCC_A1 : CO% V : VA : !
+$
+$ Disordered part of FCC_4SL, identical to FCC_A1
+$
+ PHASE A1_FCC %A 2 1 1 !
+ CONST A1_FCC : CO% V : VA : !
+$
+$ Prototype AuCu3 (cP4, Pm-3m, L1_2) and AuCu (tP4, P4/mmm, L1_0)
+$
+ PHASE FCC_4SL:F %AY 5 0.25 0.25 0.25 0.25 1 !
+ CONST FCC_4SL:F : CO V : CO V : CO V : CO V : VA : !
+$
+$ Bcc (cI2, Im-3m)
+$
+ PHASE BCC_A2 %B 2 1 3 !
+ CONST BCC_A2 : CO V% : VA : !
+$
+$ Hcp (hP2, P6_3/mmc) and Me2X (NiAs-type, hP4, P6_3/mmc, B8_1)
+$
+ PHASE HCP_A3 %A 2 1 0.5 !
+ CONST HCP_A3 : CO% V : VA : !
+$
+$ Prototype Al3Pu (hP24, P6_3/mmc)
+$
+ PHASE CO3V % 2 3 1 !
+ CONST CO3V : CO% V : CO V% : !
+$
+$ Disordered contribution to SIGMA_D8B
+$
+ PHASE DIS_SIGMA % 1 1 !
+ CONST DIS_SIGMA : CO V : !
+$
+$ Prototype CrFe (tP30)
+$
+ PHASE SIGMA_D8B %P 3 10 4 16 !
+ CONST SIGMA_D8B : CO V : CO V : CO V : !
+$
+$ Prototype Cr3Si (cP8, Pm-3n)
+$
+ PHASE COV3_A15 % 2 1 3 !
+ CONST COV3_A15 : CO : V : !
+$ ------------------------------------------------------------------------------
+$ Defaults
+$
+ DEFINE-SYSTEM-DEFAULT ELEMENT 2 !
+ DEFAULT-COM DEFINE_SYSTEM_ELEMENT VA !
+ TYPE-DEF % SEQ * !
+ TYPE-DEF A GES AMEND_PHASE_DESCRIPTION @ MAGNETIC -3 0.28 !
+ TYPE-DEF B GES AMEND_PHASE_DESCRIPTION @ MAGNETIC -1 0.4 !
+ TYPE-DEF P GES AMEND_PHASE_DESCRIPTION SIGMA_D8B NEVER_DIS DIS_SIGMA !
+ TYPE-DEF Y GES AMEND_PHASE_DESCRIPTION FCC_4SL DIS_PART A1_FCC !
+ FUNCTION ZERO      298.15  0;                                         6000 N !
+ FUNCTION UN_ASS    298.15  0;                                         6000 N !
+ FUNCTION R         298.15  +8.31451;                                  6000 N !
+$ ------------------------------------------------------------------------------
+$ Element data
+$ ------------------------------------------------------------------------------
+$ Co
+$
+ PAR  G(HCP_A3,CO:VA),,                 +GHSERCO;,,                   N 91Din !
+ PAR  TC(HCP_A3,CO:VA),,                 1396.00;,,                   N 91Din !
+ PAR  BM(HCP_A3,CO:VA),,                    1.35;,,                   N 91Din !
+ PAR  G(FCC_A1,CO:VA),,                 +GHSERCO
+             +427.591-0.615248*T;,,                                   N 91Din !
+ PAR  TC(FCC_A1,CO:VA),,                 1396.00;,,                   N 91Din !
+ PAR  BM(FCC_A1,CO:VA),,                    1.35;,,                   N 91Din !
+ PAR  G(A1_FCC,CO:VA),,                 +GHSERCO
+             +427.591-0.615248*T;,,                                   N 91Din !
+ PAR  TC(A1_FCC,CO:VA),,                 1396.00;,,                   N 91Din !
+ PAR  BM(A1_FCC,CO:VA),,                    1.35;,,                   N 91Din !
+ PAR  G(BCC_A2,CO:VA),,                 +GHSERCO+2938-0.7138*T;,,     N 91Din !
+ PAR  TC(BCC_A2,CO:VA),,                 1450.00;,,                   N 91Din !
+ PAR  BM(BCC_A2,CO:VA),,                    1.35;,,                   N 91Din !
+$PAR  G(CBCC_A12,CO:VA),,               +GHSERCO+4155;,,              N 91Din !
+$PAR  G(CUB_A13,CO:VA),,                +GHSERCO+3155;,,              N 91Din !
+ PAR  G(LIQUID,CO),,                    +GLIQCO;,,                    N 91Din !
+$
+ PAR  G(CO3V,CO:CO),,                   +4*GHSERCO+4408;,,            N 20Wan !
+ PAR  G(DIS_SIGMA,CO),,                 +GHSERCO+6958;,,              N 20Wan !
+ PAR  TC(SIGMA_D8B,CO:CO:CO),,           1400.00;,,                   N 20Wan !
+$PAR  BM(SIGMA_D8B,CO:CO:CO),,              1.66;,,                   N 20Wan !
+ PAR  BM(SIGMA_D8B,CO:CO:CO),,          5.5776E12;,,                  N 20Wan !
+$
+ FUNCTION GHSERCO   298.15  +310.241+133.36601*T-25.0861*T*LN(T)
+       -0.002654739*T**2-1.7348E-07*T**3+72527*T**(-1);
+      1768.00  Y  -17197.666+253.28374*T-40.5*T*LN(T)+9.3488E+30*T**(-9);
+      6000.00  N !
+ FUNCTION GLIQCO    298.15  +15085.037-8.931932*T+GHSERCO-2.19801E-21*T**7;
+      1768.00  Y  -846.61+243.599944*T-40.5*T*LN(T);
+      6000.00  N !
+ FUNCTION GFCCCO    298.15  +GHSERCO+427.59-0.615248*T;                6000 N !
+ FUNCTION GBCCCO    298.15  +GHSERCO+2938-0.7138*T;                    6000 N !
+$ ------------------------------------------------------------------------------
+$ V
+$
+ PAR  G(BCC_A2,V:VA),,                  +GHSERVV;                4000 N 91Din !
+ PAR  G(FCC_A1,V:VA),,                  +GHSERVV+7500+1.7*T;     4000 N 91Din !
+ PAR  G(A1_FCC,V:VA),,                  +GHSERVV+7500+1.7*T;     4000 N 91Din !
+ PAR  G(HCP_A3,V:VA),,                  +GHSERVV+4000+2.4*T;     4000 N 91Din !
+$PAR  G(CBCC_A12,V:VA),,                +GHSERVV+9000;           4000 N 91Din !
+$PAR  G(CUB_A13,V:VA),,                 +GHSERVV+10000;          4000 N 91Din !
+ PAR  G(LIQUID,V),,                     +GLIQVV;                 4000 N 91Din !
+$
+ PAR  G(CO3V,V:V),,                     +4*GHSERVV+93136;,,           N 20Wan !
+ PAR  G(DIS_SIGMA,V),,                  +GHSERVV+3768.4;,,            N 20Wan !
+$
+ FUNCTION GHSERVV   298.15  -7930.43+133.346053*T-24.134*T*LN(T)
+       -0.003098*T**2+1.2175E-07*T**3+69460*T**(-1);
+       790.00  Y  -7967.842+143.291093*T-25.9*T*LN(T)
+       +6.25E-05*T**2-6.8E-07*T**3;
+      2183.00  Y  -41689.864+321.140783*T-47.43*T*LN(T)+6.44389E+31*T**(-9);
+      4000.00  N !
+ FUNCTION GLIQVV    298.15  +20764.117-9.455552*T+GHSERVV-5.19136E-22*T**7;
+      2183.00  Y  -19617.51+311.055983*T-47.43*T*LN(T);
+      4000.00  N !
+ FUNCTION GFCCVV    298.15  +GHSERVV+7500+1.7*T;                       4000 N !
+$ ------------------------------------------------------------------------------
+$ Binary system
+$
+$ P. Wang, T. Hammerschmidt, U.R. Kattner, G.B. Olson,
+$ Calphad, 68, 101729(2020).
+$
+$ Checked against paper and author's tdb. Checked at 6000 K.
+$
+$ Sigma is modelled with an add-on model. In the paper the model is fractional
+$ which is converted to integer in this dataset.
+$
+$ There is no hcp interaction included in the paper. Using the same interaction
+$ as for fcc makes hcp stable above Co3V. The hcp interaction was set to
+$ 10 kJ/mol less than the fcc interaction.
+$
+$ The parameters for CoV3 are misprinted in the paper.
+$
+ PAR  L(LIQUID,CO,V;0),,                -60297.6+2.6502*T;,,          N 20Wan !
+ PAR  L(LIQUID,CO,V;1),,                -10417.3;,,                   N 20Wan !
+ PAR  L(LIQUID,CO,V;2),,                +18698.7;,,                   N 20Wan !
+$
+ PAR  L(FCC_A1,CO,V:VA;0),,             -69595.2+11.2314*T;,,         N 20Wan !
+ PAR  L(FCC_A1,CO,V:VA;1),,             -41802.8+4.2329*T;,,          N 20Wan !
+ PAR  L(FCC_A1,CO,V:VA;2),,             +29000;,,                     N 20Wan !
+ PAR  TC(FCC_A1,CO,V:VA;0),,            -2500.00;,,                   N 20Wan !
+ PAR  TC(FCC_A1,CO,V:VA;1),,            -1000.00;,,                   N 20Wan !
+$
+ PAR  L(A1_FCC,CO,V:VA;0),,             -69595.2+11.2314*T;,,         N 20Wan !
+ PAR  L(A1_FCC,CO,V:VA;1),,             -41802.8+4.2329*T;,,          N 20Wan !
+ PAR  L(A1_FCC,CO,V:VA;2),,             +29000;,,                     N 20Wan !
+ PAR  TC(A1_FCC,CO,V:VA;0),,            -2500.00;,,                   N 20Wan !
+ PAR  TC(A1_FCC,CO,V:VA;1),,            -1000.00;,,                   N 20Wan !
+$
+ PAR  G(FCC_4SL,CO:CO:CO:V:VA),,        +GFCO3V;,,                    N 20Wan !
+ PAR  G(FCC_4SL,CO:CO:V:V:VA),,         +GFCO2V2;,,                   N 20Wan !
+ PAR  G(FCC_4SL,CO:V:V:V:VA),,          +GFCOV3;,,                    N 20Wan !
+$
+ PAR  L(BCC_A2,CO,V:VA;0),,             -62617.3+12.1461*T;,,         N 20Wan !
+ PAR  L(BCC_A2,CO,V:VA;1),,             -18518.3;,,                   N 20Wan !
+$
+ PAR  L(HCP_A3,CO,V:VA;0),,             -59595.2+11.2314*T;,,         N Same !
+ PAR  L(HCP_A3,CO,V:VA;1),,             -41802.8+4.2329*T;,,          N Same !
+ PAR  L(HCP_A3,CO,V:VA;2),,             +29000;,,                     N Same !
+ PAR  TC(HCP_A3,CO,V:VA;0),,            -2500.00;,,                   N Same !
+ PAR  TC(HCP_A3,CO,V:VA;1),,            -1000.00;,,                   N Same !
+$
+ PAR  G(CO3V,CO:V),,                    +3*GHSERCO+GHSERVV
+             -91066+20.216*T;,,                                       N 20Wan !
+ PAR  G(CO3V,V:CO),,                    +GHSERCO+3*GHSERVV+19008;,,   N 20Wan !
+ PAR  L(CO3V,CO,V:V;0),,                -134045.2;,,                  N 20Wan !
+ PAR  L(CO3V,CO:CO,V;0),,               +80000;,,                     N 20Wan !
+$
+ PAR  L(DIS_SIGMA,CO,V;0),,             -27066.3;,,                   N 20Wan !
+ PAR  L(DIS_SIGMA,CO,V;1),,             -65628.6;,,                   N 20Wan !
+$
+ PAR  G(SIGMA_D8B,CO:CO:V),,            -509787+144.264*T;,,          N 20Wan !
+ PAR  G(SIGMA_D8B,CO:V:CO),,            -134364+154.911*T;,,          N 20Wan !
+ PAR  G(SIGMA_D8B,CO:V:V),,             -756849+84.471*T;,,           N 20Wan !
+ PAR  G(SIGMA_D8B,V:CO:CO),,            +83940;,,                     N 20Wan !
+ PAR  G(SIGMA_D8B,V:CO:V),,             -33474;,,                     N 20Wan !
+ PAR  G(SIGMA_D8B,V:V:CO),,             -169911;,,                    N 20Wan !
+$
+ PAR  G(COV3_A15,CO:V),,                +GHSERCO+3*GHSERVV
+             -84354.8+22.5684*T;,,                                    N 20Wan !
+$
+ FUNCTION U1FCOV    298.15  -4498.5+0.7535*T;                          6000 N !
+ FUNCTION GFCO3V    298.15  +3*U1FCOV;                                 6000 N !
+ FUNCTION GFCO2V2   298.15  +4*U1FCOV+9034.8;                          6000 N !
+ FUNCTION GFCOV3    298.15  +7000;                                     6000 N !
+$ ------------------------------------------------------------------------------
+$
+ ASSESSED_SYSTEM
+  CO-V(TDB -* +LIQUID +COV3_A15 +BCC_A2 +HCP_A3 +CO3V +A1_FCC
+  +FCC_4SL +SIGMA_D8B ;G5 C_S:HCP_4SL/CO:CO:CO:V:VA
+  MAJ:HCP_4SL/CO:CO:CO:CO:VA C_S:FCC_4SL/CO:CO:CO:CO:VA
+  ;P3 TMM:300/2300 STP:0.08/1000) !
+$
+$
+ LIST-OF-REFERENCE
+ NUMBER  SOURCE
+  Null   'Unknown source'
+  Same   'Same or similar interaction as in the corresponding stable phase'
+  REFLAV 'Laves phase convention: G(LAVES,X:X)=+3*GHSERXX+15000'
+  91Din  'A.T. Dinsdale, Calphad, 15, 317-425(1991).'
+  20Wan  'P. Wang, T. Hammerschmidt, U.R. Kattner, G.B. Olson,
+          Calphad, 68, 101729(2020); Co-V'
+!

--- a/pycalphad/tests/test_calculate.py
+++ b/pycalphad/tests/test_calculate.py
@@ -3,6 +3,7 @@ The calculate test module verifies that calculate() calculates
 Model quantities correctly.
 """
 
+import select
 import pytest
 from pycalphad import Database, calculate, Model, variables as v
 from itertools import chain
@@ -382,3 +383,39 @@ def test_calculate_raises_if_no_feasible_points_exist():
     # fake_points provides points and therefore calculate should not raise for having no points
     # fake_points also prevents the warning here
     grid = calculate(dbf, ["O", "ZR", "VA"], ["SPINEL"], P=1e5, T=1000, fake_points=True, to_xarray=False)
+
+
+@pytest.mark.filterwarnings("ignore:No valid points found for phase SPINEL*:UserWarning")  # Filter out an expected warning so we don't fail the test
+def test_calculate_raises_correctly_when_charged_phases_cannot_charge_balance():
+    """calculate should _not_ raise if there are phases that are infeasible, but overall there are still points
+
+    This test tests against a special case where a phase is charged and has internal DOF, but cannot charge balance.
+    We should see the same failure modes as above.
+    """
+
+    TDB = """
+    ELEMENT /-   ELECTRON_GAS              0.0000E+00  0.0000E+00  0.0000E+00!
+    ELEMENT VA   VACUUM                    0.0000E+00  0.0000E+00  0.0000E+00!
+    ELEMENT AL   BLANK                     0.0000E+00  0.0000E+00  0.0000E+00!
+    ELEMENT ZR   BLANK                     0.0000E+00  0.0000E+00  0.0000E+00!
+    SPECIES AL+3                        AL1/+3!
+    SPECIES ZR+4                        ZR1/+4!
+    PHASE SPINEL %  4 1 2 2 4 !
+    CONSTITUENT SPINEL : AL+3,ZR+4,VA : VA : VA :  !
+    PHASE GAS:G %  1  1.0  !
+    CONSTITUENT GAS:G :AL,VA,ZR :  !
+    """
+    dbf = Database(TDB)
+
+    # Gas can always charge balance, all is well
+    grid = calculate(dbf, ["AL", "ZR", "VA"], ["GAS"], P=1e5, T=1000, fake_points=False, to_xarray=False)
+    # SPINEL cannot charge balance without a negative ion.
+    # As it is the only active phase, there will be no points and should raise.
+    with pytest.raises(ConditionError):
+        grid = calculate(dbf, ["AL", "ZR", "VA"], ["SPINEL"], P=1e5, T=1000, fake_points=False, to_xarray=False)
+    # SPINEL still suspended, but doesn't raise because GAS phase provides points
+    with pytest.warns(match="No valid points found for phase SPINEL"):
+        grid = calculate(dbf, ["AL", "ZR", "VA"], ["GAS", "SPINEL"], P=1e5, T=1000, fake_points=False, to_xarray=False)
+    # fake_points provides points and therefore calculate should not raise for having no points
+    # fake_points also prevents the warning here
+    grid = calculate(dbf, ["AL", "ZR", "VA"], ["SPINEL"], P=1e5, T=1000, fake_points=True, to_xarray=False)

--- a/pycalphad/tests/test_calculate.py
+++ b/pycalphad/tests/test_calculate.py
@@ -167,11 +167,12 @@ def test_no_neutral_endmembers_single():
     np.testing.assert_allclose(np.squeeze(calc_res.Y.values), np.array([1/3, 2/3, 1]))
 
 
+@pytest.mark.filterwarnings("ignore:No valid points found for phase PYROCHLORE*:UserWarning")  # Filter out an expected warning so we don't fail the test
 @select_database("zrlayalo.tdb")
 def test_pyrochlore_infeasible(load_database):
     "calculate raises an error when it is impossible to satisfy a phase's constraints"
     dbf = load_database()
-    with pytest.raises(ValueError):
+    with pytest.raises(ConditionError):
         calculate(dbf, ['LA', 'Y', 'O'], 'PYROCHLORE', T=600, P=1e5, pdens=10)
 
 

--- a/pycalphad/tests/test_energy.py
+++ b/pycalphad/tests/test_energy.py
@@ -1400,3 +1400,29 @@ def test_higher_order_reciprocal_parameter():
         v.T: T
     }
     check_output(mod, subs_dict, 'GM', -12817.416, mode='sympy')
+
+
+
+@select_database("CoV-20Wan.tdb")
+def test_never_disorder_model(load_database):
+    """Test energy for a simple never disorder model (no disordered interaction parameters)"""
+    dbf = load_database()
+    m = Model(dbf, ['CO', 'V', 'VA'], 'SIGMA_D8B')
+
+    statevars = {
+                    v.T: 1250.0,
+                    v.SiteFraction('SIGMA_D8B', 0, 'CO'): 1, v.SiteFraction('SIGMA_D8B', 0, 'V'): 0,
+                    v.SiteFraction('SIGMA_D8B', 1, 'CO'): 0, v.SiteFraction('SIGMA_D8B', 1, 'V'): 1,
+                    v.SiteFraction('SIGMA_D8B', 2, 'CO'): 1, v.SiteFraction('SIGMA_D8B', 2, 'V'): 0,
+                }
+    # Values checked in Thermo-Calc
+    check_output(m, statevars, 'GM', -61190.088)
+
+    statevars = {
+                    v.T: 1250.0,
+                    v.SiteFraction('SIGMA_D8B', 0, 'CO'): 0.5, v.SiteFraction('SIGMA_D8B', 0, 'V'): 0.5,
+                    v.SiteFraction('SIGMA_D8B', 1, 'CO'): 0.5, v.SiteFraction('SIGMA_D8B', 1, 'V'): 0.5,
+                    v.SiteFraction('SIGMA_D8B', 2, 'CO'): 0.5, v.SiteFraction('SIGMA_D8B', 2, 'V'): 0.5,
+                }
+    # Values checked in Thermo-Calc
+    check_output(m, statevars, 'GM', -73928.245)

--- a/pycalphad/tests/test_equilibrium.py
+++ b/pycalphad/tests/test_equilibrium.py
@@ -1102,3 +1102,21 @@ def test_issue589_global_min(load_database):
     # Confirmed by turning point density up to 1e7
     assert_allclose(res.GM.values.squeeze(), np.array([-39263.10130208]))
     assert_allclose(res.MU.values.squeeze(), np.array([-73190.455829,  55931.596253, -59900.399453, -79250.493316, -80354.857076]))
+
+
+@select_database("CoV-20Wan.tdb")
+def test_equilibrium_never_disorder(load_database):
+    dbf = load_database()
+    comps = ["CO", "V", "VA"]
+    phases = list(dbf.phases.keys())
+    conditions = {v.N: 1, v.P: 1e5, v.T: 1250.0, v.X('V'): 0.60}
+    res = equilibrium(dbf, comps, phases, conditions, verbose=True)
+    print("Equilibrium Phase", res.Phase.values.squeeze())
+    print("Equilibrium NP", res.NP.values.squeeze())
+    print("Equilibrium GM", res.GM.values.squeeze())
+    print("Equilibrium Y", res.Y.values.squeeze())
+    assert res.Phase.values.squeeze().tolist() == ["SIGMA_D8B", "", ""]
+    # Values checked in Thermo-Calc
+    assert_allclose(res.GM.values.squeeze(), np.array([-80134.504]))
+    assert_allclose(res.MU.values.squeeze(), np.array([-84691.297, -77096.642]), rtol=1e-6)
+    assert_allclose(res.Y.values.squeeze()[0,:6], np.array([0.99942828, 5.7172171E-4, 1.2760143E-2, 0.98723986, 0.12216729, 0.87783271,]), rtol=2e-5)

--- a/pycalphad/tests/test_utils.py
+++ b/pycalphad/tests/test_utils.py
@@ -41,6 +41,17 @@ def test_filter_phases_removes_phases_with_inactive_sublattices(load_database):
     assert all_phases.difference(filtered_phases) == {'FCC_A1', 'PT8AL21', 'PT5AL21', 'PT2AL', 'PT2AL3', 'PT5AL3', 'ALPT2'}
 
 
+@select_database("CoV-20Wan.tdb")
+def test_filter_phases_removes_disordered_part_of_never_disorder_models(load_database):
+    """Phases that are the disordered part of a never disorder model should be removed"""
+    dbf = load_database()
+    all_phases = set(dbf.phases.keys())
+    filtered_phases = set(filter_phases(dbf, unpack_species(dbf, ['CO', 'V', 'VA'])))
+
+    # A1_FCC and DIS_SIGMA are disordered parts and should be removed
+    assert all_phases.difference(filtered_phases) == {"A1_FCC", "DIS_SIGMA"}
+
+
 @select_database("alnipt.tdb")
 def test_instantiate_models_only_returns_desired_phases(load_database):
     """instantiate_models should only return phases passed"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dev = [
     "furo>=2021.11.16",  # docs theme
     "ipython",  # for pygments syntax highlighting
     "pytest-cov",
-    "sphinx",
+    "sphinx<9",
     "nbsphinx-link",
     "docutils<0.21", # workaround for https://github.com/vidartf/nbsphinx-link/issues/22
 ]


### PR DESCRIPTION
<!--

Thank you for pull request.

Below are a few things we ask you kindly to self-check before getting a review.

-->

Checklist
* [x] Include a plain language description of your changes.
* [x] Any dependency changes are reflected in the `pyproject.toml`.

This PR implements the `NEVER_DISORDER` model described in Section 5.8.5 of Lukas, Fries, and Sundman, Computational Thermodynamics: the Calphad Method, Cambridge University Press (2007). It closes https://github.com/pycalphad/pycalphad/issues/152.

The enabling features are:
1. Extension of the TDB type definition handling to accept NEVER_DISORDER, which adds a boolean flag to the model hints
2. Modify `Model.atomic_ordering_energy` to remove configurational energy from the disordered part and to not subtract out the ordering energy at disordered site fractions.
3. tests of the energy at specific site fractions and for an equilibrium calculation that are in agreement with those computed by Thermo-Calc in a new database added to the test suite and a test that the disordered parts are filtered out by `filter_phases`.

I also separately checked a Co-Ta phase diagram and some point calculations against Thermo-Calc, which uses a disordered model for MU phase. I didn't have reason to expect it wouldn't work, but we get the same answer.

In addition, this PR also 
1. fixes docs builds by temporarily pinning to `sphinx<9`
2. fixes linux wheel builds that were failing to find OpenBLAS in the manylinux2014 image by dropping the image variable to accept the latest default. Previously it looks like we were bumping these manually (to use something newer?), but I think that is no longer necessary since these tools have become popular and just using the default latest images are probably best. Also drops deprecated version skips for very old Python versions.
3. fixes a separate bug where charged phases with internal degrees of freedom were raising exceptions of the form, in a slightly more general form of the bug fixed in https://github.com/pycalphad/pycalphad/pull/627.

```python
Traceback (most recent call last):
  File "/Users/bocklund1/src/calphad-workspace/packages/pycalphad/worktrees/never-disorder-model/trigger-bug.py", line 8, in <module>
    calculate(dbf, comps, ["C1_MO2"], P=101325, T=300, N=1)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/bocklund1/src/calphad-workspace/packages/pycalphad/worktrees/never-disorder-model/pycalphad/core/calculate.py", line 520, in calculate
    points = _sample_phase_constitution(mod, sampler_dict[phase_name] or point_sample,
                                        fixedgrid_dict[phase_name], pdens_dict[phase_name],
                                        {})
  File "/Users/bocklund1/src/calphad-workspace/packages/pycalphad/worktrees/never-disorder-model/pycalphad/core/cache.py", line 141, in wrapper
    result = user_function(*args, **kwds)
  File "/Users/bocklund1/src/calphad-workspace/packages/pycalphad/worktrees/never-disorder-model/pycalphad/core/calculate.py", line 177, in _sample_phase_constitution
    points = np.concatenate((points, extra_points))
ValueError: all the input arrays must have same number of dimensions, but the array at index 0 has 1 dimension(s) and the array at index 1 has 2 dimension(s)
```
