### PR TITLE
FIX: Fix constraint violation in Hit & Run sampler

### DIFF
--- a/pycalphad/core/polytope.py
+++ b/pycalphad/core/polytope.py
@@ -92,28 +92,25 @@ def constraints_from_bounds(lower, upper):
     return A, b
 
 
-def affine_subspace(A, b):
-    """Compute a basis of the nullspace of A, and a particular solution to Ax = b.
-    This allows to to construct arbitrary solutions as the sum of any vector in the
-    nullspace, plus the particular solution.
+def _feasible_particular_solution(A, b, lower, upper):
+    """Find a particular solution to Ax = b that also satisfies lower <= x <= upper.
 
-    Parameters
-    ----------
-    A : 2d-array of shape (n_constraints, dimension)
-        Left-hand-side of Ax <= b.
-    b : 1d-array of shape (n_constraints)
-        Right-hand-side of Ax <= b.
+    Uses a bounded least-squares solve (BVLS active set). Returns None if no
+    feasible point exists (the polytope is empty).
 
-    Returns
-    -------
-    N: 2d-array of shape (dimension, dimension)
-        Orthonormal basis of the nullspace of A.
-    xp: 1d-array of shape (dimension)
-        Particular solution to Ax = b.
+    The returned solution is nudged 1e-14 into the strict interior of the box.
+    BVLS is an active-set method and will return solutions with components
+    sitting exactly on the box bounds. The downstream Hit-and-Run sampler in
+    sample() needs xp strictly inside the box: it parameterises the polytope
+    as bt = b1 - A1 @ xp where A1 includes the box constraints, and any
+    bt component sitting at zero collapses the sampler's wiggle room in that
+    direction. Since BVLS already returns a point inside the box, the 1e-14
+    nudge perturbs A xp = b by at most ~||A|| * 1e-14.
     """
-    N = scipy.linalg.null_space(A)
-    xp = np.linalg.pinv(A) @ b
-    return N, xp
+    res = scipy.optimize.lsq_linear(A, b, bounds=(lower, upper), method="bvls")
+    if np.max(np.abs(A @ res.x - b)) > 1e-8:
+        return None
+    return np.clip(res.x, lower + 1e-14, upper - 1e-14)
 
 def sample(n_points, lower, upper, A1=None, b1=None, A2=None, b2=None):
     """Sample a number of points from a convex polytope A1 x <= b1 using the Hit & Run
@@ -153,14 +150,13 @@ def sample(n_points, lower, upper, A1=None, b1=None, A2=None, b2=None):
 
     if (A2 is not None) and (b2 is not None):
         check_Ab(A2, b2)
-        N, xp = affine_subspace(A2, b2)
+        N = scipy.linalg.null_space(A2)
+        xp = _feasible_particular_solution(A2, b2, lower, upper)
+        if xp is None:
+            raise ValueError("Unable to find a feasible solution")
     else:
         N = np.eye(A1.shape[1])
         xp = np.zeros(A1.shape[1])
-
-    # Do not allow particular solutions to fall outside of bounds
-    # This operation helps with numerical robustness
-    xp = np.clip(xp, lower+1e-14, upper-1e-14)
 
     if N.shape[1] == 0:
         # zero-dimensional polytope, return unique solution

--- a/pycalphad/tests/test_calculate.py
+++ b/pycalphad/tests/test_calculate.py
@@ -3,13 +3,15 @@ The calculate test module verifies that calculate() calculates
 Model quantities correctly.
 """
 
-import select
 import pytest
 from pycalphad import Database, calculate, Model, variables as v
 from itertools import chain
 import numpy as np
 from numpy.testing import assert_allclose
 from pycalphad.codegen.phase_record_factory import PhaseRecordFactory
+from pycalphad.core.calculate import _jacobian_from_constraints
+from pycalphad.core.constants import MIN_SITE_FRACTION
+from pycalphad.core.polytope import sample
 from pycalphad.core.utils import instantiate_models
 from pycalphad import ConditionError
 from pycalphad.tests.fixtures import select_database, load_database
@@ -420,3 +422,43 @@ def test_calculate_raises_correctly_when_charged_phases_cannot_charge_balance():
     # fake_points provides points and therefore calculate should not raise for having no points
     # fake_points also prevents the warning here
     grid = calculate(dbf, ["AL", "ZR", "VA"], ["SPINEL"], P=1e5, T=1000, fake_points=True, to_xarray=False)
+
+
+def test_calculate_produces_no_infeasible_points_for_charged_phase():
+    """Test that MgO-Al2O3 SPINEL phase can have points sampled via calculate and not raise due to points volating the constraints"""
+
+    _tdb_str = """
+    ELEMENT /- ELECTRON_GAS 0.0 0.0 0.0 !
+    ELEMENT AL BLANK 26.982 0.0 0.0 !
+    ELEMENT MG BLANK 24.305 0.0 0.0 !
+    ELEMENT O BLANK 15.999 0.0 0.0 !
+    ELEMENT VA VACUUM 0.0 0.0 0.0 !
+
+    SPECIES AL+3 AL1.0/+3 !
+    SPECIES MG+2 MG1.0/+2 !
+    SPECIES O-2 O1.0/-2 !
+
+    TYPE_DEFINITION % SEQ * !
+    DEFINE_SYSTEM_DEFAULT ELEMENT 2 !
+    DEFAULT_COMMAND DEFINE_SYSTEM_ELEMENT /- VA !
+
+    PHASE SPINEL:I %  3 1.0 2.0 4.0 !
+    CONSTITUENT SPINEL:I :AL+3,MG+2 : AL+3,MG+2,VA : O-2: !
+    """
+
+    dbf = Database(_tdb_str)
+    comps = ["MG", "AL", "O", "VA"]
+    phase_name = "SPINEL"
+    model = Model(dbf, comps, phase_name)
+
+    # When failing, this tends to produce constraint violations where the second sublattice (Al+3, Mg+2, Va) does not mass balance
+    num_points = 2
+    model_constraints = model.get_internal_constraints()
+    constraint_jac, constraint_rhs = _jacobian_from_constraints(model_constraints, model.site_fractions)
+    extra_points = sample(num_points, np.full(constraint_jac.shape[1], MIN_SITE_FRACTION), np.ones(constraint_jac.shape[1]), A2=constraint_jac, b2=constraint_rhs)
+    print(f"extra_points: {extra_points}")
+    constraints_for_points = np.abs(constraint_jac.dot(extra_points.T).T)
+    np.testing.assert_allclose(constraints_for_points, np.broadcast_to(constraint_rhs, constraints_for_points.shape), atol=1e-6, err_msg="`extra_points` produced by polytope sampler should produce feasible points")
+
+    # success if the phase does not raise
+    calc_res = calculate(dbf, comps, [phase_name], pdens=60)


### PR DESCRIPTION
Issue #675 exposed a case where the Hit & Run sampler returned extra points that violated a sublattice mass balance constraint. The root cause is that it was using `np.linalg.pinv` that gave a solution outside the box, which was then clipped inside the box in a way that violated the constraint.

Here we switch to `scipy.optimize.lst_linear` which allows passing lower/upper bounds and gives solutions, if available, inside the box. If solutions are not found, it returns `None` which raises - raising should be the correct behavior because anything that gets to this point in the H&R sampler should be able to be made feasible.

Isolated benchmarking shows that using `lst_linear` is about a 2-3x performance loss over `pinv` (20 µs -> 50 µs). With caching of points, this should be relatively inconsequential and better than using `scipy.optimize.linprog` which has about 450 µs (calls to `sample` are about 1500 µs currently, so this is a relevant amount).

Includes a test isolated from #675.