### PR TITLE
TST: Add test that state variable units survive roundtrip pickle

### DIFF
--- a/pycalphad/tests/test_variables.py
+++ b/pycalphad/tests/test_variables.py
@@ -2,6 +2,7 @@
 Test variables module.
 """
 import copy
+import pickle
 import numpy as np
 from pycalphad import variables as v
 from pycalphad.tests.fixtures import select_database, load_database
@@ -136,3 +137,14 @@ def test_getitem_units_does_not_mutate_original():
 
     # But they should be equal (same underlying symbol)
     assert t_celsius == v.T
+
+
+def test_issue557_state_variable_unit_changes_survive_roundtrip_pickle():
+    T2 = copy.deepcopy(v.T)
+    T2.display_units = 'degC'
+    T2_roundtrip = pickle.loads(pickle.dumps(T2))
+    print(f'T2: {T2.display_units}')
+    print(f'T2_roundtrip: {T2_roundtrip.display_units}')
+    assert T2.display_units == T2_roundtrip.display_units
+    T3 = pickle.loads(pickle.dumps(v.T["degC"]))
+    assert T2.display_units == T3.display_units


### PR DESCRIPTION
Closes #557. Git bisect confirms this was fixed by #656. We add a test to ensure no future regressions.

<!--

Thank you for pull request.

Below are a few things we ask you kindly to self-check before getting a review.

-->


Checklist
* [x] Include a plain language description of your changes.
* [x] Any dependency changes are reflected in the `pyproject.toml`.
