### PR TITLE
FIX: raise `ConditionError` in `calculate()` when there are missing state variables

### DIFF
--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -485,6 +485,23 @@ def calculate(dbf, comps, phases, mode=None, output='GM', fake_points=False, bro
         if len(active_phases_without_models) > 0:
             raise ValueError(f"model must contain a Model instance for every active phase. Missing Model objects for {sorted(active_phases_without_models)}")
 
+    # Every state variable the phase records were compiled against must have a
+    # value. The compiled property functions take `phase_records.state_variables + site_fractions`
+    # as input, but `calculate()` builds the dof's state-variable columns from
+    # `statevar_dict`. If a Model requires a potential (e.g. T or P) that the
+    # caller of `calcuate()` did not provide, the dof would be have a different
+    # shape than the compiled function expects and the function would read past
+    # the end of the dof buffer. We fail loudly in that case.
+    required_statevars = {str(sv) for sv in phase_records.state_variables}
+    supplied_statevars = {str(sv) for sv in statevar_dict.keys()}
+    missing_statevars = sorted(required_statevars - supplied_statevars)
+    if missing_statevars:
+        raise ConditionError(
+            f"The following state variable(s) are required by the Model(s) for the active "
+            f"phases but were not specified: {missing_statevars}. Specify them as keyword "
+            f"arguments to calculate(), e.g. calculate(..., T=300)."
+        )
+
     maximum_internal_dof = max(len(models[phase_name].site_fractions) for phase_name in active_phases)
 
     phase_local_conditions = {key: unpack_condition(value)

--- a/pycalphad/tests/test_calculate.py
+++ b/pycalphad/tests/test_calculate.py
@@ -69,6 +69,10 @@ def test_issue116(load_database):
     assert len(result_three_values.shape) == 4  # N, P, T, points
     assert result_three_values.shape[:3] == (1, 1, 1)
 
+    # NOT passing temperature when temperature is required by the Model raises
+    with pytest.raises(ConditionError):
+        calculate(dbf, ['AL', 'CR', 'NI'], 'LIQUID', P=101325, pdens=10)  # no T
+
 
 @select_database("alfe.tdb")
 def test_calculate_some_phases_filtered(load_database):
@@ -461,4 +465,21 @@ def test_calculate_produces_no_infeasible_points_for_charged_phase():
     np.testing.assert_allclose(constraints_for_points, np.broadcast_to(constraint_rhs, constraints_for_points.shape), atol=1e-6, err_msg="`extra_points` produced by polytope sampler should produce feasible points")
 
     # success if the phase does not raise
-    calc_res = calculate(dbf, comps, [phase_name], pdens=60)
+    calc_res = calculate(dbf, comps, [phase_name], T=1000, pdens=60)
+
+
+@select_database("alcrni.tdb")
+def test_calculate_dof_state_variable_width_matches_phase_record(load_database):
+    """The number of state-variable dimensions calculate() produces must equal the phase
+    record's num_statevars (the compiled function's expected state-variable input count).
+
+    This is the shape invariant whose violation causes the out-of-bounds read: the dof's
+    state-variable width must match what the compiled property function expects."""
+    dbf = load_database()
+    comps = ["AL", "CR", "NI"]
+    models = instantiate_models(dbf, comps, ["LIQUID"])
+    prf = PhaseRecordFactory(dbf, comps, {v.N: 1, v.T: 400}, models)
+    res = calculate(dbf, comps, ["LIQUID"], T=400, model=models["LIQUID"])
+    # Leading dims are the supplied state variables (N, T); trailing dim is 'points'.
+    n_statevar_dims = res.GM.values.ndim - 1
+    assert n_statevar_dims == prf["LIQUID"].num_statevars == len(prf.state_variables)


### PR DESCRIPTION
<!--

Thank you for pull request.

Below are a few things we ask you kindly to self-check before getting a review.

-->


Checklist
* [x] Include a plain language description of your changes.
* [x] Any dependency changes are reflected in the `pyproject.toml`.

In `calculate()` state variables are passed as keyword arguments. It's currently possible to call `calculate()` without providing all the state variables that are used by `Model` instances, and this creates mismatches in the expected vs. actual shapes of arguements passed to the phase record callable functions. 

This PR fixes the flaky test introduced by #679 that exhibited this behavior by not including `T` as a state variable argument. It also includes a check (with a corresponding test) that the state variables passed to `calculate()` are a superset of those required and recorded by the `PhaseRecordFactory` and raise if any required variables are not present. 

There's also an interesting historical note that #116 was basically asking for this check to exist, and at the time we provided default T and P, but those defaults got removed by #200 and the introduced in the fix for #116 didn't include a set of conditions that exercised this issue. 