### PR TITLE
ENH: Use dynamic axis labels from StateVariable attributes in eqplot

### DIFF
--- a/pycalphad/plot/binary/plot.py
+++ b/pycalphad/plot/binary/plot.py
@@ -6,7 +6,7 @@ as `equilibrium`.
 
 import pycalphad.variables as v
 import matplotlib.pyplot as plt
-from pycalphad.plot.eqplot import _axis_label
+from pycalphad.mapping.plotting import get_label
 from pycalphad.plot.utils import phase_legend
 from .map import map_binary
 
@@ -62,8 +62,8 @@ def plot_boundaries(zpf_boundary_sets, tielines=True, tieline_color=(0, 1, 0, 1)
     ax.grid(True)
     plot_title = '-'.join([component for component in sorted(zpf_boundary_sets.components) if component != 'VA'])
     ax.set_title(plot_title, fontsize=20)
-    ax.set_xlabel(_axis_label(zpf_boundary_sets.indep_comp_cond), labelpad=15, fontsize=20)
-    ax.set_ylabel(_axis_label(v.T), fontsize=20)
+    ax.set_xlabel(get_label(zpf_boundary_sets.indep_comp_cond), labelpad=15, fontsize=20)
+    ax.set_ylabel(get_label(v.T), fontsize=20)
     ax.set_xlim(0, 1)
     # autoscale needs to be used in case boundaries are plotted as lines because
     # only plotting line collections will not rescale the axes

--- a/pycalphad/plot/eqplot.py
+++ b/pycalphad/plot/eqplot.py
@@ -3,6 +3,7 @@ The eqplot module contains functions for general plotting of
 the results of equilibrium calculations.
 """
 from pycalphad.core.utils import unpack_condition
+from pycalphad.mapping.plotting import get_label
 from pycalphad.plot.utils import phase_legend
 import pycalphad.variables as v
 from matplotlib import collections as mc
@@ -10,17 +11,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 from collections import OrderedDict
 
-# TODO: support other state variables here or make isinstance elif == v.T or v.P
-_plot_labels = {v.T: 'Temperature (K)', v.P: 'Pressure (Pa)'}
-
-
-def _axis_label(ax_var):
-    if isinstance(ax_var, v.MoleFraction):
-        return 'X({})'.format(ax_var.species.name)
-    elif isinstance(ax_var, v.StateVariable):
-        return _plot_labels[ax_var]
-    else:
-        return ax_var
 
 def _map_coord_to_variable(coord):
     """
@@ -35,7 +25,7 @@ def _map_coord_to_variable(coord):
     -------
     pycalphad StateVariable
     """
-    vals = {'T': v.T, 'P': v.P}
+    vals = {'T': v.T, 'P': v.P, 'N': v.N}
     if coord.startswith('X_'):
         return v.X(coord[2:])
     elif coord in vals:
@@ -186,7 +176,7 @@ def eqplot(eq, ax=None, x=None, y=None, z=None, tielines=True, tieline_color=(0,
     ax.grid(True)
     plot_title = '-'.join([component.title() for component in sorted(comps) if component != 'VA'])
     ax.set_title(plot_title, fontsize=20)
-    ax.set_xlabel(_axis_label(x), labelpad=15, fontsize=20)
-    ax.set_ylabel(_axis_label(y), fontsize=20)
+    ax.set_xlabel(get_label(x), labelpad=15, fontsize=20)
+    ax.set_ylabel(get_label(y), fontsize=20)
 
     return ax


### PR DESCRIPTION
The _plot_labels dict in eqplot.py was hardcoded to only T and P, so passing any other state variable (like N) to _axis_label() would raise a KeyError. The same issue existed in _map_coord_to_variable().

Since every StateVariable subclass already defines display_name and display_units, I replaced the hardcoded dict with dynamic label generation using those attributes. Also updated _map_coord_to_variable() to build its lookup table dynamically from pycalphad.variables instead of listing variables manually.

Other small additions:

MassFraction support in _axis_label() for consistency with MoleFraction
9 unit tests for both functions
Note: axis labels change from abbreviated units (K, Pa) to the display_units already on the classes (kelvin, pascal). Happy to adjust if a different format is preferred.