### PR TITLE
added zip equilibrium

### DIFF
--- a/pycalphad/__init__.py
+++ b/pycalphad/__init__.py
@@ -13,7 +13,7 @@ import pycalphad.io.cs_dat
 from pycalphad.model import Model, ReferenceState
 
 from pycalphad.core.calculate import calculate
-from pycalphad.core.equilibrium import equilibrium
+from pycalphad.core.equilibrium import equilibrium, zip_equilibrium
 from pycalphad.core.workspace import Workspace
 from pycalphad.plot.eqplot import eqplot
 from pycalphad.property_framework import as_property

--- a/pycalphad/core/equilibrium.py
+++ b/pycalphad/core/equilibrium.py
@@ -3,11 +3,19 @@ The equilibrium module defines routines for interacting with
 calculated phase equilibria.
 """
 import warnings
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 from collections.abc import Iterable
 from datetime import datetime
+import pycalphad.variables as v
 from pycalphad.core.workspace import Workspace
 from pycalphad.core.light_dataset import LightDataset
+from pycalphad.core.solver import Solver
+from pycalphad.core.starting_point import starting_point
+from pycalphad.core.eqsolver import _solve_eq_at_conditions
+from pycalphad.core.utils import filter_phases, instantiate_models
+from pycalphad.codegen.phase_record_factory import PhaseRecordFactory
+from pycalphad.property_framework.units import as_quantity
+from pycalphad.core.calculate import calculate
 import numpy as np
 from pycalphad.property_framework import as_property
 
@@ -88,3 +96,115 @@ def equilibrium(dbf, comps, phases, conditions, output=None, model=None,
     if len(kwargs) > 0:
         warnings.warn('The following equilibrium keyword arguments were passed, but unused:\n{}'.format(kwargs))
     return properties
+
+
+def zip_equilibrium(dbf, comps, phases, xs, solutes, T, P, pdens=60, calc_opts=None,
+                    solver=None, verbose=False):
+    """
+    Calculate equilibria at paired composition rows without expanding composition axes.
+
+    Parameters
+    ----------
+    dbf : Database
+        Thermodynamic database.
+    comps : list
+        Names of components to consider in the calculation.
+    phases : list or dict
+        Names of phases to consider in the calculation.
+    xs : array-like, shape (n_points, n_components_without_va)
+        Composition rows. Column 0 is the dependent component. Columns 1 and
+        onward correspond to ``solutes``.
+    solutes : list
+        Independent components matching columns 1 and onward in ``xs``.
+    T : float or array-like
+        Scalar, paired, or broadcast temperatures in K. A scalar temperature
+        returns one result per composition row. A temperature array with the
+        same length as ``xs`` pairs each temperature with the corresponding row.
+        Any other temperature array is broadcast as temperature-major results.
+    P : float
+        Pressure in Pa.
+    pdens : int
+        Point density passed to ``calculate``.
+    calc_opts : dict, optional
+        Keyword arguments to pass to ``calculate``.
+    solver : SolverBase, optional
+        Solver instance.
+    verbose : bool, optional
+        Print details of calculations.
+
+    Returns
+    -------
+    list of xarray.Dataset
+        Equilibrium results for the paired or broadcast points.
+    """
+    if calc_opts is None:
+        calc_opts = {}
+    calc_opts = dict(calc_opts)
+    calc_opts.setdefault('pdens', pdens)
+    if solver is None:
+        solver = Solver(verbose=verbose)
+
+    xs = np.asarray(xs, dtype=float)
+    temperatures = np.atleast_1d(np.asarray(T, dtype=float))
+    point_count = len(xs)
+
+    if len(temperatures) == 1:
+        mode = 'scalar'
+    elif len(temperatures) == point_count:
+        mode = 'paired'
+    else:
+        mode = 'broadcast'
+
+    if isinstance(phases, str):
+        phases = [phases]
+    active_phases = [str(phase) for phase in filter_phases(dbf, v.unpack_components(comps), phases)]
+    models = instantiate_models(dbf, comps, active_phases)
+    state_variables = [v.N, v.P, v.T]
+    phase_record_factory = PhaseRecordFactory(dbf, comps, state_variables, models)
+
+    def build_grid(temperature):
+        return calculate(dbf, comps, active_phases, model=models, fake_points=True,
+                         phase_records=phase_record_factory, output='GM', to_xarray=False,
+                         N=1, T=float(temperature), P=P, **calc_opts)
+
+    def solve_row(row, temperature, grid):
+        conditions = OrderedDict()
+        conditions[v.N] = [1.0]
+        conditions[v.T] = [float(temperature)]
+        conditions[v.P] = [float(P)]
+        for index, solute in enumerate(solutes):
+            mole_fraction = float(row[index + 1])
+            mole_fraction = min(max(mole_fraction, 1e-10), 1 - 1e-10)
+            conditions[v.X(solute)] = [mole_fraction]
+
+        unitless_conditions = OrderedDict(
+            (key, as_quantity(key, value).to(key.implementation_units).magnitude)
+            for key, value in conditions.items()
+        )
+        properties = starting_point(unitless_conditions, state_variables, phase_record_factory, grid)
+        properties = _solve_eq_at_conditions(properties, phase_record_factory, grid,
+                                             list(unitless_conditions.keys()), state_variables,
+                                             verbose, solver=solver)
+        return properties.get_dataset()
+
+    if mode == 'scalar':
+        grid = build_grid(temperatures[0])
+        return [solve_row(row, temperatures[0], grid) for row in xs]
+
+    if mode == 'paired':
+        groups = defaultdict(list)
+        for index, (row, temperature) in enumerate(zip(xs, temperatures)):
+            groups[temperature].append((index, row))
+        results = [None] * point_count
+        for temperature in np.unique(temperatures):
+            grid = build_grid(temperature)
+            for original_index, row in groups[temperature]:
+                results[original_index] = solve_row(row, temperature, grid)
+        return results
+
+    results = []
+    for temperature in temperatures:
+        grid = build_grid(temperature)
+        for row in xs:
+            results.append(solve_row(row, temperature, grid))
+    return results

--- a/pycalphad/tests/test_equilibrium.py
+++ b/pycalphad/tests/test_equilibrium.py
@@ -9,7 +9,7 @@ import pytest
 from symengine import Symbol
 from numpy.testing import assert_allclose
 import numpy as np
-from pycalphad import Database, Model, calculate, equilibrium, EquilibriumError, ConditionError
+from pycalphad import Database, Model, calculate, equilibrium, zip_equilibrium, EquilibriumError, ConditionError
 from pycalphad.codegen.phase_record_factory import PhaseRecordFactory
 from pycalphad.core.solver import SolverBase, Solver
 from pycalphad.core.utils import get_state_variables, instantiate_models
@@ -74,6 +74,39 @@ def test_eq_single_phase(load_database):
                      {v.T: [1400, 2500], v.P: 101325,
                       v.X('AL'): [0.1, 0.2, 0.3, 0.7, 0.8]}, verbose=True)
     assert_allclose(np.squeeze(eq.GM), np.squeeze(res.GM), atol=0.1)
+
+
+@select_database("alfe.tdb")
+def test_zip_equilibrium_scalar_temperature(load_database):
+    "Zipped composition rows match separate scalar equilibrium calls."
+    dbf = load_database()
+    comps = ['AL', 'FE', 'VA']
+    phases = 'LIQUID'
+    xs = np.array([[0.9, 0.1], [0.8, 0.2], [0.7, 0.3]])
+    results = zip_equilibrium(dbf, comps, phases, xs, ['AL'], 1400, 101325)
+
+    assert len(results) == len(xs)
+    for row, zipped_result in zip(xs, results):
+        expected = equilibrium(dbf, comps, phases, {v.T: 1400, v.P: 101325, v.X('AL'): row[1]})
+        assert_allclose(np.squeeze(zipped_result.GM), np.squeeze(expected.GM), atol=0.1)
+
+
+@select_database("alfe.tdb")
+def test_zip_equilibrium_broadcast_temperature(load_database):
+    "Zipped composition rows can be broadcast over temperature without Cartesian composition expansion."
+    dbf = load_database()
+    comps = ['AL', 'FE', 'VA']
+    phases = 'LIQUID'
+    temperatures = [1400, 1500]
+    xs = np.array([[0.9, 0.1], [0.8, 0.2], [0.7, 0.3]])
+    results = zip_equilibrium(dbf, comps, phases, xs, ['AL'], temperatures, 101325)
+
+    assert len(results) == len(temperatures) * len(xs)
+    for index, zipped_result in enumerate(results):
+        temperature = temperatures[index // len(xs)]
+        row = xs[index % len(xs)]
+        expected = equilibrium(dbf, comps, phases, {v.T: temperature, v.P: 101325, v.X('AL'): row[1]})
+        assert_allclose(np.squeeze(zipped_result.GM), np.squeeze(expected.GM), atol=0.1)
 
 
 @select_database("alnipt.tdb")


### PR DESCRIPTION
Hey Everyone,

Disclaimer, the code was written by AI, though I have been carefully testing & validating it. (This text of this PR is completely written by hand.) 

I have a use case where I want to do 'high throughput' CALPHAD computations over the Al-Cu-Mg-Zn-..... simplex for a grid of temperatures and compositions. My understanding is that the current 'equilibrium' code is not very well suited to this because it runs a cartesian product over compositions & temperatures. I had a coding agent create a version of equilibrium version that 'zips' the conditions before running. 

As far as I can tell the 'zip equilibrium' with a massive speed bump compared to the built in method. I am guessing it probably runs with some combinatorial factor. For example on a 4 element, fairly coarse grid I get a 22x speedup over the built in method. There are some deviations but they are, as far as I can tell, very small ~10^-12 - ~10^-7 in composition, so in line with numerical error. 

While I would hestitate to make a pull request using 'AI slop' the speedup is so large that I thought it would be worth it. Especially given that the error seems fairly small (and for many use cases, like mine quite acceptable). That said I am very happy to pitch in and try to run more validation. I have included a version of the validation script I have been using so far which will confirm the large speedup and low error. 

It would be great if someone could help me confirm this is fine. I wanted to merge this in more smoothly, but am finding the 'workspace' logic a bit hard to parse. 

Thanks!

Daniel 

Unit tests have been added, below is the script I used to 'manually' verify the results. You should run it in the 'examples' directory or adjust the tdb path


```
from itertools import product
from pathlib import Path
from time import perf_counter

import numpy as np
import pandas as pd

from pycalphad import Database, equilibrium, variables as v, zip_equilibrium


dbf = Database(Path("pycalphad/tests/databases/COST507.tdb"))
components = ["AL", "MG", "SI", "CU", "VA"]
elements = components[:-1]
solutes = elements[1:]
phases = list(dbf.phases.keys())
temperatures = [1000.0, 1250.0, 1500.0]
pressure = 101325.0
density = 4
eps = 1e-4
phase_amount_cutoff = 1e-8


def composition_grid(component_count, density):
    rows = []
    for counts in product(range(density + 1), repeat=component_count):
        if sum(counts) == density:
            row = np.asarray(counts, dtype=float) / density
            row = np.clip(row, eps, 1.0)
            rows.append(row / row.sum())
    return np.asarray(rows)


def phase_values(eq_result):
    phase_names = np.asarray(eq_result.Phase.squeeze(drop=True).values).reshape(-1)
    phase_amounts = np.asarray(eq_result.NP.squeeze(drop=True).values, dtype=float).reshape(-1)
    phase_compositions = {
        element: np.asarray(eq_result.X.sel(component=element).squeeze(drop=True).values, dtype=float).reshape(-1)
        for element in elements
    }

    values = {}
    largest_amounts = {}
    for vertex, phase_name in enumerate(phase_names):
        phase_name = str(phase_name).strip()
        if not phase_name or phase_name.upper() == "NAN" or vertex >= len(phase_amounts):
            continue

        phase_amount = float(phase_amounts[vertex])
        if not np.isfinite(phase_amount) or phase_amount <= phase_amount_cutoff:
            continue
        if phase_amount <= largest_amounts.get(phase_name, -np.inf):
            continue

        largest_amounts[phase_name] = phase_amount
        values[f"NP_{phase_name}"] = phase_amount
        for element in elements:
            values[f"X_{phase_name}_{element}"] = phase_compositions[element][vertex]
    return values


def result_row(temperature, composition, eq_result):
    row = {"T_K": float(temperature)}
    for index, element in enumerate(elements):
        row[f"X_{element}"] = float(composition[index])
    row.update(phase_values(eq_result))
    return row


def drop_empty_columns(frame):
    return frame.dropna(axis="columns", how="all")


def difference_frame(classic_frame, zip_frame):
    key_columns = ["T_K"] + [f"X_{element}" for element in elements]
    output = classic_frame[key_columns].copy()
    value_columns = [column for column in classic_frame.columns if column not in key_columns]

    for column in value_columns:
        classic_values = pd.to_numeric(classic_frame[column], errors="coerce")
        zip_values = pd.to_numeric(zip_frame[column], errors="coerce")
        output[f"delta_{column}"] = zip_values - classic_values
    return drop_empty_columns(output)


composition_rows = composition_grid(len(elements), density)


# Current pycalphad usage: independent composition axes are expanded into a Cartesian grid.
classic_axes = {
    solute: np.unique(np.round(composition_rows[:, index], 12))
    for index, solute in enumerate(solutes, start=1)
}

classic_conditions = {v.T: temperatures, v.P: pressure}
for solute, values in classic_axes.items():
    classic_conditions[v.X(solute)] = values

classic_points = len(temperatures)
for solute in solutes:
    classic_points *= len(classic_conditions[v.X(solute)])

start = perf_counter()
classic_result = equilibrium(dbf, components, phases, classic_conditions)
classic_seconds = perf_counter() - start

classic_rows = []
for temperature in temperatures:
    for composition in composition_rows:
        selectors = {"T": float(temperature)}
        for index, solute in enumerate(solutes, start=1):
            selectors[f"X_{solute}"] = float(np.round(composition[index], 12))
        classic_rows.append(result_row(temperature, composition, classic_result.sel(selectors, method="nearest")))
classic_frame = drop_empty_columns(pd.DataFrame(classic_rows))


# Zip usage: generated composition rows are evaluated as paired points.
zip_xs = composition_rows
zip_points = len(temperatures) * len(zip_xs)

start = perf_counter()
zip_results = zip_equilibrium(dbf, components, phases, zip_xs, solutes, temperatures, pressure)
zip_seconds = perf_counter() - start

zip_rows = []
result_index = 0
for temperature in temperatures:
    for composition in zip_xs:
        zip_rows.append(result_row(temperature, composition, zip_results[result_index]))
        result_index += 1
zip_frame = drop_empty_columns(pd.DataFrame(zip_rows))

all_columns = list(dict.fromkeys(list(classic_frame.columns) + list(zip_frame.columns)))
classic_frame = classic_frame.reindex(columns=all_columns)
zip_frame = zip_frame.reindex(columns=all_columns)
keep_columns = drop_empty_columns(pd.concat([classic_frame, zip_frame], ignore_index=True)).columns
classic_frame = classic_frame.reindex(columns=keep_columns)
zip_frame = zip_frame.reindex(columns=keep_columns)
difference = difference_frame(classic_frame, zip_frame)

classic_frame.to_csv("classic.csv", index=False)
zip_frame.to_csv("zip.csv", index=False)
difference.to_csv("classic_zip_difference.csv", index=False)

print(f"composition rows: {len(zip_xs)}")
print(f"classic Cartesian points: {classic_points}")
print(f"zip paired points: {zip_points}")
print(f"classic equilibrium: {classic_seconds:.3f} s")
print(f"zip_equilibrium: {zip_seconds:.3f} s")
print(f"speedup: {classic_seconds / zip_seconds:.1f}x")
print("wrote classic.csv")
print("wrote zip.csv")
print("wrote classic_zip_difference.csv")

```