### PR TITLE
ENH: Expanded conditions support and Components support

### DIFF
--- a/pycalphad/codegen/phase_record_factory.py
+++ b/pycalphad/codegen/phase_record_factory.py
@@ -4,6 +4,7 @@ from pycalphad.core.utils import get_pure_elements, unpack_species, \
     extract_parameters, get_state_variables
 from pycalphad.core.phase_rec import PhaseRecord
 from pycalphad.core.constraints import build_constraints
+from pycalphad.core.errors import ConditionError
 from itertools import repeat
 from functools import lru_cache
 import numpy as np
@@ -14,6 +15,7 @@ class PhaseRecordFactory(object):
         self.pure_elements = get_pure_elements(dbf, comps)
         self.nonvacant_elements = sorted([x for x in self.pure_elements if x != 'VA'])
         self.molar_masses = np.array([dbf.refstates[x]['mass'] for x in self.nonvacant_elements], dtype='float')
+        self._build_component_basis(dbf, comps)
         parameters = parameters if parameters is not None else {}
         self.models = models
         self.state_variables = sorted(get_state_variables(models=models, conds=state_variables), key=str)
@@ -21,6 +23,78 @@ class PhaseRecordFactory(object):
 
         if len(self.param_values.shape) > 1:
             self.param_values = self.param_values[0]
+
+    def _build_component_basis(self, dbf, comps):
+        """Build the change-of-basis matrix S (components x non-vacant elements).
+
+        ``S[c, e]`` is the number of atoms of non-vacant element ``e`` per formula unit
+        of component ``c``. A *redefined* (non-trivial) component basis must be exactly
+        square and invertible: one component per non-vacant element, spanning the element
+        space independently (e.g. AL2O3, ND2O3, ZRO2, O2 over {AL, ND, O, ZR}).
+
+        For ordinary calculations the components reduce to the pure elements, giving the
+        identity basis ("trivial"), in which case all downstream code uses the original
+        element-basis paths unchanged. Normal component/species lists are frequently
+        over-determined relative to the elements (charged species, or species lists
+        expanded by ``unpack_species`` in ``calculate``); those are not redefined bases
+        and fall back to the trivial element basis without error.
+        """
+        # Charged species (e.g. F and F-1.0) share the same neutral elemental composition
+        # and are redundant for a basis over neutral elements; collapse them.
+        components_by_composition = {}
+        for c in v.unpack_components(comps, dbf):
+            if c.number_of_atoms == 0:
+                continue  # vacancies are not components of the basis
+            composition_key = frozenset((el, amt) for el, amt in c.constituents.items() if el != 'VA')
+            if composition_key not in components_by_composition:
+                components_by_composition[composition_key] = c
+        basis_components = sorted(components_by_composition.values(), key=str)
+        nonvacant_elements = self.nonvacant_elements
+        n_elements = len(nonvacant_elements)
+        n_components = len(basis_components)
+        element_index = {el: j for j, el in enumerate(nonvacant_elements)}
+
+        def _use_trivial_basis():
+            "Element basis: S = I. Preserves all existing element-basis behavior."
+            self.basis_components = [v.Component(el, {el: 1.0}) for el in nonvacant_elements]
+            self.basis_component_index = {el: j for j, el in enumerate(nonvacant_elements)}
+            self.component_basis = np.eye(n_elements)
+            self.component_basis_inv_T = np.eye(n_elements)
+            self.component_molar_masses = np.asarray(self.molar_masses, dtype=float).copy()
+            self.basis_is_trivial = True
+
+        if n_components == 0 or n_components > n_elements:
+            # Empty system, or an over-determined (normal/expanded/ionic) component list:
+            # not a redefined basis.
+            _use_trivial_basis()
+            return
+        if n_components < n_elements:
+            raise ConditionError(
+                f"Component basis is incomplete: {n_components} component(s) "
+                f"{[str(c) for c in basis_components]} cannot span {n_elements} non-vacant "
+                f"element(s) {nonvacant_elements}. Provide exactly one component per non-vacant "
+                f"element to redefine the basis.")
+        # Square: build S and require it to be invertible.
+        S = np.zeros((n_elements, n_elements))
+        for i, comp in enumerate(basis_components):
+            for el, amount in comp.constituents.items():
+                if el == 'VA':
+                    continue
+                S[i, element_index[el]] = amount
+        if np.linalg.matrix_rank(S) < n_components:
+            raise ConditionError(
+                f"Component basis is linearly dependent (rank {np.linalg.matrix_rank(S)} < "
+                f"{n_components}); components {[str(c) for c in basis_components]} do not "
+                f"independently span the non-vacant element space {nonvacant_elements}.")
+        if np.allclose(S, np.eye(n_elements)):
+            _use_trivial_basis()
+            return
+        self.basis_components = basis_components
+        self.basis_component_index = {str(c): i for i, c in enumerate(basis_components)}
+        self.component_basis = S
+        self.component_basis_inv_T = np.linalg.inv(S.T)
+        self.component_molar_masses = S @ np.asarray(self.molar_masses, dtype=float)
+        self.basis_is_trivial = False
 
     def update_parameters(self, parameters):
         new_param_symbols, new_param_values = extract_parameters(parameters)

--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -461,8 +461,8 @@ def calculate(dbf, comps, phases, mode=None, output='GM', fake_points=False, bro
     # Implicitly add 'N' state variable as a string to keyword arguements if it's not passed
     if kwargs.get('N') is None:
         kwargs['N'] = 1
-    if np.any(np.array(kwargs['N']) != 1):
-        raise ConditionError('N!=1 is not yet supported, got N={}'.format(kwargs['N']))
+    if np.any(np.array(kwargs['N']) <= 0):
+        raise ConditionError('N must be positive, got N={}'.format(kwargs['N']))
 
     # TODO: conditions dict of StateVariable instances should become part of the calculate API
     statevar_strings = [sv for sv in kwargs.keys() if getattr(v, sv) is not None]

--- a/pycalphad/core/calculate.py
+++ b/pycalphad/core/calculate.py
@@ -458,12 +458,6 @@ def calculate(dbf, comps, phases, mode=None, output='GM', fake_points=False, bro
         raise NotImplementedError('Only one property can be specified in calculate() at a time')
     output = output if output is not None else 'GM'
 
-    # Implicitly add 'N' state variable as a string to keyword arguements if it's not passed
-    if kwargs.get('N') is None:
-        kwargs['N'] = 1
-    if np.any(np.array(kwargs['N']) <= 0):
-        raise ConditionError('N must be positive, got N={}'.format(kwargs['N']))
-
     # TODO: conditions dict of StateVariable instances should become part of the calculate API
     statevar_strings = [sv for sv in kwargs.keys() if getattr(v, sv) is not None]
     # If we don't do this, sympy will get confused during substitution
@@ -485,6 +479,12 @@ def calculate(dbf, comps, phases, mode=None, output='GM', fake_points=False, bro
         if len(active_phases_without_models) > 0:
             raise ValueError(f"model must contain a Model instance for every active phase. Missing Model objects for {sorted(active_phases_without_models)}")
 
+    # Restrict the state-variable columns to exactly the potentials the callables were compiled against (P, T)
+    required_statevars = {str(sv) for sv in phase_records.state_variables}
+    statevar_dict = OrderedDict((k, val) for k, val in statevar_dict.items()
+                                if str(k) in required_statevars)
+    str_statevar_dict = OrderedDict((str(k), val) for k, val in statevar_dict.items())
+
     # Every state variable the phase records were compiled against must have a
     # value. The compiled property functions take `phase_records.state_variables + site_fractions`
     # as input, but `calculate()` builds the dof's state-variable columns from
@@ -492,7 +492,6 @@ def calculate(dbf, comps, phases, mode=None, output='GM', fake_points=False, bro
     # caller of `calcuate()` did not provide, the dof would be have a different
     # shape than the compiled function expects and the function would read past
     # the end of the dof buffer. We fail loudly in that case.
-    required_statevars = {str(sv) for sv in phase_records.state_variables}
     supplied_statevars = {str(sv) for sv in statevar_dict.keys()}
     missing_statevars = sorted(required_statevars - supplied_statevars)
     if missing_statevars:

--- a/pycalphad/core/conditions.py
+++ b/pycalphad/core/conditions.py
@@ -130,8 +130,8 @@ class Conditions:
         if isinstance(prop, v.SiteFraction) and prop not in self._wks.models[prop.phase_name].variables:
             raise ConditionError('{} refers to non-existent constituent'.format(prop))
 
-        if (prop == v.N) and np.any(value != Q_(1.0, 'mol')):
-            raise ConditionError('N!=1 is not yet supported, got N={}'.format(value))
+        if (prop == v.N) and np.any(np.asarray(value.magnitude) <= 0):
+            raise ConditionError('N must be positive, got N={}'.format(value))
         
         entry = ConditionsEntry(prop=prop, value=value)
 

--- a/pycalphad/core/conditions.py
+++ b/pycalphad/core/conditions.py
@@ -57,8 +57,6 @@ class Conditions:
     def __init__(self, wks: Optional["Workspace"]):
         self._wks = wks
         self._conds = []
-        # Default to N=1
-        self.__setitem__(v.N, Q_(np.atleast_1d(1.0), 'mol'))
 
     @classmethod
     def from_dict(cls, d):
@@ -67,7 +65,7 @@ class Conditions:
         obj = cls(wks=None)
         obj.update(d)
         return obj
-    
+
     def _find_matching_index(self, prop: "ComputableProperty"):
         for idx, (key, _) in enumerate(self._conds):
             # TODO: Use more sophisticated matching
@@ -78,7 +76,7 @@ class Conditions:
     @classmethod
     def cast_from(cls, key) -> "Conditions":
         return cls.from_dict(key)
-    
+
     def __getitem__(self, item):
         key = as_property(item)
         idx = self._find_matching_index(key)
@@ -104,7 +102,7 @@ class Conditions:
         if idx is None:
             raise IndexError(f"{item} is not a condition")
         del self._conds[idx]
-    
+
     def __setitem__(self, item, value):
         prop = as_property(item)
         if isinstance(prop, (v.MoleFraction, v.MassFraction, v.SiteFraction)):
@@ -121,7 +119,7 @@ class Conditions:
 
         if len(value) == 0:
             raise ConditionError('Condition cannot be zero-length array')
-        
+
         value = as_quantity(prop, value).to(prop.implementation_units)
 
         if isinstance(prop, (v.MoleFraction, v.MassFraction, v.ChemicalPotential)) and prop.species not in self._wks.components:
@@ -142,7 +140,7 @@ class Conditions:
             self._conds.append(entry)
         else:
             self._conds[idx] = entry
-        
+
         self._conds = sorted(self._conds, key=lambda k: str(k[0]))
 
     def keys(self):

--- a/pycalphad/core/conditions.py
+++ b/pycalphad/core/conditions.py
@@ -125,9 +125,14 @@ class Conditions:
         if isinstance(prop, (v.MoleFraction, v.MassFraction, v.ChemicalPotential)) and prop.species not in self._wks.components:
             raise ConditionError('{} refers to non-existent component'.format(prop))
 
-        if isinstance(prop, v.Moles) and getattr(prop, 'species', None) is not None \
-                and prop.species not in self._wks.components:
-            raise ConditionError('{} refers to non-existent component'.format(prop))
+        if isinstance(prop, v.Moles) and getattr(prop, "phase_name", None) is not None:
+            raise ConditionError(f"{prop}: phase-local moles conditions are not supported")
+
+        if isinstance(prop, (v.Moles, v.MassFraction, v.MoleFraction, v.ChemicalPotential)) and getattr(prop, "species", None) is not None:
+            if prop.species.number_of_atoms == 0:
+                raise ConditionError(f"{prop}: pure vacancy components cannot be conditions")
+            if prop.species not in self._wks.components:
+                raise ConditionError(f"{prop} refers to non-existent component")
 
         if isinstance(prop, v.SiteFraction) and prop not in self._wks.models[prop.phase_name].variables:
             raise ConditionError('{} refers to non-existent constituent'.format(prop))

--- a/pycalphad/core/conditions.py
+++ b/pycalphad/core/conditions.py
@@ -4,7 +4,7 @@ from pycalphad.property_framework import as_property, as_quantity
 from pycalphad.property_framework.units import Q_
 import pycalphad.variables as v
 from collections.abc import Iterable
-from typing import List, NamedTuple, Optional, TYPE_CHECKING
+from typing import cast, List, NamedTuple, Optional, TYPE_CHECKING
 import warnings
 import os
 
@@ -125,12 +125,16 @@ class Conditions:
         if isinstance(prop, (v.MoleFraction, v.MassFraction, v.ChemicalPotential)) and prop.species not in self._wks.components:
             raise ConditionError('{} refers to non-existent component'.format(prop))
 
+        if isinstance(prop, v.Moles) and getattr(prop, 'species', None) is not None \
+                and prop.species not in self._wks.components:
+            raise ConditionError('{} refers to non-existent component'.format(prop))
+
         if isinstance(prop, v.SiteFraction) and prop not in self._wks.models[prop.phase_name].variables:
             raise ConditionError('{} refers to non-existent constituent'.format(prop))
 
-        if (prop == v.N) and np.any(np.asarray(value.magnitude) <= 0):
-            raise ConditionError('N must be positive, got N={}'.format(value))
-        
+        if isinstance(prop, v.Moles) and np.any(np.asarray(value.magnitude) <= 0):
+            raise ConditionError('{} must be positive, got {}'.format(prop, value))
+
         entry = ConditionsEntry(prop=prop, value=value)
 
         idx = self._find_matching_index(prop)

--- a/pycalphad/core/eqsolver.pyx
+++ b/pycalphad/core/eqsolver.pyx
@@ -228,6 +228,9 @@ def _solve_eq_at_conditions(properties, phase_records, grid, conds_keys, state_v
         add_nearly_stable(composition_sets, phase_records, grid, curr_idx, chemical_potentials,
                           state_variable_values, -1000, verbose)
         #print('Composition Sets', composition_sets)
+        # Normalize starting phase amounts to sum to unity. This is only an initial
+        # guess scaling: the solver rescales the phase amounts to satisfy the
+        # prescribed system amount (N) condition during minimization.
         phase_amt_sum = 0.0
         for compset in composition_sets:
             phase_amt_sum += compset.NP
@@ -286,6 +289,14 @@ def _solve_eq_at_conditions(properties, phase_records, grid, conds_keys, state_v
                 prop_X_values[it.multi_index + np.index_exp[phase_idx, :]] = compset.X
                 prop_GM_values[it.multi_index] += compset.NP * compset.energy
                 var_offset += compset.phase_record.phase_dof
+            # Stored GM is the molar Gibbs energy (J/mol-atom): normalize the
+            # NP-weighted (extensive) sum by the total moles of atoms, N, counted
+            # from the elemental amounts in the composition sets
+            system_amount = 0.0
+            for compset in composition_sets:
+                system_amount += compset.NP * np.sum(compset.X)
+            if system_amount != 0:
+                prop_GM_values[it.multi_index] /= system_amount
         else:
             prop_MU_values[it.multi_index] = np.nan
             prop_NP_values[it.multi_index] = np.nan

--- a/pycalphad/core/eqsolver.pyx
+++ b/pycalphad/core/eqsolver.pyx
@@ -223,6 +223,17 @@ def _solve_eq_at_conditions(properties, phase_records, grid, conds_keys, state_v
             compset = CompositionSet(phase_record)
             compset.update(sfx, phase_amt, state_variable_values)
             composition_sets.append(compset)
+        if len(composition_sets) == 0:
+            # No stable phases at this condition point (infeasible/degenerate starting point).
+            # Record NaN like other infeasible results instead of indexing an empty list.
+            prop_MU_values[it.multi_index] = np.nan
+            prop_NP_values[it.multi_index + np.index_exp[:]] = np.nan
+            prop_Phase_values[it.multi_index + np.index_exp[:]] = ''
+            prop_X_values[it.multi_index + np.index_exp[:]] = np.nan
+            prop_Y_values[it.multi_index] = np.nan
+            prop_GM_values[it.multi_index] = np.nan
+            it.iternext()
+            continue
         chemical_potentials = prop_MU_values[it.multi_index]
         energy = prop_GM_values[it.multi_index]
         add_nearly_stable(composition_sets, phase_records, grid, curr_idx, chemical_potentials,

--- a/pycalphad/core/lower_convex_hull.py
+++ b/pycalphad/core/lower_convex_hull.py
@@ -4,7 +4,7 @@ equilibrium calculation.
 """
 from pycalphad.property_framework.computed_property import LinearCombination
 from .hyperplane import hyperplane
-from pycalphad.variables import ChemicalPotential, MassFraction, MoleFraction, IndependentPotential, SiteFraction, SystemMolesType
+from pycalphad.variables import ChemicalPotential, MassFraction, MoleFraction, IndependentPotential, SiteFraction, Moles
 import numpy as np
 
 
@@ -119,8 +119,16 @@ def lower_convex_hull(global_grid, state_variables, conds_keys, phase_record_fac
                 coef_vector[component_idx] = 1
                 idx_fixed_lincomb_molefrac_coefs.append(coef_vector)
                 idx_fixed_lincomb_molefrac_rhs.append(rhs)
-            elif isinstance(cond_key, SystemMolesType):
-                coef_vector = np.ones(num_comps)
+            elif isinstance(cond_key, Moles):
+                # Total N (species is None) constrains the sum of all component amounts;
+                # component N(i) constrains a single component. Total moles exposes no
+                # `species` attribute, so probe defensively with getattr.
+                cond_species = getattr(cond_key, 'species', None)
+                coef_vector = np.zeros(num_comps)
+                if cond_species is None:
+                    coef_vector[:] = 1.0
+                else:
+                    coef_vector[result_array.coords['component'].index(str(cond_species))] = 1.0
                 idx_fixed_lincomb_molefrac_coefs.append(coef_vector)
                 idx_fixed_lincomb_molefrac_rhs.append(rhs)
             elif isinstance(cond_key, LinearCombination):

--- a/pycalphad/core/lower_convex_hull.py
+++ b/pycalphad/core/lower_convex_hull.py
@@ -5,6 +5,7 @@ equilibrium calculation.
 from pycalphad.property_framework.computed_property import LinearCombination
 from .hyperplane import hyperplane
 from pycalphad.variables import ChemicalPotential, MassFraction, MoleFraction, IndependentPotential, SiteFraction, Moles
+from pycalphad.core.errors import ConditionError
 import numpy as np
 
 
@@ -58,6 +59,22 @@ def lower_convex_hull(global_grid, state_variables, conds_keys, phase_record_fac
     global_grid_Phase_values = global_grid.Phase
     num_comps = len(result_array.coords['component'])
 
+    # Redefined-component basis (trivial == pure-element, unchanged behavior)
+    basis_is_trivial = phase_record_factory.basis_is_trivial
+    basis_component_index = phase_record_factory.basis_component_index
+    component_basis_inv_T = np.asarray(phase_record_factory.component_basis_inv_T)
+    component_molar_masses = np.asarray(phase_record_factory.component_molar_masses)
+    molar_masses = np.asarray(phase_record_factory.molar_masses)
+    inv_T_colsum = component_basis_inv_T.sum(axis=0)
+
+    def basis_row(species):
+        name = str(species)
+        if name not in basis_component_index:
+            raise ConditionError(
+                f"{name!r} is not part of the component basis {list(basis_component_index)}; "
+                f"conditions must be expressed in terms of basis components.")
+        return basis_component_index[name]
+
     it = np.nditer(result_array_GM_values, flags=['multi_index'])
 
     while not it.finished:
@@ -101,74 +118,82 @@ def lower_convex_hull(global_grid, state_variables, conds_keys, phase_record_fac
                 # Already handled above in construction of grid_index
                 continue
             elif isinstance(cond_key, ChemicalPotential):
-                component_idx = result_array.coords['component'].index(str(cond_key.species))
-                idx_fixed_chempot_indices.append(component_idx)
-                idx_result_array_MU_values[component_idx] = rhs
+                if basis_is_trivial:
+                    component_idx = result_array.coords['component'].index(str(cond_key.species))
+                    idx_fixed_chempot_indices.append(component_idx)
+                    idx_result_array_MU_values[component_idx] = rhs
+                else:
+                    # MU(component) is a linear-combination chemical-potential constraint, which
+                    # the hyperplane (axis-aligned fixed chempots) cannot express directly. For
+                    # the starting point, treat it as a placeholder amount along the component's
+                    # direction so the hull returns a determined, feasible composition; the Newton
+                    # solver enforces the true MU(component) via its constraint row.
+                    idx_amount_coefs.append(component_basis_inv_T[basis_row(cond_key.species)].copy())
+                    idx_amount_rhs.append(1.0)
             elif isinstance(cond_key, MassFraction):
-                # wA = k -> (1-k)*MWA*xA - k*MWB*xB - k*MWC*xC = 0
-                component_idx = result_array.coords['component'].index(str(cond_key.species))
-                coef_vector = np.zeros(num_comps)
-                coef_vector -= rhs
-                coef_vector[component_idx] += 1
-                # multiply coef_vector times a vector of molecular weights
-                coef_vector = np.multiply(coef_vector, phase_record_factory.molar_masses)
+                # W(c) = k <=> (MW(c)*(S^T)^-1[c,:] - k*mass_elem) . x_elem = 0.
+                # For a pure-element basis this is (1-k)*MW_A*x_A - k*MW_B*x_B - ... = 0.
+                row = basis_row(cond_key.species)
+                coef_vector = component_molar_masses[row] * component_basis_inv_T[row] - rhs * molar_masses
                 idx_fixed_lincomb_molefrac_coefs.append(coef_vector)
                 idx_fixed_lincomb_molefrac_rhs.append(0.)
             elif isinstance(cond_key, MoleFraction):
                 if cond_key.phase_name is not None:
                     # Phase-local condition already handled in construction of grid
                     continue
-                component_idx = result_array.coords['component'].index(str(cond_key.species))
-                coef_vector = np.zeros(num_comps)
-                coef_vector[component_idx] = 1
-                idx_fixed_lincomb_molefrac_coefs.append(coef_vector)
-                idx_fixed_lincomb_molefrac_rhs.append(rhs)
+                # X(c) = k. A unit-vector (S^T)^-1 row (every pure element, and the trivial basis)
+                # keeps the direct form dot(e_c, x) = k; a multi-element component uses the
+                # homogeneous form ((S^T)^-1[c,:] - k*colsum).x = 0. See solver.get_system_spec.
+                coefs = np.array(component_basis_inv_T[basis_row(cond_key.species)])
+                if np.count_nonzero(coefs) == 1 and np.isclose(coefs.sum(), 1.0):
+                    idx_fixed_lincomb_molefrac_coefs.append(coefs)
+                    idx_fixed_lincomb_molefrac_rhs.append(rhs)
+                else:
+                    idx_fixed_lincomb_molefrac_coefs.append(coefs - rhs * inv_T_colsum)
+                    idx_fixed_lincomb_molefrac_rhs.append(0.0)
             elif isinstance(cond_key, Moles):
                 # Extensive (amount) condition. Total N (species is None) selects all
-                # components; component N(i) selects one.
+                # components; component N(i) selects one (a unit vector for a pure-element basis).
+                # Collect the selector vector + value; they become scale-invariant ratio rows
+                # after the loop. Total moles exposes no `species`, so probe with getattr.
                 cond_species = getattr(cond_key, 'species', None)
-                coef_vector = np.zeros(num_comps)
                 if cond_species is None:
-                    coef_vector[:] = 1.0
+                    coef_vector = np.ones(num_comps)  # total N: total moles of atoms
                 else:
-                    coef_vector[result_array.coords['component'].index(str(cond_species))] = 1.0
+                    coef_vector = component_basis_inv_T[basis_row(cond_species)].copy()
                 idx_amount_coefs.append(coef_vector)
                 idx_amount_rhs.append(rhs)
             elif isinstance(cond_key, LinearCombination):
+                # Linear combination of (component) mole fractions -> homogeneous element row
+                # (see solver.get_system_spec for the derivation). Pure-element basis (S = I)
+                # gives the element linear combination.
                 coef_vector = np.zeros(num_comps)
+                constant = 0.0
+                for symbol_idx, symbol in enumerate(cond_key.symbols):
+                    if symbol == 1:
+                        constant = cond_key.coefs[symbol_idx]
+                        continue
+                    coef_vector = coef_vector + cond_key.coefs[symbol_idx] * component_basis_inv_T[basis_row(symbol.species)]
                 if cond_key.denominator == 1:
-                    for symbol_idx, symbol in enumerate(cond_key.symbols):
-                        if symbol != 1:
-                            coef_idx = result_array.coords['component'].index(str(symbol.species))
-                            coef_vector[coef_idx] = cond_key.coefs[symbol_idx]
-                        else:
-                            idx_fixed_lincomb_molefrac_rhs.append(rhs-cond_key.coefs[symbol_idx])
+                    coef_vector = coef_vector - (rhs - float(constant)) * inv_T_colsum
                 else:
-                    # This is a molar ratio
-                    denominator_idx = cond_key.symbols.index(cond_key.denominator)
-                    for symbol_idx, symbol in enumerate(cond_key.symbols):
-                        if symbol_idx == denominator_idx:
-                            coef_idx = result_array.coords['component'].index(str(symbol.species))
-                            coef_vector[coef_idx] = cond_key.coefs[symbol_idx] - rhs
-                        elif symbol != 1:
-                            coef_idx = result_array.coords['component'].index(str(symbol.species))
-                            coef_vector[coef_idx] = cond_key.coefs[symbol_idx]
-                        else:
-                            if cond_key.coefs[symbol_idx] != 0:
-                                # Constant term for molar ratio should be zero
-                                raise ValueError(f'Unsupported condition {cond_key}')
-                            idx_fixed_lincomb_molefrac_rhs.append(-cond_key.coefs[symbol_idx])
+                    coef_vector = coef_vector - rhs * component_basis_inv_T[basis_row(cond_key.denominator.species)]
+                idx_fixed_lincomb_molefrac_rhs.append(0.0)
                 idx_fixed_lincomb_molefrac_coefs.append(coef_vector)
             else:
                 raise ValueError(f'Unsupported condition {cond_key}')
 
-        # Simplex closure: composition fractions sum to 1.
+        # Simplex closure: composition fractions sum to 1. This was previously supplied
+        # implicitly by a mandatory total-N=1 condition; emit it unconditionally so the hull
+        # always has a valid composition basis (the starting point works in normalized
+        # composition space; absolute scale is set later by the minimizer).
         idx_fixed_lincomb_molefrac_coefs.append(np.ones(num_comps))
         idx_fixed_lincomb_molefrac_rhs.append(1.0)
         # Extensive conditions contribute scale-invariant (ratio) constraints, not absolute
         # ones: for amount conditions m, r_0 * (c_m . x) - r_m * (c_0 . x) = 0. With k amount
         # conditions this is k-1 rows, so a fraction (X) and an amount (N) on the same component
-        # never conflict, and the system stays square.
+        # never conflict, and the system stays square (DOF check guarantees
+        # #intensive + #amount = num_comps, so composition rows + closure = num_comps).
         for m in range(1, len(idx_amount_coefs)):
             ratio_row = idx_amount_rhs[0] * idx_amount_coefs[m] - idx_amount_rhs[m] * idx_amount_coefs[0]
             idx_fixed_lincomb_molefrac_coefs.append(ratio_row)

--- a/pycalphad/core/lower_convex_hull.py
+++ b/pycalphad/core/lower_convex_hull.py
@@ -83,6 +83,10 @@ def lower_convex_hull(global_grid, state_variables, conds_keys, phase_record_fac
         idx_fixed_lincomb_molefrac_coefs = []
         idx_fixed_lincomb_molefrac_rhs = []
         idx_fixed_chempot_indices = []
+        # Extensive (amount) conditions are collected here and converted, after the loop,
+        # into a simplex-closure row plus (k-1) scale-invariant ratio rows.
+        idx_amount_coefs = []
+        idx_amount_rhs = []
 
         for coord_idx, str_cond_key in enumerate(sorted(result_array.coords.keys())):
             try:
@@ -120,17 +124,16 @@ def lower_convex_hull(global_grid, state_variables, conds_keys, phase_record_fac
                 idx_fixed_lincomb_molefrac_coefs.append(coef_vector)
                 idx_fixed_lincomb_molefrac_rhs.append(rhs)
             elif isinstance(cond_key, Moles):
-                # Total N (species is None) constrains the sum of all component amounts;
-                # component N(i) constrains a single component. Total moles exposes no
-                # `species` attribute, so probe defensively with getattr.
+                # Extensive (amount) condition. Total N (species is None) selects all
+                # components; component N(i) selects one.
                 cond_species = getattr(cond_key, 'species', None)
                 coef_vector = np.zeros(num_comps)
                 if cond_species is None:
                     coef_vector[:] = 1.0
                 else:
                     coef_vector[result_array.coords['component'].index(str(cond_species))] = 1.0
-                idx_fixed_lincomb_molefrac_coefs.append(coef_vector)
-                idx_fixed_lincomb_molefrac_rhs.append(rhs)
+                idx_amount_coefs.append(coef_vector)
+                idx_amount_rhs.append(rhs)
             elif isinstance(cond_key, LinearCombination):
                 coef_vector = np.zeros(num_comps)
                 if cond_key.denominator == 1:
@@ -158,6 +161,18 @@ def lower_convex_hull(global_grid, state_variables, conds_keys, phase_record_fac
                 idx_fixed_lincomb_molefrac_coefs.append(coef_vector)
             else:
                 raise ValueError(f'Unsupported condition {cond_key}')
+
+        # Simplex closure: composition fractions sum to 1.
+        idx_fixed_lincomb_molefrac_coefs.append(np.ones(num_comps))
+        idx_fixed_lincomb_molefrac_rhs.append(1.0)
+        # Extensive conditions contribute scale-invariant (ratio) constraints, not absolute
+        # ones: for amount conditions m, r_0 * (c_m . x) - r_m * (c_0 . x) = 0. With k amount
+        # conditions this is k-1 rows, so a fraction (X) and an amount (N) on the same component
+        # never conflict, and the system stays square.
+        for m in range(1, len(idx_amount_coefs)):
+            ratio_row = idx_amount_rhs[0] * idx_amount_coefs[m] - idx_amount_rhs[m] * idx_amount_coefs[0]
+            idx_fixed_lincomb_molefrac_coefs.append(ratio_row)
+            idx_fixed_lincomb_molefrac_rhs.append(0.0)
 
         idx_fixed_lincomb_molefrac_coefs = np.atleast_2d(idx_fixed_lincomb_molefrac_coefs)
         idx_fixed_lincomb_molefrac_rhs = np.atleast_1d(idx_fixed_lincomb_molefrac_rhs)

--- a/pycalphad/core/minimizer.pxd
+++ b/pycalphad/core/minimizer.pxd
@@ -14,6 +14,7 @@ cdef class SystemState:
     cdef int[::1] free_stable_compset_indices
     cdef double system_amount
     cdef double[::1] mole_fractions
+    cdef double[::1] mole_amounts
     cdef double[::1] _driving_forces
     cdef double[:, ::1] _phase_energies_per_mole_atoms
     cdef double[:, :, ::1] _phase_amounts_per_mole_atoms
@@ -23,10 +24,13 @@ cdef class SystemState:
 
 cdef class SystemSpecification:
     cdef int num_statevars, num_components, max_num_free_stable_phases
-    cdef double prescribed_system_amount
     cdef double ALLOWED_MASS_RESIDUAL
     cdef double[::1] initial_chemical_potentials, prescribed_mole_fraction_rhs
     cdef double[:,::1] prescribed_mole_fraction_coefficients
+    # Extensive amount conditions (N, N(i), B, B(i))
+    # each row is a coefficient vector over components with a rhs
+    cdef double[::1] prescribed_mole_amount_rhs
+    cdef double[:,::1] prescribed_mole_amount_coefficients
     cdef int[::1] free_chemical_potential_indices, free_statevar_indices
     cdef int[::1] fixed_chemical_potential_indices, fixed_statevar_indices, fixed_stable_compset_indices
     cpdef bint check_convergence(self, SystemState state)

--- a/pycalphad/core/minimizer.pxd
+++ b/pycalphad/core/minimizer.pxd
@@ -33,6 +33,9 @@ cdef class SystemSpecification:
     cdef double[:,::1] prescribed_mole_amount_coefficients
     cdef int[::1] free_chemical_potential_indices, free_statevar_indices
     cdef int[::1] fixed_chemical_potential_indices, fixed_statevar_indices, fixed_stable_compset_indices
+    # MU(component) constraints: each row is sum_e coef[e]*mu_e = rhs over element chemical potentials
+    cdef double[:,::1] fixed_chempot_coefs
+    cdef double[::1] fixed_chempot_rhs
     cpdef bint check_convergence(self, SystemState state)
     cpdef bint pre_solve_hook(self, SystemState state)
     cpdef bint post_solve_hook(self, SystemState state)

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -188,7 +188,12 @@ cdef void write_row_fixed_mole_amount(double[:] out_row, double* out_rhs, int co
                                       double[::1] chemical_potentials,
                                       double[:, ::1] mass_jac, double[:, ::1] c_component,
                                       double[:, ::1] c_statevars, double[::1] c_G, double[:, ::1] masses,
-                                      double[::1] phase_amt, int idx):
+                                      double[::1] phase_amt, int idx, double prefactor):
+    # prefactor is the coefficient of this component in the extensive mole-amount condition:
+    # 1 for total N, the unit-vector entry for N(i), a mass-weighted entry for B/B(i),
+    # or a stoichiometric ratio for a Component.
+    if prefactor == 0.0:
+        return
     cdef int free_variable_column_offset = 0
     cdef int num_statevars = c_statevars.shape[1]
     cdef int i, j, chempot_idx, compset_idx, statevar_idx
@@ -196,7 +201,7 @@ cdef void write_row_fixed_mole_amount(double[:] out_row, double* out_rhs, int co
     for i in range(free_chemical_potential_indices.shape[0]):
         chempot_idx = free_chemical_potential_indices[i]
         for j in range(c_component.shape[1]):
-            out_row[free_variable_column_offset + i] += \
+            out_row[free_variable_column_offset + i] += prefactor * \
                 phase_amt[idx] * mass_jac[component_idx, num_statevars+j] * c_component[chempot_idx, j]
     free_variable_column_offset += free_chemical_potential_indices.shape[0]
     # 2a. This component row: free stable composition sets
@@ -204,36 +209,37 @@ cdef void write_row_fixed_mole_amount(double[:] out_row, double* out_rhs, int co
         compset_idx = free_stable_compset_indices[i]
         # Only fill this out if the current idx is equal to a free composition set
         if compset_idx == idx:
-            out_row[free_variable_column_offset + i] += masses[component_idx, 0]
+            out_row[free_variable_column_offset + i] += prefactor * masses[component_idx, 0]
     free_variable_column_offset += free_stable_compset_indices.shape[0]
     # 2a. This component row: free state variables
     for i in range(free_statevar_indices.shape[0]):
         statevar_idx = free_statevar_indices[i]
         for j in range(c_statevars.shape[0]):
-            out_row[free_variable_column_offset + i] += \
+            out_row[free_variable_column_offset + i] += prefactor * \
                 phase_amt[idx] * mass_jac[component_idx, num_statevars+j] * c_statevars[j, statevar_idx]
     # 3.
     for j in range(c_G.shape[0]):
-        out_rhs[0] += -phase_amt[idx] * mass_jac[component_idx, num_statevars+j] * c_G[j]
+        out_rhs[0] += -prefactor * phase_amt[idx] * mass_jac[component_idx, num_statevars+j] * c_G[j]
     # 4. Subtract fixed chemical potentials from each phase RHS
     for i in range(fixed_chemical_potential_indices.shape[0]):
         chempot_idx = fixed_chemical_potential_indices[i]
-        # Subtract fixed chemical potentials from the system amount (N) row
+        # Subtract fixed chemical potentials from the mole amount row
         for j in range(c_component.shape[1]):
-            out_rhs[0] -= phase_amt[idx] * chemical_potentials[
+            out_rhs[0] -= prefactor * phase_amt[idx] * chemical_potentials[
                 chempot_idx] * mass_jac[component_idx, num_statevars+j] * c_component[chempot_idx, j]
 
 
 cdef void fill_equilibrium_system(double[::1,:] equilibrium_matrix, double[::1] equilibrium_rhs,
                                   SystemSpecification spec, SystemState state):
     cdef int stable_idx, idx, component_row_offset, component_idx, fixed_idx, free_idx
-    cdef int fixed_component_idx, comp_idx, system_amount_index, fixed_molefrac_cond_idx
+    cdef int fixed_component_idx, comp_idx, amount_row_offset, fixed_molefrac_cond_idx, amount_cond_idx
     cdef CompositionSet compset
     cdef CompsetState csst
     cdef int num_components = state.chemical_potentials.shape[0]
     cdef int num_stable_phases = state.free_stable_compset_indices.shape[0]
     cdef int num_fixed_phases = spec.fixed_stable_compset_indices.shape[0]
     cdef int num_fixed_mole_fraction_conditions = spec.prescribed_mole_fraction_rhs.shape[0]
+    cdef int num_mole_amount_conditions = spec.prescribed_mole_amount_rhs.shape[0]
     cdef double prefactor
 
     for stable_idx in range(state.free_stable_compset_indices.shape[0]):
@@ -276,16 +282,18 @@ cdef void fill_equilibrium_system(double[::1,:] equilibrium_matrix, double[::1] 
                                             csst.c_G, csst.masses, csst.moles_normalization,
                                             csst.moles_normalization_grad, state.phase_amt, idx, prefactor)
 
-        system_amount_index = component_row_offset + num_fixed_mole_fraction_conditions
-        # 2X. Also handle the system amount (N) row
-        for component_idx in range(num_components):
-            write_row_fixed_mole_amount(equilibrium_matrix[system_amount_index, :],
-                                        &equilibrium_rhs[system_amount_index], component_idx,
-                                        spec.free_chemical_potential_indices, state.free_stable_compset_indices,
-                                        spec.free_statevar_indices, spec.fixed_chemical_potential_indices,
-                                        state.chemical_potentials, csst.mass_jac, csst.c_component,
-                                        csst.c_statevars, csst.c_G, csst.masses,
-                                        state.phase_amt, idx)
+        amount_row_offset = component_row_offset + num_fixed_mole_fraction_conditions
+        # 2X. Handle the extensive amount rows
+        for amount_cond_idx in range(num_mole_amount_conditions):
+            for component_idx in range(num_components):
+                prefactor = spec.prescribed_mole_amount_coefficients[amount_cond_idx, component_idx]
+                write_row_fixed_mole_amount(equilibrium_matrix[amount_row_offset + amount_cond_idx, :],
+                                            &equilibrium_rhs[amount_row_offset + amount_cond_idx], component_idx,
+                                            spec.free_chemical_potential_indices, state.free_stable_compset_indices,
+                                            spec.free_statevar_indices, spec.fixed_chemical_potential_indices,
+                                            state.chemical_potentials, csst.mass_jac, csst.c_component,
+                                            csst.c_statevars, csst.c_G, csst.masses,
+                                            state.phase_amt, idx, prefactor)
 
     for fixed_idx in range(spec.fixed_stable_compset_indices.shape[0]):
         idx = spec.fixed_stable_compset_indices[fixed_idx]
@@ -307,37 +315,43 @@ cdef void fill_equilibrium_system(double[::1,:] equilibrium_matrix, double[::1] 
                                             csst.c_G, csst.masses, csst.moles_normalization,
                                             csst.moles_normalization_grad, state.phase_amt, idx, prefactor)
 
-        system_amount_index = component_row_offset + num_fixed_mole_fraction_conditions
-        # 2X. Also handle the system amount (N) row
-        for component_idx in range(num_components):
-            write_row_fixed_mole_amount(equilibrium_matrix[system_amount_index, :],
-                                        &equilibrium_rhs[system_amount_index], component_idx,
-                                        spec.free_chemical_potential_indices, state.free_stable_compset_indices,
-                                        spec.free_statevar_indices, spec.fixed_chemical_potential_indices,
-                                        state.chemical_potentials, csst.mass_jac, csst.c_component,
-                                        csst.c_statevars, csst.c_G, csst.masses,
-                                        state.phase_amt, idx)
+        amount_row_offset = component_row_offset + num_fixed_mole_fraction_conditions
+        # 2X. Handle the extensive amount rows
+        for amount_cond_idx in range(num_mole_amount_conditions):
+            for component_idx in range(num_components):
+                prefactor = spec.prescribed_mole_amount_coefficients[amount_cond_idx, component_idx]
+                write_row_fixed_mole_amount(equilibrium_matrix[amount_row_offset + amount_cond_idx, :],
+                                            &equilibrium_rhs[amount_row_offset + amount_cond_idx], component_idx,
+                                            spec.free_chemical_potential_indices, state.free_stable_compset_indices,
+                                            spec.free_statevar_indices, spec.fixed_chemical_potential_indices,
+                                            state.chemical_potentials, csst.mass_jac, csst.c_component,
+                                            csst.c_statevars, csst.c_G, csst.masses,
+                                            state.phase_amt, idx, prefactor)
 
 
-    # Add mass residual to fixed component row RHS, plus system amount (N) row
+    # Add mass residual to fixed mole-fraction rows, plus the extensive mole-amount rows
     component_row_offset = num_stable_phases + num_fixed_phases
-    system_amount_index = component_row_offset + num_fixed_mole_fraction_conditions
+    amount_row_offset = component_row_offset + num_fixed_mole_fraction_conditions
     for fixed_molefrac_cond_idx in range(num_fixed_mole_fraction_conditions):
         component_residual = np.dot(spec.prescribed_mole_fraction_coefficients[fixed_molefrac_cond_idx, :], state.mole_fractions) - spec.prescribed_mole_fraction_rhs[fixed_molefrac_cond_idx]
         equilibrium_rhs[component_row_offset + fixed_molefrac_cond_idx] -= component_residual
-    system_residual = state.system_amount - spec.prescribed_system_amount
-    equilibrium_rhs[system_amount_index] -= system_residual
+    for amount_cond_idx in range(num_mole_amount_conditions):
+        # Total N: dot(ones, mole_amounts) == system_amount; N(i): mole_amounts[i]
+        amount_residual = np.dot(spec.prescribed_mole_amount_coefficients[amount_cond_idx, :], state.mole_amounts) - spec.prescribed_mole_amount_rhs[amount_cond_idx]
+        equilibrium_rhs[amount_row_offset + amount_cond_idx] -= amount_residual
 
 
 cdef class SystemSpecification:
-    def __init__(self, int num_statevars, int num_components, double prescribed_system_amount,
+    def __init__(self, int num_statevars, int num_components,
+                   double[:, ::1] prescribed_mole_amount_coefficients, double[::1] prescribed_mole_amount_rhs,
                    double[::1] initial_chemical_potentials, double[:, ::1] prescribed_mole_fraction_coefficients,
                    double[::1] prescribed_mole_fraction_rhs, int[::1] free_chemical_potential_indices,
                    int[::1] free_statevar_indices, int[::1] fixed_chemical_potential_indices,
                    int[::1] fixed_statevar_indices, int[::1] fixed_stable_compset_indices):
         self.num_statevars = num_statevars
         self.num_components = num_components
-        self.prescribed_system_amount = prescribed_system_amount
+        self.prescribed_mole_amount_coefficients = prescribed_mole_amount_coefficients
+        self.prescribed_mole_amount_rhs = prescribed_mole_amount_rhs
         self.initial_chemical_potentials = initial_chemical_potentials
         self.prescribed_mole_fraction_coefficients = prescribed_mole_fraction_coefficients
         self.prescribed_mole_fraction_rhs = prescribed_mole_fraction_rhs
@@ -361,7 +375,8 @@ cdef class SystemSpecification:
             self.ALLOWED_MASS_RESIDUAL = 1e-8
 
     def __getstate__(self):
-        return (self.num_statevars, self.num_components, self.prescribed_system_amount,
+        return (self.num_statevars, self.num_components,
+                np.array(self.prescribed_mole_amount_coefficients), np.array(self.prescribed_mole_amount_rhs),
                 np.array(self.initial_chemical_potentials), np.array(self.prescribed_mole_fraction_coefficients),
                 np.array(self.prescribed_mole_fraction_rhs), np.array(self.free_chemical_potential_indices),
                 np.array(self.free_statevar_indices), np.array(self.fixed_chemical_potential_indices),
@@ -523,6 +538,7 @@ cdef class SystemState:
         self.largest_y_change[0] = 0
         self.system_amount = 0
         self.mole_fractions = np.zeros(spec.num_components)
+        self.mole_amounts = np.zeros(spec.num_components)
         self._driving_forces = np.zeros(len(compsets))
         self._phase_energies_per_mole_atoms = np.zeros((len(compsets), 1))
         self._phase_amounts_per_mole_atoms = np.zeros((len(compsets), spec.num_components, 1))
@@ -546,13 +562,15 @@ cdef class SystemState:
                 np.array(self.phase_amt), np.array(self.chemical_potentials), np.array(self.previous_chemical_potentials),
                 np.array(self.delta_ms), np.array(self.phase_compositions), self.largest_chemical_potential_difference,
                 self.largest_statevar_change[0], self.largest_phase_amt_change[0], self.largest_y_change[0],
-                np.array(self.free_stable_compset_indices), self.system_amount, np.array(self.mole_fractions))
+                np.array(self.free_stable_compset_indices), self.system_amount, np.array(self.mole_fractions),
+                np.array(self.mole_amounts))
     def __setstate__(self, state):
         (self.compsets, self.cs_states, self.dof, self.iteration, self.iterations_since_last_phase_change,
          self.metastable_phase_iterations, self.times_compset_removed, self.mass_residual,
          self.phase_amt, self.chemical_potentials, self.previous_chemical_potentials,
          self.delta_ms, self.phase_compositions, self.largest_chemical_potential_difference, self.largest_statevar_change[0],
-         self.largest_phase_amt_change[0], self.largest_y_change[0], self.free_stable_compset_indices, self.system_amount, self.mole_fractions) = state
+         self.largest_phase_amt_change[0], self.largest_y_change[0], self.free_stable_compset_indices, self.system_amount,
+         self.mole_fractions, self.mole_amounts) = state
 
     @cython.boundscheck(False)
     cpdef void recompute(self, SystemSpecification spec):
@@ -563,10 +581,12 @@ cdef class SystemState:
         cdef int idx, comp_idx, cons_idx, i, j, stable_idx, fixed_idx, fixed_molefrac_cond_idx, num_phase_dof
         cdef double mu_c_sum
         cdef double phase_comp_sum
+        self.mole_amounts[:] = 0
         self.mole_fractions[:] = 0
         self.delta_ms[:, :] = 0
         self.system_amount = 0
-        # Compute normalized global quantities
+        # Compute the absolute moles of each component (mole_amounts) from phase amounts and
+        # phase compositions, then the total system amount and normalized mole fractions.
         for idx in range(len(self.compsets)):
             x = self.dof[idx]
             compset = self.compsets[idx]
@@ -575,11 +595,11 @@ cdef class SystemState:
             for comp_idx in range(num_components):
                 compset.phase_record.formulamole_obj(csst.masses[comp_idx, :], x, comp_idx)
                 if self.phase_amt[idx] > 0:
-                    self.mole_fractions[comp_idx] += self.phase_amt[idx] * csst.masses[comp_idx, 0]
+                    self.mole_amounts[comp_idx] += self.phase_amt[idx] * csst.masses[comp_idx, 0]
                     self.system_amount += self.phase_amt[idx] * csst.masses[comp_idx, 0]
                 self.phase_compositions[idx, comp_idx] = csst.masses[comp_idx, 0]
         for comp_idx in range(self.mole_fractions.shape[0]):
-            self.mole_fractions[comp_idx] /= self.system_amount
+            self.mole_fractions[comp_idx] = self.mole_amounts[comp_idx] / self.system_amount
 
         self.mass_residual = 0.0
         for fixed_molefrac_cond_idx in range(spec.prescribed_mole_fraction_rhs.shape[0]):
@@ -674,14 +694,16 @@ cpdef construct_equilibrium_system(SystemSpecification spec, SystemState state, 
     cdef double[::1,:] equilibrium_matrix  # Fortran ordering required by call into lapack
     cdef double[::1] equilibrium_soln
     cdef int num_stable_phases, num_fixed_phases, num_fixed_mole_fraction_conditions, num_free_variables
+    cdef int num_mole_amount_conditions
 
     num_stable_phases = state.free_stable_compset_indices.shape[0]
     num_fixed_phases = spec.fixed_stable_compset_indices.shape[0]
     num_fixed_mole_fraction_conditions = spec.prescribed_mole_fraction_rhs.shape[0]
+    num_mole_amount_conditions = spec.prescribed_mole_amount_rhs.shape[0]
     num_free_variables = spec.free_chemical_potential_indices.shape[0] + num_stable_phases + \
                          spec.free_statevar_indices.shape[0]
 
-    equilibrium_matrix = np.zeros((num_stable_phases + num_fixed_phases + num_fixed_mole_fraction_conditions + num_reserved_rows + 1,
+    equilibrium_matrix = np.zeros((num_stable_phases + num_fixed_phases + num_fixed_mole_fraction_conditions + num_mole_amount_conditions + num_reserved_rows,
                                    num_free_variables), order='F')
     equilibrium_rhs = np.zeros(equilibrium_matrix.shape[0])
     if (equilibrium_matrix.shape[0] != equilibrium_matrix.shape[1]):

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -340,6 +340,19 @@ cdef void fill_equilibrium_system(double[::1,:] equilibrium_matrix, double[::1] 
         amount_residual = np.dot(spec.prescribed_mole_amount_coefficients[amount_cond_idx, :], state.mole_amounts) - spec.prescribed_mole_amount_rhs[amount_cond_idx]
         equilibrium_rhs[amount_row_offset + amount_cond_idx] -= amount_residual
 
+    # MU(component) constraint rows: sum_e coef[e]*mu_e = rhs. Element chemical potentials
+    # are solved absolutely (see solve_state), so the row places the constituent coefficients
+    # in the free-chemical-potential columns with the prescribed value as RHS.
+    cdef int num_chempot_conditions = spec.fixed_chempot_rhs.shape[0]
+    cdef int chempot_row_offset = amount_row_offset + num_mole_amount_conditions
+    cdef int chempot_cond_idx, free_chempot_i, free_chempot_el
+    for chempot_cond_idx in range(num_chempot_conditions):
+        for free_chempot_i in range(spec.free_chemical_potential_indices.shape[0]):
+            free_chempot_el = spec.free_chemical_potential_indices[free_chempot_i]
+            equilibrium_matrix[chempot_row_offset + chempot_cond_idx, free_chempot_i] = \
+                spec.fixed_chempot_coefs[chempot_cond_idx, free_chempot_el]
+        equilibrium_rhs[chempot_row_offset + chempot_cond_idx] = spec.fixed_chempot_rhs[chempot_cond_idx]
+
 
 cdef class SystemSpecification:
     def __init__(self, int num_statevars, int num_components,
@@ -347,7 +360,8 @@ cdef class SystemSpecification:
                    double[::1] initial_chemical_potentials, double[:, ::1] prescribed_mole_fraction_coefficients,
                    double[::1] prescribed_mole_fraction_rhs, int[::1] free_chemical_potential_indices,
                    int[::1] free_statevar_indices, int[::1] fixed_chemical_potential_indices,
-                   int[::1] fixed_statevar_indices, int[::1] fixed_stable_compset_indices):
+                   int[::1] fixed_statevar_indices, int[::1] fixed_stable_compset_indices,
+                   double[:, ::1] fixed_chempot_coefs=None, double[::1] fixed_chempot_rhs=None):
         self.num_statevars = num_statevars
         self.num_components = num_components
         self.prescribed_mole_amount_coefficients = prescribed_mole_amount_coefficients
@@ -360,6 +374,13 @@ cdef class SystemSpecification:
         self.fixed_chemical_potential_indices = fixed_chemical_potential_indices
         self.fixed_statevar_indices = fixed_statevar_indices
         self.fixed_stable_compset_indices = fixed_stable_compset_indices
+        # MU(component) constraints: each row is sum_e coef[e]*mu_e = rhs over element chempots.
+        if fixed_chempot_coefs is None:
+            fixed_chempot_coefs = np.zeros((0, num_components))
+        if fixed_chempot_rhs is None:
+            fixed_chempot_rhs = np.zeros(0)
+        self.fixed_chempot_coefs = fixed_chempot_coefs
+        self.fixed_chempot_rhs = fixed_chempot_rhs
         self.max_num_free_stable_phases = num_components + len(free_statevar_indices) - len(fixed_stable_compset_indices)
 
         # Assuming the prescribed_mole_fraction_rhs doesn't change, this is
@@ -380,7 +401,8 @@ cdef class SystemSpecification:
                 np.array(self.initial_chemical_potentials), np.array(self.prescribed_mole_fraction_coefficients),
                 np.array(self.prescribed_mole_fraction_rhs), np.array(self.free_chemical_potential_indices),
                 np.array(self.free_statevar_indices), np.array(self.fixed_chemical_potential_indices),
-                np.array(self.fixed_statevar_indices), np.array(self.fixed_stable_compset_indices))
+                np.array(self.fixed_statevar_indices), np.array(self.fixed_stable_compset_indices),
+                np.array(self.fixed_chempot_coefs), np.array(self.fixed_chempot_rhs))
     def __setstate__(self, state):
         self.__init__(*state)
 
@@ -694,16 +716,17 @@ cpdef construct_equilibrium_system(SystemSpecification spec, SystemState state, 
     cdef double[::1,:] equilibrium_matrix  # Fortran ordering required by call into lapack
     cdef double[::1] equilibrium_soln
     cdef int num_stable_phases, num_fixed_phases, num_fixed_mole_fraction_conditions, num_free_variables
-    cdef int num_mole_amount_conditions
+    cdef int num_mole_amount_conditions, num_chempot_conditions
 
     num_stable_phases = state.free_stable_compset_indices.shape[0]
     num_fixed_phases = spec.fixed_stable_compset_indices.shape[0]
     num_fixed_mole_fraction_conditions = spec.prescribed_mole_fraction_rhs.shape[0]
     num_mole_amount_conditions = spec.prescribed_mole_amount_rhs.shape[0]
+    num_chempot_conditions = spec.fixed_chempot_rhs.shape[0]
     num_free_variables = spec.free_chemical_potential_indices.shape[0] + num_stable_phases + \
                          spec.free_statevar_indices.shape[0]
 
-    equilibrium_matrix = np.zeros((num_stable_phases + num_fixed_phases + num_fixed_mole_fraction_conditions + num_mole_amount_conditions + num_reserved_rows,
+    equilibrium_matrix = np.zeros((num_stable_phases + num_fixed_phases + num_fixed_mole_fraction_conditions + num_mole_amount_conditions + num_chempot_conditions + num_reserved_rows,
                                    num_free_variables), order='F')
     equilibrium_rhs = np.zeros(equilibrium_matrix.shape[0])
     if (equilibrium_matrix.shape[0] != equilibrium_matrix.shape[1]):

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -218,7 +218,7 @@ cdef void write_row_fixed_mole_amount(double[:] out_row, double* out_rhs, int co
     # 4. Subtract fixed chemical potentials from each phase RHS
     for i in range(fixed_chemical_potential_indices.shape[0]):
         chempot_idx = fixed_chemical_potential_indices[i]
-        # 6. Subtract fixed chemical potentials from the N=1 row
+        # Subtract fixed chemical potentials from the system amount (N) row
         for j in range(c_component.shape[1]):
             out_rhs[0] -= phase_amt[idx] * chemical_potentials[
                 chempot_idx] * mass_jac[component_idx, num_statevars+j] * c_component[chempot_idx, j]
@@ -277,7 +277,7 @@ cdef void fill_equilibrium_system(double[::1,:] equilibrium_matrix, double[::1] 
                                             csst.moles_normalization_grad, state.phase_amt, idx, prefactor)
 
         system_amount_index = component_row_offset + num_fixed_mole_fraction_conditions
-        # 2X. Also handle the N=1 row
+        # 2X. Also handle the system amount (N) row
         for component_idx in range(num_components):
             write_row_fixed_mole_amount(equilibrium_matrix[system_amount_index, :],
                                         &equilibrium_rhs[system_amount_index], component_idx,
@@ -308,7 +308,7 @@ cdef void fill_equilibrium_system(double[::1,:] equilibrium_matrix, double[::1] 
                                             csst.moles_normalization_grad, state.phase_amt, idx, prefactor)
 
         system_amount_index = component_row_offset + num_fixed_mole_fraction_conditions
-        # 2X. Also handle the N=1 row
+        # 2X. Also handle the system amount (N) row
         for component_idx in range(num_components):
             write_row_fixed_mole_amount(equilibrium_matrix[system_amount_index, :],
                                         &equilibrium_rhs[system_amount_index], component_idx,
@@ -319,7 +319,7 @@ cdef void fill_equilibrium_system(double[::1,:] equilibrium_matrix, double[::1] 
                                         state.phase_amt, idx)
 
 
-    # Add mass residual to fixed component row RHS, plus N=1 row
+    # Add mass residual to fixed component row RHS, plus system amount (N) row
     component_row_offset = num_stable_phases + num_fixed_phases
     system_amount_index = component_row_offset + num_fixed_mole_fraction_conditions
     for fixed_molefrac_cond_idx in range(num_fixed_mole_fraction_conditions):

--- a/pycalphad/core/phase_rec.pxd
+++ b/pycalphad/core/phase_rec.pxd
@@ -61,6 +61,12 @@ cdef public class PhaseRecord(object)[type PhaseRecordType, object PhaseRecordOb
     cdef public object components
     cdef public object pure_elements
     cdef public object nonvacant_elements
+    cdef public object basis_components
+    cdef public object basis_component_index
+    cdef public object component_basis
+    cdef public object component_basis_inv_T
+    cdef public object component_molar_masses
+    cdef public bint basis_is_trivial
     cdef public double[::1] molar_masses
     cdef public double[::1] parameters
     cdef public int phase_dof

--- a/pycalphad/core/phase_rec.pyx
+++ b/pycalphad/core/phase_rec.pyx
@@ -176,6 +176,12 @@ cdef public class PhaseRecord(object)[type PhaseRecordType, object PhaseRecordOb
         self.num_statevars = len(phase_record_factory.state_variables)
         self.pure_elements = phase_record_factory.pure_elements
         self.nonvacant_elements = phase_record_factory.nonvacant_elements
+        self.basis_components = phase_record_factory.basis_components
+        self.basis_component_index = phase_record_factory.basis_component_index
+        self.component_basis = phase_record_factory.component_basis
+        self.component_basis_inv_T = phase_record_factory.component_basis_inv_T
+        self.component_molar_masses = phase_record_factory.component_molar_masses
+        self.basis_is_trivial = phase_record_factory.basis_is_trivial
         self.molar_masses = phase_record_factory.molar_masses
         self.parameters = phase_record_factory.param_values
         

--- a/pycalphad/core/solver.py
+++ b/pycalphad/core/solver.py
@@ -1,3 +1,4 @@
+from typing import cast
 import numpy as np
 from collections import namedtuple
 from pycalphad.core.minimizer import SystemSpecification
@@ -50,15 +51,20 @@ class Solver(SolverBase):
         """
         # Prevent circular import
         from pycalphad.variables import ChemicalPotential, MassFraction, MoleFraction, \
-            SiteFraction, SystemMolesType
+            SiteFraction, Moles
+        from pycalphad.core.errors import ConditionError
         compsets = composition_sets
         state_variables = compsets[0].phase_record.state_variables
         nonvacant_elements = compsets[0].phase_record.nonvacant_elements
         num_statevars = len(state_variables)
         num_components = len(nonvacant_elements)
         chemical_potentials = np.zeros(num_components)
+        # X(i), W(i)
         prescribed_mole_fraction_coefficients = []
         prescribed_mole_fraction_rhs = []
+        # N, N(i), B, B(i)
+        prescribed_mole_amount_coefficients = []
+        prescribed_mole_amount_rhs = []
         local_conditions = {key: value for key, value in conditions.items()
                             if getattr(key, 'phase_name', None) is not None}
         for compset in compsets:
@@ -111,14 +117,31 @@ class Solver(SolverBase):
                     denominator_idx = cond.symbols.index(cond.denominator)
                     coefs[denominator_idx] -= value
                 prescribed_mole_fraction_coefficients.append(coefs)
+            elif isinstance(cond, Moles) or (isinstance(cond, str) and (cond == 'N' or cond.startswith('N_'))):
+                # Extensive: total N (species is None) or component N(i). Conditions may be
+                # keyed by a Moles object or by string ('N', 'N_<EL>'). Total moles exposes no
+                # `species` attribute, so probe defensively with getattr.
+                if isinstance(cond, Moles):
+                    if getattr(cond, 'phase_name', None) is not None:
+                        raise ConditionError(f'Phase-local moles condition {cond} is not supported')
+                    cond_species = getattr(cond, 'species', None)
+                else:
+                    # cond must be a string per outer elif
+                    cond_species = None if cond == 'N' else cast(str, cond)[2:]
+                coefs = np.zeros(num_components)
+                if cond_species is None:
+                    coefs[:] = 1.0  # total N: sum of all component amounts
+                else:
+                    coefs[list(nonvacant_elements).index(str(cond_species))] = 1.0  # N(species)
+                prescribed_mole_amount_coefficients.append(coefs)
+                prescribed_mole_amount_rhs.append(value)
         prescribed_mole_fraction_coefficients = np.atleast_2d(prescribed_mole_fraction_coefficients)
         prescribed_mole_fraction_rhs = np.array(prescribed_mole_fraction_rhs)
-        # Conditions may be keyed by str or StateVariable
-        prescribed_system_amount = np.asarray(conditions.get(SystemMolesType(), conditions.get('N', 1.0)))
-        if prescribed_system_amount.ndim > 0:
-            # TODO: resolve type instability for scalar vs. 1D arrays
-            assert prescribed_system_amount.size == 1
-            prescribed_system_amount = prescribed_system_amount[0]
+        if len(prescribed_mole_amount_coefficients) > 0:
+            prescribed_mole_amount_coefficients = np.atleast_2d(prescribed_mole_amount_coefficients)
+        else:
+            prescribed_mole_amount_coefficients = np.zeros((0, num_components))
+        prescribed_mole_amount_rhs = np.array(prescribed_mole_amount_rhs, dtype=np.float64)
 
         fixed_chemical_potential_indices = np.array([nonvacant_elements.index(str(key)[3:]) for key in conditions.keys() if str(key).startswith('MU_')], dtype=np.int32)
         free_chemical_potential_indices = np.array(sorted(set(range(num_components)) - set(fixed_chemical_potential_indices)), dtype=np.int32)
@@ -132,7 +155,8 @@ class Solver(SolverBase):
         free_statevar_indices = np.array(sorted(set(range(num_statevars)) - set(fixed_statevar_indices)), dtype=np.int32)
         fixed_statevar_indices = np.array(fixed_statevar_indices, dtype=np.int32)
         fixed_stable_compset_indices = np.array([i for i, compset in enumerate(compsets) if compset.fixed], dtype=np.int32)
-        spec = SystemSpecification(num_statevars, num_components, prescribed_system_amount,
+        spec = SystemSpecification(num_statevars, num_components,
+                                   prescribed_mole_amount_coefficients, prescribed_mole_amount_rhs,
                                    chemical_potentials, prescribed_mole_fraction_coefficients,
                                    prescribed_mole_fraction_rhs,
                                    free_chemical_potential_indices, free_statevar_indices,

--- a/pycalphad/core/solver.py
+++ b/pycalphad/core/solver.py
@@ -50,7 +50,7 @@ class Solver(SolverBase):
         """
         # Prevent circular import
         from pycalphad.variables import ChemicalPotential, MassFraction, MoleFraction, \
-            SiteFraction
+            SiteFraction, SystemMolesType
         compsets = composition_sets
         state_variables = compsets[0].phase_record.state_variables
         nonvacant_elements = compsets[0].phase_record.nonvacant_elements
@@ -113,7 +113,13 @@ class Solver(SolverBase):
                 prescribed_mole_fraction_coefficients.append(coefs)
         prescribed_mole_fraction_coefficients = np.atleast_2d(prescribed_mole_fraction_coefficients)
         prescribed_mole_fraction_rhs = np.array(prescribed_mole_fraction_rhs)
-        prescribed_system_amount = conditions.get('N', 1.0)
+        # Conditions may be keyed by str or StateVariable
+        prescribed_system_amount = np.asarray(conditions.get(SystemMolesType(), conditions.get('N', 1.0)))
+        if prescribed_system_amount.ndim > 0:
+            # TODO: resolve type instability for scalar vs. 1D arrays
+            assert prescribed_system_amount.size == 1
+            prescribed_system_amount = prescribed_system_amount[0]
+
         fixed_chemical_potential_indices = np.array([nonvacant_elements.index(str(key)[3:]) for key in conditions.keys() if str(key).startswith('MU_')], dtype=np.int32)
         free_chemical_potential_indices = np.array(sorted(set(range(num_components)) - set(fixed_chemical_potential_indices)), dtype=np.int32)
         for fixed_chempot_index in fixed_chemical_potential_indices:

--- a/pycalphad/core/solver.py
+++ b/pycalphad/core/solver.py
@@ -2,6 +2,7 @@ from typing import cast
 import numpy as np
 from collections import namedtuple
 from pycalphad.core.minimizer import SystemSpecification
+from pycalphad.core.errors import ConditionError
 
 SolverResult = namedtuple('SolverResult', ['converged', 'x', 'chemical_potentials'])
 
@@ -52,13 +53,29 @@ class Solver(SolverBase):
         # Prevent circular import
         from pycalphad.variables import ChemicalPotential, MassFraction, MoleFraction, \
             SiteFraction, Moles
-        from pycalphad.core.errors import ConditionError
         compsets = composition_sets
         state_variables = compsets[0].phase_record.state_variables
         nonvacant_elements = compsets[0].phase_record.nonvacant_elements
         num_statevars = len(state_variables)
         num_components = len(nonvacant_elements)
         chemical_potentials = np.zeros(num_components)
+        # Redefined-component basis. For a trivial (pure-element) basis these are unused and
+        # the original element-basis construction below runs unchanged.
+        phase_record = compsets[0].phase_record
+        basis_is_trivial = phase_record.basis_is_trivial
+        basis_component_index = phase_record.basis_component_index
+        component_basis_inv_T = np.asarray(phase_record.component_basis_inv_T)
+        component_molar_masses = np.asarray(phase_record.component_molar_masses)
+        molar_masses = np.asarray(phase_record.molar_masses)
+        inv_T_colsum = component_basis_inv_T.sum(axis=0)
+
+        def basis_row(species):
+            name = str(species)
+            if name not in basis_component_index:
+                raise ConditionError(
+                    f"{name!r} is not part of the component basis {list(basis_component_index)}; "
+                    f"conditions must be expressed in terms of basis components.")
+            return basis_component_index[name]
         # X(i), W(i)
         prescribed_mole_fraction_coefficients = []
         prescribed_mole_fraction_rhs = []
@@ -76,11 +93,18 @@ class Solver(SolverBase):
             # values should all be scalar floats
             value = float(np.asarray(value).flat[0])
             if isinstance(cond, MoleFraction) and cond.phase_name is None:
-                el = str(cond)[2:]
-                el_idx = list(nonvacant_elements).index(el)
-                prescribed_mole_fraction_rhs.append(value)
-                coefs = np.zeros(num_components)
-                coefs[el_idx] = 1.0
+                # X(c) = k. A component whose (S^T)^-1 row is a unit vector (every pure element,
+                # and the whole trivial basis) keeps the direct form dot(e_c, x) = k: it is exact
+                # (the component total equals the atom total) and stays one-hot, which the
+                # Jansson-derivative matching in fixed_component_differential relies on. A genuine
+                # multi-element component uses the homogeneous form ((S^T)^-1[c,:] - k*colsum).x = 0
+                # because its component total differs from the atom total.
+                coefs = np.array(component_basis_inv_T[basis_row(cond.species)])
+                if np.count_nonzero(coefs) == 1 and np.isclose(coefs.sum(), 1.0):
+                    prescribed_mole_fraction_rhs.append(value)
+                else:
+                    coefs = coefs - value * inv_T_colsum
+                    prescribed_mole_fraction_rhs.append(0.0)
                 prescribed_mole_fraction_coefficients.append(coefs)
             elif isinstance(cond, MoleFraction) and cond.phase_name is not None:
                 # phase-local condition; already handled
@@ -89,50 +113,48 @@ class Solver(SolverBase):
                 # phase-local condition; already handled
                 continue
             elif isinstance(cond, MassFraction):
-                # wA = k -> (1-k)*MWA*xA - k*MWB*xB - k*MWC*xC = 0
-                el = str(cond)[2:]
-                el_idx = list(nonvacant_elements).index(el)
-                coef_vector = np.zeros(num_components)
-                coef_vector -= value
-                coef_vector[el_idx] += 1
-                # multiply coef_vector times a vector of molecular weights
-                coef_vector = np.multiply(coef_vector, compsets[0].phase_record.molar_masses)
+                # W(c) = k  <=>  (MW(c) * (S^T)^-1[c,:] - k * mass_elem) . x_elem = 0.
+                # For a pure-element basis this reduces to (1-k)*MW_A*x_A - k*MW_B*x_B - ... = 0.
+                row = basis_row(cond.species)
+                coef_vector = component_molar_masses[row] * component_basis_inv_T[row] - value * molar_masses
                 prescribed_mole_fraction_rhs.append(0.)
                 prescribed_mole_fraction_coefficients.append(coef_vector)
             elif str(cond).startswith('LinComb_'):
+                # Linear combination of (component) mole fractions. With
+                # X(c) = (S^T)^-1[c,:].x / (colsum.x), sum_k a_k X(c_k) + const = value
+                # multiplies through by the (positive) component total to the homogeneous
+                # row (sum_k a_k (S^T)^-1[c_k] - (value-const)*colsum).x = 0. For a molar
+                # ratio the component total cancels, leaving (S^T)^-1[num] - value*(S^T)^-1[den].
+                # For a pure-element basis (S = I) this is the element linear combination.
                 coefs = np.zeros(num_components)
                 constant = 0.0
                 for symbol, coef in zip(cond.symbols, cond.coefs):
                     if symbol == 1:
                         constant = coef
                         continue
-                    el = str(symbol)[2:]
-                    el_idx = list(nonvacant_elements).index(el)
-                    coefs[el_idx] = coef
+                    coefs = coefs + coef * component_basis_inv_T[basis_row(symbol.species)]
                 if cond.denominator == 1:
-                    prescribed_mole_fraction_rhs.append(value - float(constant))
+                    coefs = coefs - (value - float(constant)) * inv_T_colsum
                 else:
-                    # Adjust coefficients to account for molar ratio
-                    prescribed_mole_fraction_rhs.append(-float(constant))
-                    denominator_idx = cond.symbols.index(cond.denominator)
-                    coefs[denominator_idx] -= value
+                    coefs = coefs - value * component_basis_inv_T[basis_row(cond.denominator.species)]
+                prescribed_mole_fraction_rhs.append(0.0)
                 prescribed_mole_fraction_coefficients.append(coefs)
             elif isinstance(cond, Moles) or (isinstance(cond, str) and (cond == 'N' or cond.startswith('N_'))):
                 # Extensive: total N (species is None) or component N(i). Conditions may be
                 # keyed by a Moles object or by string ('N', 'N_<EL>'). Total moles exposes no
                 # `species` attribute, so probe defensively with getattr.
                 if isinstance(cond, Moles):
-                    if getattr(cond, 'phase_name', None) is not None:
-                        raise ConditionError(f'Phase-local moles condition {cond} is not supported')
+                    # Phase-local moles are rejected upstream (Conditions); a direct Solver
+                    # caller is backstopped by set_local_conditions / build_phase_local_constraints.
                     cond_species = getattr(cond, 'species', None)
                 else:
                     # cond must be a string per outer elif
                     cond_species = None if cond == 'N' else cast(str, cond)[2:]
-                coefs = np.zeros(num_components)
                 if cond_species is None:
-                    coefs[:] = 1.0  # total N: sum of all component amounts
+                    coefs = np.ones(num_components)  # total N: total moles of atoms (basis-independent)
                 else:
-                    coefs[list(nonvacant_elements).index(str(cond_species))] = 1.0  # N(species)
+                    # N(c) = (S^T)^-1[c,:] . n_elem  (a unit vector for a pure-element basis)
+                    coefs = component_basis_inv_T[basis_row(cond_species)].copy()
                 prescribed_mole_amount_coefficients.append(coefs)
                 prescribed_mole_amount_rhs.append(value)
         prescribed_mole_fraction_coefficients = np.atleast_2d(prescribed_mole_fraction_coefficients)
@@ -143,11 +165,37 @@ class Solver(SolverBase):
             prescribed_mole_amount_coefficients = np.zeros((0, num_components))
         prescribed_mole_amount_rhs = np.array(prescribed_mole_amount_rhs, dtype=np.float64)
 
-        fixed_chemical_potential_indices = np.array([nonvacant_elements.index(str(key)[3:]) for key in conditions.keys() if str(key).startswith('MU_')], dtype=np.int32)
+        # MU conditions. For a trivial (pure-element) basis, fix individual element chemical
+        # potentials by index (unchanged). For a redefined basis, MU(component) fixes a linear
+        # combination of element chemical potentials, sum_e constituents[e]*mu_e = value, added
+        # as a constraint row; all element chemical potentials stay free and solved.
+        fixed_chempot_coefs = []
+        fixed_chempot_rhs = []
+        if basis_is_trivial:
+            fixed_chemical_potential_indices = np.array(
+                [nonvacant_elements.index(str(key)[3:]) for key in conditions.keys() if str(key).startswith('MU_')],
+                dtype=np.int32)
+            for fixed_chempot_index in fixed_chemical_potential_indices:
+                el = nonvacant_elements[fixed_chempot_index]
+                chemical_potentials[fixed_chempot_index] = conditions.get(ChemicalPotential(el))
+        else:
+            fixed_chemical_potential_indices = np.array([], dtype=np.int32)
+            for key in conditions.keys():
+                if not isinstance(key, ChemicalPotential):
+                    continue
+                row = np.zeros(num_components)
+                for el, mult in key.species.constituents.items():
+                    if el == 'VA':
+                        continue
+                    row[nonvacant_elements.index(el)] = mult
+                fixed_chempot_coefs.append(row)
+                fixed_chempot_rhs.append(float(np.asarray(conditions[key]).flat[0]))
+        if len(fixed_chempot_coefs) > 0:
+            fixed_chempot_coefs = np.atleast_2d(fixed_chempot_coefs)
+        else:
+            fixed_chempot_coefs = np.zeros((0, num_components))
+        fixed_chempot_rhs = np.array(fixed_chempot_rhs, dtype=np.float64)
         free_chemical_potential_indices = np.array(sorted(set(range(num_components)) - set(fixed_chemical_potential_indices)), dtype=np.int32)
-        for fixed_chempot_index in fixed_chemical_potential_indices:
-            el = nonvacant_elements[fixed_chempot_index]
-            chemical_potentials[fixed_chempot_index] = conditions.get(ChemicalPotential(el))
         fixed_statevar_indices = []
         for statevar_idx, statevar in enumerate(state_variables):
             if str(statevar) in [str(k) for k in conditions.keys()]:
@@ -161,7 +209,8 @@ class Solver(SolverBase):
                                    prescribed_mole_fraction_rhs,
                                    free_chemical_potential_indices, free_statevar_indices,
                                    fixed_chemical_potential_indices, fixed_statevar_indices,
-                                   fixed_stable_compset_indices)
+                                   fixed_stable_compset_indices,
+                                   fixed_chempot_coefs, fixed_chempot_rhs)
         return spec
 
     @staticmethod

--- a/pycalphad/core/starting_point.py
+++ b/pycalphad/core/starting_point.py
@@ -1,6 +1,7 @@
 from pycalphad import variables as v
 from pycalphad.core.lower_convex_hull import lower_convex_hull
 from pycalphad.core.light_dataset import LightDataset
+from pycalphad.core.errors import ConditionError
 from pycalphad.property_framework.computed_property import LinearCombination
 from xarray import Dataset
 import numpy as np
@@ -33,7 +34,7 @@ def global_min_is_possible(conditions, state_variables):
            isinstance(cond, v.SiteFraction) or \
            isinstance(cond, LinearCombination) or \
            isinstance(cond, v.ChemicalPotential) or \
-           cond == v.N:
+           isinstance(cond, v.Moles):
             continue
         global_min = False
     return global_min
@@ -72,14 +73,22 @@ def starting_point(conditions, state_variables, phase_records, grid):
         len(nonvacant_elements) + 1)  # +1 is to accommodate the degenerate degree of freedom at the invariant reactions
     coord_dict['component'] = nonvacant_elements
     conds_as_strings = [str(k) for k in conditions.keys()]
-    number_dof = len(nonvacant_elements) - 1
-    for i in conditions.keys():
-        if not (hasattr(i, 'species') or isinstance(i, LinearCombination)):
+    # At least one condition must be extensive, otherwise the intensive set is rank-deficient
+    number_dof = len(nonvacant_elements)
+    num_extensive = 0
+    for cond in conditions.keys():
+        if getattr(cond, 'phase_name', None) is not None:
+            # Phase-local conditions do not reduce the total (global) degrees of freedom
             continue
-        if hasattr(i, 'species') and hasattr(i, 'phase_name') and i.phase_name is not None:
-            # Phase-local conditions do not reduce the total degrees of freedom
-            continue
-        number_dof -= 1
+        if isinstance(cond, (v.MoleFraction, v.MassFraction, v.ChemicalPotential, LinearCombination)):
+            number_dof -= 1
+        elif isinstance(cond, v.Moles):  # extensive: total N or component N(i) (future B/B(i))
+            number_dof -= 1
+            num_extensive += 1
+    if num_extensive < 1:
+        raise ConditionError(
+            'At least one extensive condition fixing the system size must be specified '
+            '(e.g. v.N or v.Moles(component)); only intensive conditions were given.')
     if number_dof != 0:
         raise ValueError('Number of degrees of freedom is not zero')
 

--- a/pycalphad/core/utils.py
+++ b/pycalphad/core/utils.py
@@ -427,7 +427,7 @@ def get_state_variables(models=None, conds=None):
     --------
     >>> from pycalphad import variables as v
     >>> from pycalphad.core.utils import get_state_variables
-    >>> get_state_variables(conds={v.P: 101325, v.N: 1, v.X('AL'): 0.2}) == {v.P, v.N, v.T}
+    >>> get_state_variables(conds={v.P: 101325, v.N: 1, v.X('AL'): 0.2}) == {v.P, v.T}
     True
     """
     state_vars = set()
@@ -436,9 +436,9 @@ def get_state_variables(models=None, conds=None):
             state_vars.update(mod.state_variables)
     if conds is not None:
         for c in conds:
-            # StateVariable instances are ok (e.g. P, T, N, V, S),
-            # however, subclasses (X, Y, MU, NP) are not ok.
-            if isinstance(c, (v.IndependentPotential, v.SystemMolesType)):
+            # Only independent potentials (P, T) are state variables of the energy
+            # callables. Extensive conditions (N, N(i), B, B(i)) are handled by the minimizer.
+            if isinstance(c, v.IndependentPotential):
                 state_vars.add(c)
     return state_vars
 

--- a/pycalphad/core/workspace.py
+++ b/pycalphad/core/workspace.py
@@ -1,6 +1,13 @@
 import warnings
 from collections import OrderedDict, Counter, defaultdict
 from copy import copy
+from typing import Optional, Tuple, Type, TypeVar, Union
+
+import numpy as np
+from symengine import Basic
+from runtype import isa
+from runtype.pytypes import Dict, List, Sequence, SumType, Mapping, NoneType
+
 from pycalphad.property_framework.computed_property import JanssonDerivative
 import pycalphad.variables as v
 from pycalphad.core.utils import unpack_species, unpack_condition, unpack_phases, filter_phases, instantiate_models
@@ -12,17 +19,11 @@ from pycalphad.core.composition_set import CompositionSet
 from pycalphad.core.solver import Solver, SolverBase
 from pycalphad.core.light_dataset import LightDataset
 from pycalphad.model import Model
-import numpy as np
-import numpy.typing as npt
-from typing import Optional, Tuple, Type
 from pycalphad.io.database import Database
 from pycalphad.variables import Species, StateVariable
 from pycalphad.core.conditions import Conditions, ConditionError
 from pycalphad.property_framework import ComputableProperty, as_property
 from pycalphad.property_framework.units import as_quantity, Q_, to_display_units
-from runtype import isa
-from runtype.pytypes import Dict, List, Sequence, SumType, Mapping, NoneType
-from typing import TypeVar
 
 
 
@@ -495,7 +496,7 @@ class Workspace:
                 conds_keys[cond_idx] = k
         return [c for c in conds_keys if c is not None]
 
-    def get_dict(self, *args: Tuple[ComputableProperty]):
+    def get_dict(self, *args: Union[str, Basic, ComputableProperty]):
         args = list(map(as_property, args))
         self._expand_property_arguments(args)
 
@@ -530,7 +531,7 @@ class Workspace:
 
         return results
 
-    def get(self, *args: Tuple[ComputableProperty]):
+    def get(self, *args: Union[str, Basic, ComputableProperty]):
         result = list(self.get_dict(*args).values())
         if len(result) != 1:
             return result

--- a/pycalphad/core/workspace.py
+++ b/pycalphad/core/workspace.py
@@ -295,9 +295,6 @@ class EquilibriumCalculationField(TypedField):
 # Defined to allow type checking for Model or its subclasses
 ModelType = TypeVar('ModelType', bound=Model)
 
-# TODO: enable converting v.X conditions for v.Component objects into
-# LinearCombination conditions for components with more than one constituent
-
 class Workspace:
     """
     Reactive equilibrium calculator.

--- a/pycalphad/property_framework/computed_property.py
+++ b/pycalphad/property_framework/computed_property.py
@@ -62,11 +62,27 @@ class ModelComputedProperty(object):
         else:
             return None
 
+    def _is_molar(self) -> bool:
+        # TODO: this is kind of a hack until we have proper suffix-normalization support on conditions and is used to detect when a property should be normalized by the number of atoms.
+        # Molar (per-mole-atom) quantities carry per-mole implementation units (e.g. 'J / mol').
+        # Extensive quantities (G, H) do not. Mirrors the test in property_framework/units.py.
+        # Sort of a hack until we have proper suffix support
+        return '/ mol' in str(self.implementation_units)
+
     def compute_property(self, compsets: List[CompositionSet], cur_conds: Dict[str, float], chemical_potentials: npt.ArrayLike) -> npt.ArrayLike:
         if len(compsets) == 0:
             return np.nan
         if self.phase_name is None:
-            return np.sum([compset.NP*self._compute_per_phase_property(compset, cur_conds) for compset in compsets])
+            result = np.sum([compset.NP*self._compute_per_phase_property(compset, cur_conds) for compset in compsets])
+            if self._is_molar():
+                # The total system amount, N, is counted from the elemental amounts
+                # in the composition sets; a global N condition is not required to exist.
+                system_amount = np.sum([compset.NP * np.sum(compset.X) for compset in compsets])
+                if system_amount != 0:
+                    result = result / system_amount
+                else:
+                    raise ValueError(f"The system has zero moles. Got composition sets: {compsets}")
+            return result
         else:
             tokens = self.phase_name.split('#')
             phase_name = tokens[0]
@@ -109,6 +125,15 @@ class ModelComputedProperty(object):
             else:
                 jansson_derivative += np.dot(deltas.delta_statevars, grad_value[:len(state_variables)])
                 jansson_derivative += np.dot(delta_sitefracs, grad_value[len(state_variables):])
+        if (self.phase_name is None) and self._is_molar() and not np.isnan(jansson_derivative):
+            # The accumulated value is the derivative of the extensive quantity B = sum(NP*q).
+            # N is held fixed by the equilibrium system (dN == 0 along the perturbation),
+            # so the molar derivative is exactly dB / N. No quotient rule is needed.
+            system_amount = np.sum([compset.NP * np.sum(compset.X) for compset in compsets])
+            if system_amount != 0:
+                jansson_derivative /= system_amount
+            else:
+                raise ValueError(f"The system has zero moles. Got composition sets: {compsets}")
         return jansson_derivative
 
     def _compute_per_phase_property(self, compset: CompositionSet, cur_conds: Dict[str, float]) -> float:

--- a/pycalphad/tests/test_calculate.py
+++ b/pycalphad/tests/test_calculate.py
@@ -61,13 +61,17 @@ def test_issue116(load_database):
     result_three_values = result_three.GM.values
     np.testing.assert_array_equal(np.squeeze(result_one_values), np.squeeze(result_two_values))
     np.testing.assert_array_equal(np.squeeze(result_one_values), np.squeeze(result_three_values))
-    # N is added automatically
-    assert len(result_one_values.shape) == 3  # N, T, points
+    # N is not a coordinate of calculate(); only P and T are.
+    # An explicit N kwarg is ignored (filtered out) and does not add a dimension.
+    assert len(result_one_values.shape) == 2  # T, points
     assert result_one_values.shape[0] == 1
-    assert len(result_two_values.shape) == 4  # N, P, T, points
-    assert result_two_values.shape[:3] == (1, 1, 1)
-    assert len(result_three_values.shape) == 4  # N, P, T, points
-    assert result_three_values.shape[:3] == (1, 1, 1)
+    assert len(result_two_values.shape) == 3  # P, T, points
+    assert result_two_values.shape[:2] == (1, 1)
+    assert len(result_three_values.shape) == 3  # P, T, points (N ignored)
+    assert result_three_values.shape[:2] == (1, 1)
+    # N is not a coordinate of the calculate() output
+    assert 'N' not in result_one.coords
+    assert 'N' not in result_three.coords
 
     # NOT passing temperature when temperature is required by the Model raises
     with pytest.raises(ConditionError):

--- a/pycalphad/tests/test_codegen.py
+++ b/pycalphad/tests/test_codegen.py
@@ -83,7 +83,7 @@ def test_complex_infinity_can_build_callables_successfully(load_database):
     """Test that functions that containing complex infinity can be built with codegen."""
     dbf = load_database()
     mod = Model(dbf, ['C'], 'DIAMOND_A4')
-    mod_vars = [v.N, v.P, v.T] + mod.site_fractions
+    mod_vars = [v.P, v.T] + mod.site_fractions
 
     # Test builds functions only, since functions takes about 1 second to run.
     # Both lambda and llvm backends take a few seconds to build the derivatives
@@ -107,7 +107,7 @@ def test_exponents_of_negative_bases_can_be_built():
     PARAMETER G(LIQUID,C;0) 298.15 X**(2); 6000 N !
     """)
     mod = Model(dbf, ["C"], "LIQUID")
-    mod_vars = [v.N, v.P, v.T] + mod.site_fractions
+    mod_vars = [v.P, v.T] + mod.site_fractions
     int_cons = mod.get_internal_constraints()
 
     # lambdify uses real=True by default, which raises if the expression contains complex numbers
@@ -125,7 +125,7 @@ def test_complex_numbers_generated_in_complicated_models_can_be_built(load_datab
     # In this case, the base of an exponent expression in GPCL2C evaluates to a constant, negative number.
     dbf = load_database()
     mod = Model(dbf, ["C"], "LIQUID")
-    mod_vars = [v.N, v.P, v.T] + mod.site_fractions
+    mod_vars = [v.P, v.T] + mod.site_fractions
     int_cons = mod.get_internal_constraints()
 
     build_functions(mod.GM, mod_vars, include_obj=True, include_grad=True, include_hess=True)

--- a/pycalphad/tests/test_define_components.py
+++ b/pycalphad/tests/test_define_components.py
@@ -1,0 +1,388 @@
+"""Tests for the redefined-component-basis ("define components") feature.
+
+A component basis lets conditions and outputs be expressed in terms of components
+that are linear combinations of the non-vacant pure elements (e.g. AL2O3, SIO2, O2).
+The change-of-basis matrix S (components x non-vacant elements) is built and validated
+in PhaseRecordFactory; for a pure-element component list S is the identity ("trivial"
+basis) and behavior is unchanged.
+"""
+import numpy as np
+import pytest
+from pycalphad import Workspace, variables as v
+from pycalphad.core.errors import ConditionError
+from pycalphad.tests.fixtures import select_database, load_database
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: change-of-basis matrix construction, trivial detection, validation
+# ---------------------------------------------------------------------------
+
+@select_database("alzn_mey.tdb")
+def test_trivial_basis_is_identity(load_database):
+    """A pure-element component list yields the identity basis (trivial)."""
+    dbf = load_database()
+    wks = Workspace(dbf, ['AL', 'ZN', 'VA'], ['FCC_A1'])
+    prf = wks.phase_record_factory
+    assert prf.nonvacant_elements == ['AL', 'ZN']
+    assert prf.basis_is_trivial is True
+    np.testing.assert_array_equal(prf.component_basis, np.eye(2))
+    np.testing.assert_array_equal(prf.component_basis_inv_T, np.eye(2))
+
+
+@select_database("alzn_mey.tdb")
+def test_synthetic_binary_basis_matrix(load_database):
+    """A synthetic molecular component basis builds the expected non-identity S."""
+    dbf = load_database()
+    # ALZN = {AL:1, ZN:1}; basis components sorted by name -> [ALZN, ZN] over [AL, ZN]
+    wks = Workspace(dbf, ['ALZN', 'ZN', 'VA'], ['FCC_A1'])
+    prf = wks.phase_record_factory
+    assert prf.nonvacant_elements == ['AL', 'ZN']
+    assert [str(c) for c in prf.basis_components] == ['ALZN', 'ZN']
+    expected_S = np.array([[1.0, 1.0],
+                           [0.0, 1.0]])
+    np.testing.assert_array_equal(prf.component_basis, expected_S)
+    np.testing.assert_allclose(prf.component_basis_inv_T, np.linalg.inv(expected_S.T))
+    assert prf.basis_is_trivial is False
+    # component molar masses: MW(ALZN) = m_AL + m_ZN; MW(ZN) = m_ZN
+    m_al, m_zn = prf.molar_masses  # sorted [AL, ZN]
+    np.testing.assert_allclose(prf.component_molar_masses, [m_al + m_zn, m_zn])
+
+
+@select_database("alcrni.tdb")
+def test_synthetic_ternary_basis_matrix(load_database):
+    """A 3x3 synthetic basis is built and inverted."""
+    dbf = load_database()
+    wks = Workspace(dbf, ['ALCR', 'CRNI', 'NI', 'VA'], ['FCC_A1'])
+    prf = wks.phase_record_factory
+    assert prf.nonvacant_elements == ['AL', 'CR', 'NI']
+    assert [str(c) for c in prf.basis_components] == ['ALCR', 'CRNI', 'NI']
+    expected_S = np.array([[1.0, 1.0, 0.0],
+                           [0.0, 1.0, 1.0],
+                           [0.0, 0.0, 1.0]])
+    np.testing.assert_array_equal(prf.component_basis, expected_S)
+    np.testing.assert_allclose(prf.component_basis_inv_T, np.linalg.inv(expected_S.T))
+    assert prf.basis_is_trivial is False
+
+
+@select_database("alcrni.tdb")
+def test_fractional_basis_matrix(load_database):
+    """Components with stoichiometric coefficients > 1 and shared elements (oxide-like)
+    build the expected S. Uses a metallic database so the model builds cleanly; the
+    matrix math is independent of the phase."""
+    dbf = load_database()
+    # AL2CR={AL:2,CR:1}, CRNI3={CR:1,NI:3}, NI={NI:1}
+    wks = Workspace(dbf, ['AL2CR', 'CRNI3', 'NI', 'VA'], ['FCC_A1'])
+    prf = wks.phase_record_factory
+    assert prf.nonvacant_elements == ['AL', 'CR', 'NI']
+    assert [str(c) for c in prf.basis_components] == ['AL2CR', 'CRNI3', 'NI']
+    # rows: AL2CR, CRNI3, NI ; cols: AL, CR, NI
+    expected_S = np.array([[2.0, 1.0, 0.0],
+                           [0.0, 1.0, 3.0],
+                           [0.0, 0.0, 1.0]])
+    np.testing.assert_array_equal(prf.component_basis, expected_S)
+    np.testing.assert_allclose(prf.component_basis_inv_T, np.linalg.inv(expected_S.T))
+    assert prf.basis_is_trivial is False
+
+
+@select_database("alcrni.tdb")
+def test_incomplete_basis_raises(load_database):
+    """Too few components to span the element space raises immediately, before solving."""
+    dbf = load_database()
+    # ALCR spans {AL, CR} but is a single component -> 1 < 2
+    with pytest.raises(ConditionError, match="incomplete"):
+        Workspace(dbf, ['ALCR', 'VA'], ['FCC_A1'])
+
+
+@select_database("alzn_mey.tdb")
+def test_overdetermined_components_fall_back_to_element_basis(load_database):
+    """An over-determined component list (more distinct components than elements) is a
+    normal calculation, not a redefined basis, and falls back to the trivial element
+    basis without error. This is the same shape as ionic/expanded-species lists from
+    `calculate`, which must not be rejected."""
+    dbf = load_database()
+    wks = Workspace(dbf, ['AL', 'ZN', 'ALZN', 'VA'], ['FCC_A1'])
+    prf = wks.phase_record_factory
+    assert prf.basis_is_trivial is True
+    np.testing.assert_array_equal(prf.component_basis, np.eye(2))
+
+
+@select_database("alzn_mey.tdb")
+def test_linearly_dependent_basis_raises(load_database):
+    """A square but singular basis (linearly dependent components) raises."""
+    dbf = load_database()
+    # AL2ZN2 = 2*ALZN -> rows are proportional -> rank 1 < 2
+    with pytest.raises(ConditionError, match="linearly dependent"):
+        Workspace(dbf, ['ALZN', 'AL2ZN2', 'VA'], ['FCC_A1'])
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: property outputs (MU(component) forward S; non-basis output raises)
+# ---------------------------------------------------------------------------
+
+@select_database("alcrni.tdb")
+def test_mu_component_output_forward_S(load_database):
+    """MU(component) output sums element chemical potentials over constituents and works
+    for components that are NOT part of the (here trivial, pure-element) basis."""
+    dbf = load_database()
+    wks = Workspace(dbf, ['AL', 'CR', 'NI', 'VA'], ['FCC_A1', 'BCC_A2', 'LIQUID'],
+                    {v.T: 1200, v.P: 1e5, v.N: 1, v.X('AL'): 0.2, v.X('CR'): 0.3})
+    mu_al = float(np.squeeze(wks.get('MU(AL)')))
+    mu_cr = float(np.squeeze(wks.get('MU(CR)')))
+    np.testing.assert_allclose(float(np.squeeze(wks.get('MU(ALCR)'))), mu_al + mu_cr, atol=1e-6)
+    np.testing.assert_allclose(float(np.squeeze(wks.get('MU(AL2CR)'))), 2 * mu_al + mu_cr, atol=1e-6)
+
+
+@select_database("alzn_mey.tdb")
+def test_component_amount_output_not_in_basis_raises(load_database):
+    """N/X/W of a multi-element component that is not part of the basis is ill-defined
+    and raises a clear error (here the basis is the pure elements)."""
+    dbf = load_database()
+    wks = Workspace(dbf, ['AL', 'ZN', 'VA'], ['FCC_A1'],
+                    {v.T: 600, v.P: 1e5, v.N: 1, v.X('ZN'): 0.3})
+    with pytest.raises(ConditionError, match="not part of the calculation's component basis"):
+        wks.get('X(ALZN)')
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: amount and fraction conditions in the component basis (equivalence)
+# ---------------------------------------------------------------------------
+
+def _assert_props_match(wks_a, wks_b, props, atol=1e-6):
+    for prop in props:
+        np.testing.assert_allclose(
+            np.squeeze(np.asarray(wks_a.get(prop), dtype=float)),
+            np.squeeze(np.asarray(wks_b.get(prop), dtype=float)),
+            atol=atol, err_msg=f"property {prop} differs between component and element bases")
+
+
+# Collision-free synthetic bases (component names differ from element names, as real
+# oxide/fluoride bases do), so element outputs are unambiguous.
+#   binary  [AL2ZN, ALZN2] over [AL, ZN]:  n_AL = 2a+b, n_ZN = a+2b
+#   ternary [AL2CR, CRNI2, NI3] over [AL, CR, NI]:  n_AL=2p, n_CR=p+q, n_NI=2q+3r
+
+@select_database("alzn_mey.tdb")
+def test_binary_amount_conditions_equivalence(load_database):
+    """N(component) conditions reproduce the equivalent pure-element equilibrium."""
+    dbf = load_database()
+    phases = ['FCC_A1', 'HCP_A3', 'LIQUID']
+    base = {v.T: 600.0, v.P: 1e5}
+    a, b = 0.2, 0.1  # n_AL = 2a+b = 0.5, n_ZN = a+2b = 0.4
+    wks_comp = Workspace(dbf, ['AL2ZN', 'ALZN2', 'VA'], phases,
+                         {**base, v.Moles('AL2ZN'): a, v.Moles('ALZN2'): b})
+    wks_elem = Workspace(dbf, ['AL', 'ZN', 'VA'], phases,
+                         {**base, v.Moles('AL'): 2 * a + b, v.Moles('ZN'): a + 2 * b})
+    _assert_props_match(wks_comp, wks_elem, ['GM', 'MU(AL)', 'MU(ZN)', 'X(AL)', 'X(ZN)', v.N])
+    # component conditions satisfied (outputs use (S^T)^-1)
+    np.testing.assert_allclose(np.squeeze(wks_comp.get(v.Moles('AL2ZN'))), a, atol=1e-6)
+    np.testing.assert_allclose(np.squeeze(wks_comp.get(v.Moles('ALZN2'))), b, atol=1e-6)
+
+
+@select_database("alcrni.tdb")
+def test_ternary_amount_conditions_equivalence(load_database):
+    """3x3 basis [AL2CR, CRNI2, NI3]: n_AL=2p, n_CR=p+q, n_NI=2q+3r."""
+    dbf = load_database()
+    phases = ['FCC_A1', 'BCC_A2', 'LIQUID']
+    base = {v.T: 1200.0, v.P: 1e5}
+    p, q, r = 0.1, 0.2, 0.1  # n_AL=0.2, n_CR=0.3, n_NI=0.7
+    wks_comp = Workspace(dbf, ['AL2CR', 'CRNI2', 'NI3', 'VA'], phases,
+                         {**base, v.Moles('AL2CR'): p, v.Moles('CRNI2'): q, v.Moles('NI3'): r})
+    wks_elem = Workspace(dbf, ['AL', 'CR', 'NI', 'VA'], phases,
+                         {**base, v.Moles('AL'): 2 * p, v.Moles('CR'): p + q, v.Moles('NI'): 2 * q + 3 * r})
+    _assert_props_match(wks_comp, wks_elem,
+                        ['GM', 'MU(AL)', 'MU(CR)', 'MU(NI)', 'X(AL)', 'X(CR)', 'X(NI)', v.N])
+
+
+@select_database("alzn_mey.tdb")
+def test_binary_mole_fraction_condition_roundtrip(load_database):
+    """X(component) (homogeneous form) round-trips and produces an equilibrium reproducible
+    from its resulting element composition. (X(component)=n_c/sum n_c' is not X(element).)"""
+    dbf = load_database()
+    phases = ['FCC_A1', 'HCP_A3', 'LIQUID']
+    base = {v.T: 600.0, v.P: 1e5, v.N: 1.0}
+    k = 0.3
+    wks_comp = Workspace(dbf, ['AL2ZN', 'ALZN2', 'VA'], phases, {**base, v.X('AL2ZN'): k})
+    np.testing.assert_allclose(np.squeeze(wks_comp.get('X(AL2ZN)')), k, atol=1e-6)
+    x_al = float(np.squeeze(wks_comp.get('X(AL)')))
+    wks_elem = Workspace(dbf, ['AL', 'ZN', 'VA'], phases, {**base, v.X('AL'): x_al})
+    _assert_props_match(wks_comp, wks_elem, ['GM', 'MU(AL)', 'MU(ZN)', 'X(ZN)'])
+
+
+@select_database("alzn_mey.tdb")
+def test_binary_mass_fraction_condition_roundtrip(load_database):
+    """W(component) condition round-trips and yields an equilibrium reproducible from the
+    resulting element composition (so the homogeneous mass-fraction constraint is correct)."""
+    dbf = load_database()
+    phases = ['FCC_A1', 'HCP_A3', 'LIQUID']
+    base = {v.T: 600.0, v.P: 1e5, v.N: 1.0}
+    k = 0.35
+    wks_comp = Workspace(dbf, ['AL2ZN', 'ALZN2', 'VA'], phases, {**base, v.W('AL2ZN'): k})
+    np.testing.assert_allclose(np.squeeze(wks_comp.get('W(AL2ZN)')), k, atol=1e-6)
+    x_al = float(np.squeeze(wks_comp.get('X(AL)')))
+    wks_elem = Workspace(dbf, ['AL', 'ZN', 'VA'], phases, {**base, v.X('AL'): x_al})
+    _assert_props_match(wks_comp, wks_elem, ['GM', 'MU(AL)', 'MU(ZN)', 'X(ZN)'])
+
+
+@select_database("alzn_mey.tdb")
+def test_component_name_shadows_element(load_database):
+    """When a basis component is named like an element (e.g. ZN in [ALZN, ZN]), N/X of that
+    name resolve to the *component*, not the element."""
+    dbf = load_database()
+    phases = ['FCC_A1', 'HCP_A3', 'LIQUID']
+    # [ALZN, ZN]: N(ALZN)=0.3, N(ZN_component)=0.4 -> n_AL=0.3, n_ZN=0.7
+    wks = Workspace(dbf, ['ALZN', 'ZN', 'VA'], phases,
+                    {v.T: 600.0, v.P: 1e5, v.Moles('ALZN'): 0.3, v.Moles('ZN'): 0.4})
+    np.testing.assert_allclose(np.squeeze(wks.get(v.Moles('ZN'))), 0.4, atol=1e-6)  # component
+    np.testing.assert_allclose(np.squeeze(wks.get(v.Moles('ALZN'))), 0.3, atol=1e-6)
+    np.testing.assert_allclose(np.squeeze(wks.get(v.N)), 1.0, atol=1e-6)  # total atoms 0.3+0.7
+
+
+@select_database("alzn_mey.tdb")
+def test_element_condition_under_component_basis_raises(load_database):
+    """No mixing: a pure-element condition is rejected under a component basis."""
+    dbf = load_database()
+    with pytest.raises(ConditionError):
+        Workspace(dbf, ['AL2ZN', 'ALZN2', 'VA'], ['FCC_A1'],
+                  {v.T: 600.0, v.P: 1e5, v.X('AL'): 0.3, v.N: 1.0})
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: linear combination conditions over basis components
+# ---------------------------------------------------------------------------
+
+@select_database("alzn_mey.tdb")
+def test_linear_combination_condition_over_components(load_database):
+    """A linear combination of component mole fractions is satisfied at equilibrium."""
+    dbf = load_database()
+    phases = ['FCC_A1', 'HCP_A3', 'LIQUID']
+    base = {v.T: 600.0, v.P: 1e5, v.N: 1.0}
+    expr = 0.5 * v.X('AL2ZN') - 7 * v.X('ALZN2')
+    wks = Workspace(dbf, ['AL2ZN', 'ALZN2', 'VA'], phases, {**base, expr: 0.1})
+    result = 0.5 * float(np.squeeze(wks.get('X(AL2ZN)'))) - 7 * float(np.squeeze(wks.get('X(ALZN2)')))
+    np.testing.assert_allclose(result, 0.1, atol=1e-6)
+    # the same expression evaluated as an output property agrees
+    np.testing.assert_allclose(np.squeeze(wks.get(expr)), 0.1, atol=1e-6)
+
+
+@select_database("alzn_mey.tdb")
+def test_linear_combination_ratio_over_components(load_database):
+    """A molar ratio of component mole fractions is satisfied at equilibrium."""
+    dbf = load_database()
+    phases = ['FCC_A1', 'HCP_A3', 'LIQUID']
+    base = {v.T: 600.0, v.P: 1e5, v.N: 1.0}
+    target = 2.5
+    wks = Workspace(dbf, ['AL2ZN', 'ALZN2', 'VA'], phases,
+                    {**base, v.X('AL2ZN') / v.X('ALZN2'): target})
+    ratio = float(np.squeeze(wks.get('X(AL2ZN)'))) / float(np.squeeze(wks.get('X(ALZN2)')))
+    np.testing.assert_allclose(ratio, target, atol=1e-6)
+    # change of basis is exact: ratio 2.5 over [AL2ZN, ALZN2] gives n_AL = (4/3) n_ZN -> X(AL)=4/7
+    np.testing.assert_allclose(float(np.squeeze(wks.get('X(AL)'))), 4.0 / 7.0, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: MU(component) conditions (fixed linear combination of chemical potentials)
+# ---------------------------------------------------------------------------
+
+@select_database("alzn_mey.tdb")
+def test_mu_component_condition_enforced(load_database):
+    """A MU(component) condition fixes sum_e constituents[e]*mu_e and is satisfied at
+    equilibrium, with element chemical potentials recovered consistently.
+
+    Note: like any chemical-potential condition, MU(component) can have multiple composition
+    solutions; we assert the constraint is enforced and self-consistent, not a unique
+    composition (see test_mu_component_with_composition_is_unique for a pinned case)."""
+    dbf = load_database()
+    phases = ['FCC_A1', 'HCP_A3', 'LIQUID']
+    base = {v.T: 900.0, v.P: 1e5}
+    ref = Workspace(dbf, ['AL2ZN', 'ALZN2', 'VA'], phases,
+                    {**base, v.Moles('AL2ZN'): 0.2, v.Moles('ALZN2'): 0.1})
+    mu_target = float(np.squeeze(ref.get('MU(AL2ZN)')))
+    total_n = float(np.squeeze(ref.get(v.N)))
+    test = Workspace(dbf, ['AL2ZN', 'ALZN2', 'VA'], phases,
+                     {**base, v.MU('AL2ZN'): mu_target, v.N: total_n})
+    np.testing.assert_allclose(np.squeeze(test.get('MU(AL2ZN)')), mu_target, atol=1e-3)
+    # element chemical potentials are solved and consistent: MU(AL2ZN) == 2*MU(AL) + MU(ZN)
+    mu_al = float(np.squeeze(test.get('MU(AL)')))
+    mu_zn = float(np.squeeze(test.get('MU(ZN)')))
+    np.testing.assert_allclose(2 * mu_al + mu_zn, mu_target, atol=1e-3)
+    assert np.isfinite(float(np.squeeze(test.get('GM'))))
+
+
+@select_database("alcrni.tdb")
+def test_mu_single_element_multiple_component(load_database):
+    """MU(component) for a single-element multiple (NI3 = {NI:3}) equals 3*MU(NI)."""
+    dbf = load_database()
+    phases = ['FCC_A1', 'BCC_A2', 'LIQUID']
+    base = {v.T: 1200.0, v.P: 1e5}
+    ref = Workspace(dbf, ['AL2CR', 'CRNI2', 'NI3', 'VA'], phases,
+                    {**base, v.Moles('AL2CR'): 0.1, v.Moles('CRNI2'): 0.2, v.Moles('NI3'): 0.1})
+    np.testing.assert_allclose(np.squeeze(ref.get('MU(NI3)')),
+                               3 * float(np.squeeze(ref.get('MU(NI)'))), atol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Phase 6: comprehensive coverage, string parsing, out-of-basis outputs, realism
+# ---------------------------------------------------------------------------
+
+def test_unpack_components_parses_formula_strings():
+    """Multi-element component strings parse to their elemental constituents (including
+    fractional stoichiometry)."""
+    by_name = {str(c): c for c in v.unpack_components(['AL2O3', 'SIO2', 'SI1O2'])}
+    assert by_name['AL2O3'].constituents == {'AL': 2.0, 'O': 3.0}
+    assert by_name['SIO2'].constituents == {'SI': 1.0, 'O': 2.0}
+    assert by_name['SI1O2'].constituents == {'SI': 1.0, 'O': 2.0}
+    # fractional stoichiometry via explicit construction (the '/N' suffix denotes charge)
+    assert v.Component('ALO3', {'AL': 1.0, 'O': 1.5}).constituents == {'AL': 1.0, 'O': 1.5}
+
+
+def test_manual_component_construction_for_adjacent_single_letters():
+    """Adjacent single-letter element symbols (e.g. K, F in 'KF') are ambiguous to the
+    formula parser (it greedily reads two letters as one symbol), so such components must be
+    constructed explicitly. This is the documented fallback."""
+    assert v.Component('KF').constituents == {'KF': 1.0}  # parser limitation
+    kf = v.Component('KF', {'K': 1.0, 'F': 1.0})          # explicit construction works
+    assert kf.constituents == {'K': 1.0, 'F': 1.0}
+
+
+@select_database("alcrni.tdb")
+def test_outputs_outside_basis(load_database):
+    """Under a redefined basis, pure-element and non-basis-component MU/X outputs are all
+    computable (element X; MU as a forward stoichiometric sum)."""
+    dbf = load_database()
+    phases = ['FCC_A1', 'BCC_A2', 'LIQUID']
+    wks = Workspace(dbf, ['AL2CR', 'CRNI2', 'NI3', 'VA'], phases,
+                    {v.T: 1200.0, v.P: 1e5, v.Moles('AL2CR'): 0.1, v.Moles('CRNI2'): 0.2, v.Moles('NI3'): 0.1})
+    for el in ['AL', 'CR', 'NI']:
+        assert np.isfinite(float(np.squeeze(wks.get(f'X({el})'))))
+        assert np.isfinite(float(np.squeeze(wks.get(f'MU({el})'))))
+    # MU of a component not in the basis = forward sum over its constituents
+    mu_cr = float(np.squeeze(wks.get('MU(CR)')))
+    mu_ni = float(np.squeeze(wks.get('MU(NI)')))
+    np.testing.assert_allclose(float(np.squeeze(wks.get('MU(CRNI)'))), mu_cr + mu_ni, atol=1e-4)
+    np.testing.assert_allclose(float(np.squeeze(wks.get('MU(NI2)'))), 2 * mu_ni, atol=1e-4)
+
+
+@select_database("Ocadiz-Flores.dat")
+def test_realistic_oxide_fluoride_equivalence(load_database):
+    """Realistic ionic database: a NiF2-KF-F2 component basis reproduces the equivalent
+    pure-element (Ni, K, F) equilibrium off the pseudo-binary line. Components are built
+    explicitly because 'KF' has adjacent single-letter elements."""
+    dbf = load_database()
+    NIF2 = v.Component('NIF2', {'NI': 1.0, 'F': 2.0})
+    KF = v.Component('KF', {'K': 1.0, 'F': 1.0})
+    F2 = v.Component('F2', {'F': 2.0})
+    phases = list(dbf.phases.keys())
+    base = {v.T: 1300.0, v.P: 1e5}
+    a, b, c = 0.2, 0.5, 0.1  # off the pseudo-binary (excess F via F2); n_F=2a+b+2c, n_K=b, n_NI=a
+    wks_comp = Workspace(dbf, [NIF2, KF, F2, 'VA'], phases,
+                         {**base, v.Moles(NIF2): a, v.Moles(KF): b, v.Moles(F2): c})
+    assert wks_comp.phase_record_factory.basis_is_trivial is False
+    assert wks_comp.phase_record_factory.nonvacant_elements == ['F', 'K', 'NI']
+    wks_elem = Workspace(dbf, ['NI', 'K', 'F', 'VA'], phases,
+                         {**base, v.Moles('NI'): a, v.Moles('K'): b, v.Moles('F'): 2 * a + b + 2 * c})
+    _assert_props_match(wks_comp, wks_elem,
+                        ['GM', 'MU(NI)', 'MU(K)', 'MU(F)', 'X(NI)', 'X(K)', 'X(F)', v.N], atol=1e-5)
+    # component amounts and a non-basis component output (MU(F2) = 2*MU(F))
+    np.testing.assert_allclose(np.squeeze(wks_comp.get(v.Moles(NIF2))), a, atol=1e-5)
+    np.testing.assert_allclose(np.squeeze(wks_comp.get(v.Moles(KF))), b, atol=1e-5)
+    np.testing.assert_allclose(np.squeeze(wks_comp.get(v.MU(F2))),
+                               2 * float(np.squeeze(wks_comp.get('MU(F)'))), atol=1e-4)

--- a/pycalphad/tests/test_equilibrium.py
+++ b/pycalphad/tests/test_equilibrium.py
@@ -26,7 +26,7 @@ def test_rose_nine(load_database):
     dbf = load_database()
     my_phases_rose = ['TEST']
     comps = ['H', 'HE', 'LI', 'BE', 'B', 'C', 'N', 'O', 'F']
-    conds = dict({v.T: 1000, v.P: 101325})
+    conds = dict({v.T: 1000, v.P: 101325, v.N: 1})
     for comp in comps[:-1]:
         conds[v.X(comp)] = 1.0/float(len(comps))
     eqx = equilibrium(dbf, comps, my_phases_rose, conds, verbose=True)
@@ -41,7 +41,7 @@ def test_eq_binary(load_database):
     my_phases = ['LIQUID', 'FCC_A1', 'HCP_A3', 'AL5FE2',
                  'AL2FE', 'AL13FE4', 'AL5FE4']
     comps = ['AL', 'FE', 'VA']
-    conds = {v.T: 1400, v.P: 101325, v.X('AL'): 0.55}
+    conds = {v.T: 1400, v.P: 101325, v.N: 1, v.X('AL'): 0.55}
     eqx = equilibrium(dbf, comps, my_phases, conds, verbose=True)
     assert_allclose(eqx.GM.values.flat[0], -9.608807e4)
 
@@ -71,7 +71,7 @@ def test_eq_single_phase(load_database):
                     points={'LIQUID': [[0.1, 0.9], [0.2, 0.8], [0.3, 0.7],
                                        [0.7, 0.3], [0.8, 0.2]]})
     eq = equilibrium(dbf, ['AL', 'FE'], 'LIQUID',
-                     {v.T: [1400, 2500], v.P: 101325,
+                     {v.T: [1400, 2500], v.P: 101325, v.N: 1,
                       v.X('AL'): [0.1, 0.2, 0.3, 0.7, 0.8]}, verbose=True)
     assert_allclose(np.squeeze(eq.GM), np.squeeze(res.GM), atol=0.1)
 
@@ -83,7 +83,7 @@ def test_eq_b2_without_all_comps(load_database):
     all components in a Database are selected for the calculation.
     """
     dbf = load_database()
-    equilibrium(dbf, ['AL', 'NI', 'VA'], 'BCC_B2', {v.X('NI'): 0.4, v.P: 101325, v.T: 1200},
+    equilibrium(dbf, ['AL', 'NI', 'VA'], 'BCC_B2', {v.X('NI'): 0.4, v.P: 101325, v.N: 1, v.T: 1200},
                 verbose=True)
 
 
@@ -95,7 +95,7 @@ def test_eq_underdetermined_comps(load_database):
     """
     dbf = load_database()
     with pytest.raises(ValueError):
-        equilibrium(dbf, ['AL', 'FE'], 'LIQUID', {v.T: 2000, v.P: 101325})
+        equilibrium(dbf, ['AL', 'FE'], 'LIQUID', {v.T: 2000, v.P: 101325, v.N: 1})
 
 
 @select_database("alfe.tdb")
@@ -106,7 +106,7 @@ def test_eq_overdetermined_comps(load_database):
     """
     dbf = load_database()
     with pytest.raises(ValueError):
-        equilibrium(dbf, ['AL', 'FE'], 'LIQUID', {v.T: 2000, v.P: 101325,
+        equilibrium(dbf, ['AL', 'FE'], 'LIQUID', {v.T: 2000, v.P: 101325, v.N: 1,
                                                   v.X('FE'): 0.2, v.X('AL'): 0.8})
 
 @pytest.mark.solver
@@ -119,11 +119,11 @@ def test_dilute_condition(load_database):
     # if exactly zero is specified as composition, we do not warn about dilute composition
     with warnings.catch_warnings():
         warnings.simplefilter("error", UserWarning)
-        eq = equilibrium(dbf, ['AL', 'FE', 'VA'], 'FCC_A1', {v.T: 1300, v.P: 101325, v.X('AL'): 0}, verbose=True)
+        eq = equilibrium(dbf, ['AL', 'FE', 'VA'], 'FCC_A1', {v.T: 1300, v.P: 101325, v.N: 1, v.X('AL'): 0}, verbose=True)
     assert_allclose(np.squeeze(eq.GM.values), -64415.84, atol=0.1)
     # if the user specifies a small (but nonzero) value below the supported limit, then we warn
     with pytest.warns(UserWarning, match='Some specified compositions are below the minimum allowed composition'):
-        eq = equilibrium(dbf, ['AL', 'FE', 'VA'], 'FCC_A1', {v.T: 1300, v.P: 101325, v.X('AL'): 1e-12}, verbose=True)
+        eq = equilibrium(dbf, ['AL', 'FE', 'VA'], 'FCC_A1', {v.T: 1300, v.P: 101325, v.N: 1, v.X('AL'): 1e-12}, verbose=True)
     assert_allclose(np.squeeze(eq.GM.values), -64415.841)
     assert_allclose(np.squeeze(eq.MU.values), [-385499.682936,  -64415.837878], atol=1.0)
 
@@ -138,7 +138,7 @@ def test_eq_illcond_hessian(load_database):
     dbf = load_database()
     # This set of conditions is known to trigger the issue
     eq = equilibrium(dbf, ['AL', 'FE', 'VA'], 'LIQUID',
-                     {v.X('FE'): 0.73999999999999999, v.T: 401.5625, v.P: 1e5})
+                     {v.X('FE'): 0.73999999999999999, v.T: 401.5625, v.P: 1e5, v.N: 1})
     assert_allclose(np.squeeze(eq.GM.values), -16507.22325998)
     # chemical potentials were checked in TC and accurate to 1 J/mol
     # pycalphad values used for more significant figures
@@ -156,7 +156,7 @@ def test_eq_illcond_magnetic_hessian(load_database):
     dbf = load_database()
     # This set of conditions is known to trigger the issue
     eq = equilibrium(dbf, ['AL', 'FE', 'VA'], ['FCC_A1', 'AL13FE4'],
-                     {v.X('AL'): 0.8, v.T: 300, v.P: 1e5}, verbose=True)
+                     {v.X('AL'): 0.8, v.T: 300, v.P: 1e5, v.N: 1}, verbose=True)
     assert_allclose(np.squeeze(eq.GM.values), -31414.46677)
     # These chemical potentials have a strong dependence on MIN_SITE_FRACTION
     # Smaller values tend to shift the potentials +- 1 J/mol
@@ -172,7 +172,7 @@ def test_eq_composition_cond_sorting(load_database):
     """
     dbf = load_database()
     eq = equilibrium(dbf, ['AL', 'FE'], 'LIQUID',
-                     {v.T: 2000, v.P: 101325, v.X('FE'): 0.2})
+                     {v.T: 2000, v.P: 101325, v.N: 1, v.X('FE'): 0.2})
     # Values computed by Thermo-Calc
     tc_energy = -143913.3
     tc_mu_fe = -184306.01
@@ -188,7 +188,7 @@ def test_eq_output_property(load_database):
     """
     dbf = load_database()
     equilibrium(dbf, ['AL', 'FE', 'VA'], ['LIQUID', 'B2_BCC'],
-                {v.X('AL'): 0.25, v.T: (300, 2000, 500), v.P: 101325},
+                {v.X('AL'): 0.25, v.T: (300, 2000, 500), v.P: 101325, v.N: 1},
                 output=['heat_capacity', 'degree_of_ordering'])
 
 
@@ -200,7 +200,7 @@ def test_eq_on_endmember(load_database):
     """
     dbf = load_database()
     equilibrium(dbf, ['AL', 'FE', 'VA'], ['LIQUID', 'B2_BCC'],
-                {v.X('AL'): [0.4, 0.5, 0.6], v.T: [300, 600], v.P: 101325}, verbose=True)
+                {v.X('AL'): [0.4, 0.5, 0.6], v.T: [300, 600], v.P: 101325, v.N: 1}, verbose=True)
 
 
 @pytest.mark.solver
@@ -211,7 +211,7 @@ def test_eq_four_sublattice(load_database):
     """
     dbf = load_database()
     eq = equilibrium(dbf, ['AL', 'NI', 'VA'], 'FCC_L12',
-                     {v.T: 1073, v.X('NI'): 0.7601, v.P: 101325})
+                     {v.T: 1073, v.X('NI'): 0.7601, v.P: 101325, v.N: 1})
     assert_allclose(np.squeeze(eq.X.sel(vertex=0).values), [1-.7601, .7601])
     # Not a strict equality here because we can't yet reach TC's value of -87260.6
     assert eq.GM.values < -87256.3
@@ -227,7 +227,7 @@ def test_eq_missing_component(load_database):
     with pytest.raises(EquilibriumError):
         equilibrium(dbf, ['AL', 'CO', 'CR', 'VA'], ['LIQUID'],
                     {v.T: 1523, v.X('AL'): 0.88811111111111107,
-                     v.X('CO'): 0.11188888888888888, v.P: 101325})
+                     v.X('CO'): 0.11188888888888888, v.P: 101325, v.N: 1})
 
 
 @select_database("alnifcc4sl.tdb")
@@ -240,7 +240,7 @@ def test_eq_missing_component(load_database):
     with pytest.raises(ConditionError):
         equilibrium(dbf, ['AL', 'NI', 'VA'], ['LIQUID'],
                     {v.T: 1523, v.X('AL'): 0.88811111111111107,
-                     v.X('CO'): 0.11188888888888888, v.P: 101325})
+                     v.X('CO'): 0.11188888888888888, v.P: 101325, v.N: 1})
 
 
 @pytest.mark.solver
@@ -252,7 +252,7 @@ def test_eq_ternary_edge_case_mass(load_database):
     dbf = load_database()
     eq = equilibrium(dbf, ['AL', 'CO', 'CR', 'VA'], ['L12_FCC', 'BCC_B2', 'LIQUID'],
                      {v.T: 1523, v.X('AL'): 0.8881111111,
-                      v.X('CO'): 0.1118888888, v.P: 101325}, verbose=True)
+                      v.X('CO'): 0.1118888888, v.P: 101325, v.N: 1}, verbose=True)
     mass_error = np.nansum(np.squeeze(eq.NP * eq.X), axis=-2) - \
                  [0.8881111111, 0.1118888888, 1e-10]
     assert_allclose(eq.GM.values, -97913.542)  # from Thermo-Calc 2017b
@@ -271,7 +271,7 @@ def test_eq_ternary_inside_mass(load_database):
     dbf = load_database()
     eq = equilibrium(dbf, ['AL', 'CO', 'CR', 'VA'], ['L12_FCC', 'BCC_B2', 'LIQUID'],
                      {v.T: 1523, v.X('AL'): 0.44455555555555554,
-                      v.X('CO'): 0.22277777777777777, v.P: 101325}, verbose=True)
+                      v.X('CO'): 0.22277777777777777, v.P: 101325, v.N: 1}, verbose=True)
     assert_allclose(eq.GM.values, -105871.54, atol=0.1)  # Thermo-Calc: -105871.54
     # Thermo-Calc: [-104653.83, -142595.49, -82905.784]
     assert_allclose(eq.MU.values.flatten(), [-104653.83, -142595.49, -82905.784], atol=0.1)
@@ -286,7 +286,7 @@ def test_eq_ternary_edge_misc_gap(load_database):
     dbf = load_database()
     eq = equilibrium(dbf, ['AL', 'CO', 'CR', 'VA'], ['L12_FCC', 'BCC_B2', 'LIQUID'],
                      {v.T: 1523, v.X('AL'): 0.33366666666666667,
-                      v.X('CO'): 0.44455555555555554, v.P: 101325}, verbose=True)
+                      v.X('CO'): 0.44455555555555554, v.P: 101325, v.N: 1}, verbose=True)
     mass_error = np.nansum(np.squeeze(eq.NP * eq.X), axis=-2) - \
                  [0.33366666666666667, 0.44455555555555554, 0.22177777777777785]
     assert np.all(np.abs(mass_error) < 0.001)
@@ -300,7 +300,7 @@ def test_eq_issue43_chempots_misc_gap(load_database):
     """
     dbf = load_database()
     eq = equilibrium(dbf, ['AL', 'NI', 'CR', 'VA'], 'GAMMA_PRIME',
-                     {v.X('AL'): .1246, v.X('CR'): 1e-9, v.T: 1273, v.P: 101325},
+                     {v.X('AL'): .1246, v.X('CR'): 1e-9, v.T: 1273, v.P: 101325, v.N: 1},
                      verbose=True)
     chempots = np.array([-206144.57, -272150.79, -64253.652])
     assert_allclose(np.nansum(np.squeeze(eq.NP * eq.X), axis=-2), [0.1246, 1e-9, 1-(.1246+1e-9)], rtol=3e-5)
@@ -316,7 +316,7 @@ def test_eq_issue43_chempots_tricky_potentials(load_database):
     """
     dbf = load_database()
     eq = equilibrium(dbf, ['AL', 'NI', 'CR', 'VA'], ['FCC_A1', 'GAMMA_PRIME'],
-                     {v.X('AL'): .1246, v.X('CR'): 0.6, v.T: 1273, v.P: 101325},
+                     {v.X('AL'): .1246, v.X('CR'): 0.6, v.T: 1273, v.P: 101325, v.N: 1},
                      verbose=True)
     chempots = np.array([-135620.9960449, -47269.29002414, -92304.23688281])
     assert_allclose(eq.GM.values, -70680.53695)
@@ -352,7 +352,7 @@ def test_eq_stoichiometric_phase_in_binary(load_database):
     """
     dbf = load_database()
     eq = equilibrium(dbf, ['AL', 'NI', 'VA'], list(dbf.phases.keys()),
-                     {v.P: 101325, v.T: 780, v.X('NI'): 0.625}, verbose=True)
+                     {v.P: 101325, v.N: 1, v.T: 780, v.X('NI'): 0.625}, verbose=True)
     # GM = -84676.46413558903
     # Chempots are meaningless, i.e. as of 0.11 we get something like [-59771.62174277 -99619.36957128]
     # Proper chemical potentials on the Al-rich side of the stoichiometric phase are:
@@ -374,7 +374,7 @@ def test_eq_issue62_last_component_not_va():
     CONSTITUENT FCC_A1  :AL,CO,CR,W : VA% :  !
     """
     equilibrium(Database(test_tdb), ['AL', 'CO', 'CR', 'W', 'VA'], ['FCC_A1'],
-                {"T": 1248, "P": 101325, v.X("AL"): 0.081, v.X("CR"): 0.020, v.X("W"): 0.094})
+                {"T": 1248, "P": 101325, v.N: 1, v.X("AL"): 0.081, v.X("CR"): 0.020, v.X("W"): 0.094})
 
 
 @select_database("alfe.tdb")
@@ -386,7 +386,7 @@ def test_eq_avoid_phase_cycling(load_database):
     # This set of conditions is known to trigger the issue
     my_phases_alfe = ['LIQUID', 'B2_BCC', 'FCC_A1', 'HCP_A3', 'AL5FE2', 'AL2FE', 'AL13FE4', 'AL5FE4']
     equilibrium(dbf, ['AL', 'FE', 'VA'], my_phases_alfe, {v.X('AL'): 0.44,
-                                                          v.T: 1600, v.P: 101325}, verbose=True)
+                                                          v.T: 1600, v.P: 101325, v.N: 1}, verbose=True)
 
 
 @pytest.mark.solver
@@ -399,7 +399,7 @@ def test_eq_issue76_dilute_potentials(load_database):
     my_phases = ['LIQUID', 'FCC_A1']
     Tvector = np.arange(900.0, 950.0, 1.0)
     eq = equilibrium(dbf, ['AL', 'FE', 'VA'], my_phases,
-                     {v.X('FE'): 1.5e-3, v.T: Tvector, v.P: 101325}, verbose=True)
+                     {v.X('FE'): 1.5e-3, v.T: Tvector, v.P: 101325, v.N: 1}, verbose=True)
     # Spot check at one temperature, plus monotonic decrease of chemical potential
     np.testing.assert_allclose(eq.GM.sel(T=930, P=101325).values, -37799.510894)
     assert np.all(np.diff(eq.MU.sel(component='FE').values <= 0))
@@ -412,7 +412,7 @@ def test_eq_model_phase_name(load_database):
     """
     dbf = load_database()
     eq = equilibrium(dbf, ['AL', 'FE', 'VA'], 'LIQUID',
-                     {v.X('FE'): 0.3, v.T: 1000, v.P: 101325}, model=Model)
+                     {v.X('FE'): 0.3, v.T: 1000, v.P: 101325, v.N: 1}, model=Model)
     assert eq.Phase.sel(vertex=0).isel(T=0, P=0, X_FE=0) == 'LIQUID'
 
 
@@ -421,16 +421,16 @@ def test_unused_equilibrium_kwarg_warns(load_database):
     "Check that an unused keyword argument raises a warning"
     dbf = load_database()
     with pytest.warns(UserWarning, match='The following equilibrium keyword arguments were passed, but unused'):
-        equilibrium(dbf, ['AL', 'FE', 'VA'], 'FCC_A1', {v.T: 1300, v.P: 101325, v.X('AL'): 0}, unused_kwarg='should raise a warning')
+        equilibrium(dbf, ['AL', 'FE', 'VA'], 'FCC_A1', {v.T: 1300, v.P: 101325, v.N: 1, v.X('AL'): 0}, unused_kwarg='should raise a warning')
 
 
 @select_database("alfe.tdb")
 def test_eq_unary_issue78(load_database):
     "Unary equilibrium calculations work with property calculations."
     dbf = load_database()
-    eq = equilibrium(dbf, ['AL', 'VA'], 'FCC_A1', {v.T: 1200, v.P: 101325}, output='SM')
+    eq = equilibrium(dbf, ['AL', 'VA'], 'FCC_A1', {v.T: 1200, v.P: 101325, v.N: 1}, output='SM')
     np.testing.assert_allclose(eq.SM, 68.143273)
-    eq = equilibrium(dbf, ['AL', 'VA'], 'FCC_A1', {v.T: 1200, v.P: 101325}, output='SM', parameters={'GHSERAL': 1000})
+    eq = equilibrium(dbf, ['AL', 'VA'], 'FCC_A1', {v.T: 1200, v.P: 101325, v.N: 1}, output='SM', parameters={'GHSERAL': 1000})
     np.testing.assert_allclose(eq.GM, 1000)
     np.testing.assert_allclose(eq.SM, 0, atol=1e-14)
 
@@ -439,9 +439,9 @@ def test_eq_unary_issue78(load_database):
 @select_database("cuo.tdb")
 def test_eq_gas_phase(load_database):
     dbf = load_database()
-    eq = equilibrium(dbf, ['O'], 'GAS', {v.T: 1000, v.P: 1e5}, verbose=True)
+    eq = equilibrium(dbf, ['O'], 'GAS', {v.T: 1000, v.P: 1e5, v.N: 1}, verbose=True)
     np.testing.assert_allclose(eq.GM, -110380.61071, atol=0.1)
-    eq = equilibrium(dbf, ['O'], 'GAS', {v.T: 1000, v.P: 1e9}, verbose=True)
+    eq = equilibrium(dbf, ['O'], 'GAS', {v.T: 1000, v.P: 1e9, v.N: 1}, verbose=True)
     np.testing.assert_allclose(eq.GM, -7.20909E+04, atol=0.1)
 
 
@@ -449,7 +449,7 @@ def test_eq_gas_phase(load_database):
 @select_database("cuo.tdb")
 def test_eq_ionic_liquid(load_database):
     dbf = load_database()
-    eq = equilibrium(dbf, ['CU', 'O', 'VA'], 'IONIC_LIQ', {v.T: 1000, v.P: 1e5, v.X('CU'): 0.6618}, verbose=True)
+    eq = equilibrium(dbf, ['CU', 'O', 'VA'], 'IONIC_LIQ', {v.T: 1000, v.P: 1e5, v.N: 1, v.X('CU'): 0.6618}, verbose=True)
     np.testing.assert_allclose(eq.GM, -9.25057E+04, atol=0.1)
 
 
@@ -461,7 +461,7 @@ def test_eq_parameter_override(load_database):
     comps = ["AL"]
     dbf = load_database()
     phases = ['FCC_A1']
-    conds = {v.P: 101325, v.T: 500}
+    conds = {v.P: 101325, v.N: 1, v.T: 500}
 
     # Check that current database should work as expected
     eq_res = equilibrium(dbf, comps, phases, conds)
@@ -502,7 +502,7 @@ def test_eq_some_phases_filtered(load_database):
     """
     dbf = load_database()
     # should not raise; AL13FE4 should be filtered out
-    equilibrium(dbf, ['AL', 'VA'], ['FCC_A1', 'AL13FE4'], {v.T: 1200, v.P: 101325})
+    equilibrium(dbf, ['AL', 'VA'], ['FCC_A1', 'AL13FE4'], {v.T: 1200, v.P: 101325, v.N: 1})
 
 
 @select_database("alfe.tdb")
@@ -512,7 +512,7 @@ def test_equilibrium_result_dataset_can_serialize_to_netcdf(load_database):
     """
     dbf = load_database()
     fname = 'eq_result_netcdf_test.nc'
-    eq = equilibrium(dbf, ['AL', 'VA'], 'FCC_A1', {v.T: 1200, v.P: 101325})
+    eq = equilibrium(dbf, ['AL', 'VA'], 'FCC_A1', {v.T: 1200, v.P: 101325, v.N: 1})
     eq.to_netcdf(fname)
     os.remove(fname)  # cleanup
 
@@ -523,7 +523,7 @@ def test_equilibrium_raises_with_no_active_phases_passed(load_database):
     # the only phases passed are the disordered phases, which are inactive
     dbf = load_database()
     with pytest.raises(ConditionError):
-        equilibrium(dbf, ['AL', 'NI', 'VA'], ['FCC_A1', 'BCC_A2'], {v.T: 300, v.P: 101325})
+        equilibrium(dbf, ['AL', 'NI', 'VA'], ['FCC_A1', 'BCC_A2'], {v.T: 300, v.P: 101325, v.N: 1})
 
 
 @select_database("alfe.tdb")
@@ -532,7 +532,7 @@ def test_equilibrium_raises_when_no_phases_can_be_active(load_database):
     # all phases contain AL and/or FE in a sublattice, so no phases can be active
     dbf = load_database()
     with pytest.raises(ConditionError):
-        equilibrium(dbf, ['VA'], list(dbf.phases.keys()), {v.T: 300, v.P: 101325})
+        equilibrium(dbf, ['VA'], list(dbf.phases.keys()), {v.T: 300, v.P: 101325, v.N: 1})
 
 
 # Defer test until inclusion of NP conditions, so test can be rewritten properly
@@ -545,7 +545,7 @@ def test_dataset_can_hold_maximum_phases_allowed_by_gibbs_phase_rule(load_databa
     comps = ['PB', 'SN', 'VA']
     phases = list(dbf.phases.keys())
     # "Exact" invariant temperature is very sensitive to solver convergence criteria
-    eq_res = equilibrium(dbf, comps, phases, {v.P: 101325, v.T: 454.56201, v.X('SN'): 0.738})
+    eq_res = equilibrium(dbf, comps, phases, {v.P: 101325, v.N: 1, v.T: 454.56201, v.X('SN'): 0.738})
     assert eq_res.vertex.size == 3  # C+1
     assert np.sum(~np.isnan(eq_res.NP.values)) == 3
     assert np.sum(eq_res.Phase.values != '') == 3
@@ -558,7 +558,7 @@ def test_equilibrium_raises_with_invalid_solver(load_database):
     """
     dbf = load_database()
     with pytest.raises(NotImplementedError):
-        equilibrium(dbf, ['O'], 'GAS', {v.T: 1000, v.P: 1e5}, solver=SolverBase())
+        equilibrium(dbf, ['O'], 'GAS', {v.T: 1000, v.P: 1e5, v.N: 1}, solver=SolverBase())
 
 
 @select_database("pbsn.tdb")
@@ -571,7 +571,7 @@ def test_equilibrium_no_opt_solver(load_database):
     dbf = load_database()
     comps = ['PB', 'SN', 'VA']
     phases = list(dbf.phases.keys())
-    conds = {v.T: 300, v.P: 101325, v.X('SN'): 0.50}
+    conds = {v.T: 300, v.P: 101325, v.N: 1, v.X('SN'): 0.50}
     ipopt_solver_eq_res = equilibrium(dbf, comps, phases, conds, solver=Solver(), verbose=True)
     # NoOptSolver's results are pdens-dependent
     no_opt_eq_res = equilibrium(dbf, comps, phases, conds,
@@ -615,7 +615,7 @@ def test_eq_tricky_chempot_cond(load_database):
     """
     dbf = load_database()
     eq = equilibrium(dbf, ['AL', 'NI', 'CR', 'VA'], ['FCC_A1', 'GAMMA_PRIME'],
-                     {v.MU('AL'): -135620.9960449, v.MU('CR'): -47269.29002414, v.T: 1273, v.P: 101325},
+                     {v.MU('AL'): -135620.9960449, v.MU('CR'): -47269.29002414, v.T: 1273, v.P: 101325, v.N: 1},
                      verbose=True)
     chempots = np.array([-135620.9960449, -47269.29002414, -92304.23688281])
     print(np.nansum(np.squeeze(eq.NP * eq.X), axis=-2))
@@ -634,7 +634,7 @@ def test_eq_magnetic_chempot_cond(load_database):
     dbf = load_database()
     # This set of conditions is known to trigger the issue
     eq = equilibrium(dbf, ['AL', 'FE', 'VA'], ['FCC_A1', 'AL13FE4'],
-                     {v.MU('FE'): -123110, v.T: 300, v.P: 1e5}, verbose=True)
+                     {v.MU('FE'): -123110, v.T: 300, v.P: 1e5, v.N: 1}, verbose=True)
     # Checked in Thermo-Calc 2017b
     assert_allclose(np.squeeze(eq.GM.values), -35427.064, atol=0.1)
     assert_allclose(np.squeeze(eq.MU.values), [-8490.6849, -123110], atol=0.1)
@@ -1048,7 +1048,7 @@ def test_issue_503_suspend_pure_vacancy_configuration():
     CONSTITUENT HALITE :V,V+2,V+3,VA : O-2,VA :  !
 """
     dbf = Database(tdb)
-    result = equilibrium(dbf, ['O', 'VA'], ['GAS', 'HALITE'], {v.T: 1000, v.P: 1e5})
+    result = equilibrium(dbf, ['O', 'VA'], ['GAS', 'HALITE'], {v.T: 1000, v.P: 1e5, v.N: 1})
     print(result)
     assert np.all(np.isclose(result.NP.squeeze(), [1.0, np.nan], equal_nan=True))
     assert np.all(result.Phase.squeeze() == ["GAS", ""])

--- a/pycalphad/tests/test_mapping_strategy.py
+++ b/pycalphad/tests/test_mapping_strategy.py
@@ -276,7 +276,7 @@ def test_isopleth_strategy_node_exit():
     comp_sets = []
     for p in phases:
         cs = CompositionSet(strategy.phase_records[p])
-        cs.update(np.array(phase_comps[p], dtype=np.float64), 0.25, np.array([1, 101325, 700], dtype=np.float64))
+        cs.update(np.array(phase_comps[p], dtype=np.float64), 0.25, np.array([101325, 700], dtype=np.float64))
         comp_sets.append(cs)
     comp_sets[0].fixed = True
     comp_sets[1].fixed = True
@@ -340,7 +340,7 @@ def test_global_min_check_writable_array(load_database):
     phases = list(dbf.phases.keys())
     conds = {v.T: 1000, v.P: 101325, v.X('FE'): 0.3, v.X('S'): 0.2, v.N: 1}
     models = instantiate_models(dbf, comps, phases)
-    phase_records = PhaseRecordFactory(dbf, comps, {v.N, v.P, v.T}, models)
+    phase_records = PhaseRecordFactory(dbf, comps, {v.P, v.T}, models)
 
     point = point_from_equilibrium(dbf, comps, phases, conds)
 

--- a/pycalphad/tests/test_mapping_zpf_checks.py
+++ b/pycalphad/tests/test_mapping_zpf_checks.py
@@ -227,7 +227,7 @@ def test_check_global_min(load_database):
         "phases": phases,
     }
     system_info["models"] = instantiate_models(system_info["dbf"], comps, phases)
-    system_info["phase_records"] = PhaseRecordFactory(system_info["dbf"], comps, {v.N, v.P, v.T}, system_info["models"])
+    system_info["phase_records"] = PhaseRecordFactory(system_info["dbf"], comps, {v.P, v.T}, system_info["models"])
     extra_args["system_info"] = system_info
 
     # check_change_in_phases for same set of phases -> no change

--- a/pycalphad/tests/test_model.py
+++ b/pycalphad/tests/test_model.py
@@ -79,7 +79,7 @@ def test_degree_of_ordering(load_database):
     dbf = load_database()
     my_phases = ['B2_BCC']
     comps = ['AL', 'FE', 'VA']
-    conds = {v.T: 300, v.P: 101325, v.X('AL'): 0.25}
+    conds = {v.T: 300, v.P: 101325, v.N: 1, v.X('AL'): 0.25}
     eqx = equilibrium(dbf, comps, my_phases, conds, output='degree_of_ordering', verbose=True)
     print('Degree of ordering: {}'.format(eqx.degree_of_ordering.values.flatten()))
     assert np.isclose(eqx.degree_of_ordering.values.flatten(), np.array([0.6666]), atol=1e-4)

--- a/pycalphad/tests/test_plot.py
+++ b/pycalphad/tests/test_plot.py
@@ -30,7 +30,7 @@ def test_eqplot_binary(load_database):
     my_phases = ['LIQUID', 'FCC_A1', 'HCP_A3', 'AL5FE2',
                  'AL2FE', 'AL13FE4', 'AL5FE4']
     comps = ['AL', 'FE', 'VA']
-    conds = {v.T: (1400, 1500, 50), v.P: 101325, v.X('AL'): (0, 1, 0.5)}
+    conds = {v.T: (1400, 1500, 50), v.P: 101325, v.N: 1, v.X('AL'): (0, 1, 0.5)}
     eq = equilibrium(dbf, comps, my_phases, conds)
     ax = eqplot(eq)
     assert isinstance(ax, Axes)
@@ -44,7 +44,7 @@ def test_eqplot_ternary(load_database):
     """
     dbf = load_database()
     eq = equilibrium(dbf, ['AL', 'CO', 'CR', 'VA'], ['LIQUID'],
-                     {v.T: 2500, v.X('AL'): (0,0.5,0.33), v.X('CO'): (0,0.5,0.3), v.P: 101325})
+                     {v.T: 2500, v.X('AL'): (0,0.5,0.33), v.X('CO'): (0,0.5,0.3), v.P: 101325, v.N: 1})
     ax = eqplot(eq)
     assert isinstance(ax, Axes)
     assert ax.name == 'triangular'

--- a/pycalphad/tests/test_property_framework.py
+++ b/pycalphad/tests/test_property_framework.py
@@ -169,11 +169,11 @@ def test_jansson_derivative_zero_and_undefined(load_database):
     wks = Workspace(dbf, comps, conditions=conds)
 
     cs_liq = CompositionSet(wks.phase_record_factory['LIQUID'])
-    cs_liq.update(np.array([8.97729829e-01, 1.02270171e-01]), 0.0, np.array([1, 1e5, temp]))
+    cs_liq.update(np.array([8.97729829e-01, 1.02270171e-01]), 0.0, np.array([1e5, temp]))
     cs_liq.fixed = True
 
     cs_stoich = CompositionSet(wks.phase_record_factory['PT8AL21'])
-    cs_stoich.update(np.array([1., 1.]), 1.0, np.array([1, 1e5, temp]))
+    cs_stoich.update(np.array([1., 1.]), 1.0, np.array([1e5, temp]))
     cs_stoich.fixed = False
 
     comp_sets = [cs_liq, cs_stoich]
@@ -183,7 +183,8 @@ def test_jansson_derivative_zero_and_undefined(load_database):
     #   Since PT8AL21 is stoichiometric, everything should be undefined here since
     #   it would be impossible move the global composition while still having the NP(PT8AL21) = 1
     x_deltas = compute_deltas(comp_sets, conds, chem_pots, v.X('AL'), v.T)
-    assert np.isnan(x_deltas.delta_statevars[2])
+    # delta_statevars is ordered [P, T] (T is index 1)
+    assert np.isnan(x_deltas.delta_statevars[1])
     dtdx = v.T.jansson_derivative(comp_sets, conds, chem_pots, x_deltas)
     assert np.isnan(dtdx)
 
@@ -192,7 +193,7 @@ def test_jansson_derivative_zero_and_undefined(load_database):
     #     The delta composition for PT8AL21 should be 0, but it can change for the liquid phase
     #     But because the liquid phase is fixed at 0, the overall change in v.X('AL') should also be 0
     T_deltas = compute_deltas(comp_sets, conds, chem_pots, v.T, v.X('AL'))
-    np.testing.assert_allclose(T_deltas.delta_statevars[2], 1., atol=1e-8)
+    np.testing.assert_allclose(T_deltas.delta_statevars[1], 1., atol=1e-8)
     # Since we trace along PT8AL21, then X('PT8AL21', 'AL').T = X('AL').T = 0
     dxdt_phase = v.X('PT8AL21', 'AL').jansson_derivative(comp_sets, conds, chem_pots, T_deltas)
     dxdt = v.X('AL').jansson_derivative(comp_sets, conds, chem_pots, T_deltas)

--- a/pycalphad/tests/test_property_framework.py
+++ b/pycalphad/tests/test_property_framework.py
@@ -93,7 +93,7 @@ def test_cpf_reference_state(load_database):
     # small deviations in the endpoint will push the reference state around, for large step sizes
     x_re = np.linspace(0, 1, num=10, endpoint=True)
     wks = Workspace(load_database(), ["NB", "RE", "VA"], ["LIQUID_RENB"],
-                    {v.P: 101325, v.T: 2800, v.X("RE"): x_re})
+                    {v.P: 101325, v.N: 1, v.T: 2800, v.X("RE"): x_re})
 
     ref = ReferenceState([("LIQUID_RENB", {v.X("RE"): 0}),
                         ("LIQUID_RENB", {v.X("RE"): 1})
@@ -217,7 +217,7 @@ def test_chemical_potentials_for_isolated_phases(load_database):
     """IsolatedPhase chemical potentials should correspond to the constrained, metastable composition set"""
     dbf = load_database()
     temperature = 100 # K
-    wks = Workspace(dbf, phases=["BCT_A5"], components=["PB", "SN", "VA"], conditions={v.T: temperature, v.P:101325, v.X("SN"): 0.6})
+    wks = Workspace(dbf, phases=["BCT_A5"], components=["PB", "SN", "VA"], conditions={v.T: temperature, v.P:101325, v.N: 1, v.X("SN"): 0.6})
 
     isolated_GM = wks.get(IsolatedPhase("BCT_A5",wks=wks)("GM"))
     # TODO: use X(*) and MU(*) when supported

--- a/pycalphad/tests/test_solver.py
+++ b/pycalphad/tests/test_solver.py
@@ -30,8 +30,8 @@ def test_non_unity_N_conditions(load_database):
     prf = PhaseRecordFactory(dbf, components, conditions, models)
 
     compset = CompositionSet(prf[phase_name])
-    # FCC_A1 in this database reduces to a single site fraction for pure AL
-    compset.update(np.array([1.0]), 1.0, np.array([conditions[v.N], conditions[v.P], conditions[v.T]]))
+    # FCC_A1 in this database reduces to a single site fraction for pure AL.
+    compset.update(np.array([1.0]), 1.0, np.array([conditions[v.P], conditions[v.T]]))
 
     solver = Solver()
     result = solver.solve([compset], str_conditions)

--- a/pycalphad/tests/test_solver.py
+++ b/pycalphad/tests/test_solver.py
@@ -30,7 +30,8 @@ def test_non_unity_N_conditions(load_database):
     prf = PhaseRecordFactory(dbf, components, conditions, models)
 
     compset = CompositionSet(prf[phase_name])
-    compset.update(np.array([1.0, 1.0]), 1.0, np.array([conditions[v.N], conditions[v.P], conditions[v.T]]))
+    # FCC_A1 in this database reduces to a single site fraction for pure AL
+    compset.update(np.array([1.0]), 1.0, np.array([conditions[v.N], conditions[v.P], conditions[v.T]]))
 
     solver = Solver()
     result = solver.solve([compset], str_conditions)

--- a/pycalphad/tests/test_solver.py
+++ b/pycalphad/tests/test_solver.py
@@ -1,0 +1,47 @@
+"""Unit tests for internal Solver class"""
+
+from pycalphad.core.solver import Solver
+from pycalphad import Model
+from pycalphad.core.composition_set import CompositionSet
+import pycalphad.variables as v
+from pycalphad.tests.fixtures import select_database, load_database
+from pycalphad.codegen.phase_record_factory import PhaseRecordFactory
+from pycalphad.core.utils import instantiate_models
+from pycalphad.property_framework import ModelComputedProperty
+
+from collections import OrderedDict
+
+import pytest
+import numpy as np
+
+# Mark every test in this module as a solver test
+pytestmark = [pytest.mark.solver,]
+
+@select_database("alzn_mey.tdb")
+def test_non_unity_N_conditions(load_database):
+    dbf = load_database()
+    components = ["AL", "VA"]
+    phase_name = "FCC_A1"
+    phases = [phase_name]
+    conditions = {v.N: 2.0, v.P: 1.0e5, v.T: 300.0}
+    str_conditions = OrderedDict(N=conditions[v.N], P=conditions[v.P], T=conditions[v.T])
+
+    models = instantiate_models(dbf, components, phases)
+    prf = PhaseRecordFactory(dbf, components, conditions, models)
+
+    compset = CompositionSet(prf[phase_name])
+    compset.update(np.array([1.0, 1.0]), 1.0, np.array([conditions[v.N], conditions[v.P], conditions[v.T]]))
+
+    solver = Solver()
+    result = solver.solve([compset], str_conditions)
+
+    expected_GM = -8496.605669599447  # computed by hand
+    GM = ModelComputedProperty('GM').compute_property([compset], str_conditions, result.chemical_potentials)
+    G = ModelComputedProperty('G').compute_property([compset], str_conditions, result.chemical_potentials)
+
+    print(GM, G)
+    print(f"NP: {compset.NP}")
+    np.testing.assert_allclose(result.chemical_potentials, expected_GM, atol=1e-5)
+    np.testing.assert_allclose(compset.NP, conditions[v.N])  # assumes 1 mole of f.u. per 1 mole atoms
+    np.testing.assert_allclose(GM, expected_GM, atol=1e-5)
+    np.testing.assert_allclose(G, GM * conditions[v.N])

--- a/pycalphad/tests/test_solver.py
+++ b/pycalphad/tests/test_solver.py
@@ -46,3 +46,42 @@ def test_non_unity_N_conditions(load_database):
     np.testing.assert_allclose(compset.NP, conditions[v.N])  # assumes 1 mole of f.u. per 1 mole atoms
     np.testing.assert_allclose(GM, expected_GM, atol=1e-5)
     np.testing.assert_allclose(G, GM * conditions[v.N])
+
+
+@select_database("alzn_mey.tdb")
+def test_per_component_moles_conditions(load_database):
+    """Per-component amount conditions N(i) give the same equilibrium as X + total N.
+
+    For a single FCC_A1 (AL, ZN) phase at fixed (P, T), the condition set
+    {N(AL)=0.3, N(ZN)=0.7} (two extensive amounts, no X and no total N) must
+    converge to the same intensive state as {X(AL)=0.3, N=1}.
+    """
+    dbf = load_database()
+    components = ["AL", "ZN", "VA"]
+    phase_name = "FCC_A1"
+    phases = [phase_name]
+    models = instantiate_models(dbf, components, phases)
+    prf = PhaseRecordFactory(dbf, components, {v.P, v.T}, models)
+
+    def solve(conditions):
+        compset = CompositionSet(prf[phase_name])
+        # Initial guess: site fractions [Y(AL), Y(ZN)]; state variables [P, T]
+        compset.update(np.array([0.3, 0.7]), 1.0,
+                       np.array([conditions[v.P], conditions[v.T]]))
+        result = Solver().solve([compset], conditions)
+        assert result.converged
+        return compset, result
+
+    ref_conds = {v.X("AL"): 0.3, v.N: 1.0, v.P: 1.0e5, v.T: 600.0}
+    amt_conds = {v.Moles("AL"): 0.3, v.Moles("ZN"): 0.7, v.P: 1.0e5, v.T: 600.0}
+
+    cs_ref, res_ref = solve(ref_conds)
+    cs_amt, res_amt = solve(amt_conds)
+
+    al_idx = cs_amt.phase_record.nonvacant_elements.index("AL")
+    # Same intensive state (chemical potentials and composition)
+    np.testing.assert_allclose(res_amt.chemical_potentials, res_ref.chemical_potentials, atol=1e-5)
+    np.testing.assert_allclose(np.asarray(cs_amt.X), np.asarray(cs_ref.X), atol=1e-6)
+    np.testing.assert_allclose(cs_amt.X[al_idx], 0.3, atol=1e-5)
+    # Total system amount N = sum_i NP_i * sum(X_i) = N(AL) + N(ZN) = 1.0
+    np.testing.assert_allclose(cs_amt.NP * np.sum(cs_amt.X), 1.0, atol=1e-6)

--- a/pycalphad/tests/test_variables.py
+++ b/pycalphad/tests/test_variables.py
@@ -120,6 +120,58 @@ def test_copy_with_cached_new():
     assert y_copy == y, "copy of SiteFraction should be equal to original"
 
 
+def test_moles_construction_and_dispatch():
+    """Moles() dispatches to the total SystemMolesType; Moles(species) and
+    Moles(phase, species) build component and phase-local amounts."""
+    # Total moles: Moles() returns the SystemMolesType singleton (== v.N)
+    assert v.Moles() is v.N
+    assert isinstance(v.N, v.SystemMolesType)
+    assert isinstance(v.N, v.Moles)
+    assert str(v.N) == 'N'
+    # Total moles deliberately exposes no species/phase_name attributes (duck-typing)
+    assert getattr(v.N, 'species', None) is None
+    assert getattr(v.N, 'phase_name', None) is None
+    assert not hasattr(v.N, 'species')
+
+    # Component moles
+    n_al = v.Moles('AL')
+    assert str(n_al) == 'N_AL'
+    assert n_al.species == v.Component('AL')
+    assert n_al.phase_name is None
+    assert isinstance(n_al, v.Moles)
+    assert not isinstance(n_al, v.SystemMolesType)
+
+    # Phase-local moles: valid to construct (not yet a solver condition)
+    n_fcc_al = v.Moles('FCC_A1', 'AL')
+    assert str(n_fcc_al) == 'N_FCC_A1_AL'
+    assert n_fcc_al.phase_name == 'FCC_A1'
+    assert n_fcc_al.species == v.Component('AL')
+    assert isinstance(n_fcc_al, v.Moles)
+
+    # Singleton/caching behavior
+    assert v.Moles('AL') is v.Moles('AL')
+
+
+def test_moles_copy_and_reduce():
+    """Moles instances survive copy.copy (cache-bypassing __new__) and pickling-style reduce."""
+    n_al = v.Moles('AL')
+    n_al_copy = copy.copy(n_al)
+    assert n_al_copy is not n_al
+    assert n_al_copy == n_al
+    assert copy.deepcopy(n_al) == n_al
+    assert copy.deepcopy(v.Moles('FCC_A1', 'AL')) == v.Moles('FCC_A1', 'AL')
+
+    # Total moles copy
+    n_copy = copy.copy(v.N)
+    assert n_copy is not v.N
+    assert n_copy == v.N
+
+    # Unit variant via __getitem__ -> __copy__ must not raise or mutate original
+    n_al_mol = v.Moles('AL')['mol']
+    assert n_al_mol.display_units == 'mol'
+    assert n_al_mol == n_al
+
+
 def test_getitem_units_does_not_mutate_original():
     """Test that using __getitem__ for unit conversion doesn't mutate the original.
 

--- a/pycalphad/tests/test_workspace.py
+++ b/pycalphad/tests/test_workspace.py
@@ -116,6 +116,51 @@ def test_jansson_derivative_binary_temperature(load_database):
     # Checked by finite difference
     assert_allclose(y_dot, -28.775364)
 
+@pytest.mark.solver
+@pytest.mark.parametrize("N", [1.0, 2.0, 5.0])
+@select_database("alzn_mey.tdb")
+def test_non_unity_N_conditions_workspace(load_database, N):
+    """Workspace point calculations with N != 1 return intensive molar properties and extensive amounts."""
+    dbf = load_database()
+    wks = Workspace(dbf, ["AL", "VA"], ["FCC_A1"], {v.N: N, v.P: 1.0e5, v.T: 300.0})
+    expected_GM = -8496.605669599447  # J/mol-atom, computed by hand
+    GM = np.squeeze(wks.get('GM'))
+    G = np.squeeze(wks.get('G'))
+    NP = np.squeeze(wks.get('NP(FCC_A1)'))
+    MU_AL = np.squeeze(wks.get('MU(AL)'))
+    assert_allclose(GM, expected_GM, atol=1e-5)  # intensive, independent of N
+    assert_allclose(MU_AL, expected_GM, atol=1e-5)
+    assert_allclose(NP, N)  # extensive; 1 mole of f.u. per mole of atoms in FCC_A1
+    assert_allclose(G, expected_GM * N, rtol=1e-10)  # extensive
+    # The stored equilibrium dataset GM is intensive and consistent with the property framework
+    assert_allclose(np.squeeze(wks.eq.GM), GM, rtol=1e-10)
+    # Jansson derivatives of intensive properties are intensive: dGM/dT == -SM
+    dGM_dT = np.squeeze(wks.get('GM.T'))
+    SM = np.squeeze(wks.get('SM'))
+    assert_allclose(dGM_dT, -SM, rtol=1e-6)
+
+
+@pytest.mark.solver
+@select_database("alzn_mey.tdb")
+def test_non_unity_N_conditions_workspace_two_phase(load_database):
+    """Two-phase equilibrium at N=2: intensive properties match N=1; extensive amounts scale with N."""
+    dbf = load_database()
+    components = ['AL', 'ZN', 'VA']
+    phases = ['FCC_A1', 'HCP_A3', 'LIQUID']
+    conds = {v.P: 101325, v.T: 500, v.X('ZN'): 0.7}
+    wks_1 = Workspace(dbf, components, phases, {v.N: 1.0, **conds})
+    wks_2 = Workspace(dbf, components, phases, {v.N: 2.0, **conds})
+    # Intensive properties are independent of N
+    for prop in ['GM', 'X(ZN)', 'MU(ZN)', 'GM.T']:
+        assert_allclose(np.squeeze(wks_2.get(prop)), np.squeeze(wks_1.get(prop)), rtol=1e-6,
+                        err_msg=f'{prop} should be independent of N')
+    # Extensive properties scale linearly with N
+    assert_allclose(np.squeeze(wks_2.get('G')), 2.0 * np.squeeze(wks_1.get('G')), rtol=1e-6)
+    # Stored phase amounts sum to N
+    assert_allclose(np.nansum(wks_1.eq.NP), 1.0, atol=1e-8)
+    assert_allclose(np.nansum(wks_2.eq.NP), 2.0, atol=1e-8)
+
+
 @select_database("alnipt.tdb")
 def test_jansson_derivative_with_invalid_mass_conditions(load_database):
     """

--- a/pycalphad/tests/test_workspace.py
+++ b/pycalphad/tests/test_workspace.py
@@ -603,3 +603,67 @@ def test_intensive_only_conditions_raises(load_database):
     wks = Workspace(dbf, ['AL', 'ZN', 'VA'], ['FCC_A1'], {v.X('AL'): 0.3, v.P: 1e5, v.T: 600.0})
     with pytest.raises(ConditionError):
         wks.get('GM')
+
+
+@select_database("alzn_mey.tdb")
+def test_vacancy_mole_amount_condition_raises(load_database):
+    """N(VA) is meaningless (vacancies have no mole amount) and must be rejected clearly."""
+    dbf = load_database()
+    with pytest.raises(ConditionError):
+        Workspace(dbf, ['AL', 'ZN', 'VA'], ['FCC_A1'],
+                  {v.P: 1e5, v.T: 600.0, v.Moles('VA'): 0.5, v.X('AL'): 0.3})
+
+
+@select_database("alzn_mey.tdb")
+def test_phase_local_moles_condition_raises(load_database):
+    """Phase-local moles (e.g. v.Moles('FCC_A1','AL')) are not supported as conditions."""
+    dbf = load_database()
+    with pytest.raises(ConditionError):
+        Workspace(dbf, ['AL', 'ZN', 'VA'], ['FCC_A1'],
+                  {v.P: 1e5, v.T: 600.0, v.N: 1.0, v.X('ZN'): 0.3,
+                   v.Moles('FCC_A1', 'AL'): 0.1})
+
+
+@select_database("alzn_mey.tdb")
+def test_empty_starting_point_does_not_crash(load_database):
+    """An infeasible/degenerate starting point must not raise IndexError (returns a value)."""
+    dbf = load_database()
+    wks = Workspace(dbf, ['AL', 'ZN', 'VA'], ['FCC_A1'],
+                    {v.P: 1e5, v.T: 600.0, v.X('AL'): 0.5, v.Moles('AL'): 0.3})
+    # Must not raise IndexError. (Before Phase 4 this is NaN; after Phase 4 it is a finite value.)
+    gm = np.squeeze(wks.get('GM'))
+    assert gm is not None  # the call completed without crashing
+
+
+@select_database("alzn_mey.tdb")
+def test_fraction_and_amount_same_component(load_database):
+    """X(i) and N(i) on the same component (no total N) is feasible: total N = N(i)/X(i)."""
+    # if this is failing, check that we didn't break the starting point
+    dbf = load_database()
+    wks = Workspace(dbf, ['AL', 'ZN', 'VA'], ['FCC_A1'],
+                    {v.P: 1e5, v.T: 600.0, v.X('AL'): 0.5, v.Moles('AL'): 0.3})
+    assert_allclose(np.squeeze(wks.get('X(AL)')), 0.5, atol=1e-5)
+    assert_allclose(np.squeeze(wks.get(v.N)), 0.6, atol=1e-6)   # 0.3 / 0.5
+
+
+@select_database("alzn_mey.tdb")
+def test_chempot_plus_component_amount_feasible(load_database):
+    """MU + N(i) is well-posed and converges when the potential is feasible for the component."""
+    dbf = load_database()
+    C = ['AL', 'ZN', 'VA']
+    # Feasible interior potential: the equilibrium MU(ZN) at X(AL)=0.3
+    wref = Workspace(dbf, C, ['FCC_A1'], {v.P: 1e5, v.T: 600.0, v.X('AL'): 0.3, v.N: 1.0})
+    mu_zn = float(np.squeeze(wref.get('MU(ZN)')))
+    wks = Workspace(dbf, C, ['FCC_A1'], {v.P: 1e5, v.T: 600.0, v.MU('ZN'): mu_zn, v.Moles('AL'): 0.3})
+    assert_allclose(np.squeeze(wks.get('X(AL)')), 0.3, atol=1e-4)
+    assert_allclose(np.squeeze(wks.get(v.N)), 1.0, atol=1e-4)
+
+
+@select_database("alzn_mey.tdb")
+def test_chempot_plus_component_amount_infeasible_is_nan(load_database):
+    """An infeasible potential (drives X(component)->0) yields NaN, not a crash."""
+    dbf = load_database()
+    # MU(ZN)=-15000 drives FCC to ~pure ZN, so N(AL)=0.3 needs NP->inf: infeasible.
+    wks = Workspace(dbf, ['AL', 'ZN', 'VA'], ['FCC_A1'],
+                    {v.P: 1e5, v.T: 600.0, v.MU('ZN'): -15000.0, v.Moles('AL'): 0.3})
+    assert np.all(np.isnan(np.atleast_1d(np.squeeze(wks.get('GM')))))

--- a/pycalphad/tests/test_workspace.py
+++ b/pycalphad/tests/test_workspace.py
@@ -567,3 +567,39 @@ def test_get_dict_phase_specific_unit_conversion_uses_phase_molar_mass(load_data
     expected = Q_(raw_value, 'J/mol').to('J/g', phase_context).magnitude.item()
 
     assert_allclose(get_dict_value, expected)
+
+
+@select_database("alzn_mey.tdb")
+def test_per_component_moles_conditions_workspace(load_database):
+    """Component-amount conditions N(i) via the Workspace API match X + total N,
+    and the total system size N scales with the sum of component amounts."""
+    dbf = load_database()
+    comps = ['AL', 'ZN', 'VA']
+    phases = ['FCC_A1']
+
+    wks_ref = Workspace(dbf, comps, phases, {v.X('AL'): 0.3, v.N: 1.0, v.P: 1e5, v.T: 600.0})
+    wks_amt = Workspace(dbf, comps, phases, {v.Moles('AL'): 0.3, v.Moles('ZN'): 0.7, v.P: 1e5, v.T: 600.0})
+
+    # Intensive quantities (composition, molar Gibbs energy) match the X + N specification
+    assert_allclose(np.squeeze(wks_amt.get('X(AL)')), np.squeeze(wks_ref.get('X(AL)')), atol=1e-6)
+    assert_allclose(np.squeeze(wks_amt.get('X(AL)')), 0.3, atol=1e-5)
+    assert_allclose(np.squeeze(wks_amt.get('GM')), np.squeeze(wks_ref.get('GM')), atol=1e-4)
+    # Total system amount and per-component amounts are recovered from the solution state
+    assert_allclose(np.squeeze(wks_amt.get(v.N)), 1.0, atol=1e-6)
+    assert_allclose(np.squeeze(wks_amt.get(v.Moles('AL'))), 0.3, atol=1e-6)
+    assert_allclose(np.squeeze(wks_amt.get(v.Moles('ZN'))), 0.7, atol=1e-6)
+
+    # Non-unity scale: doubling the component amounts doubles N but keeps X and GM intensive
+    wks_2x = Workspace(dbf, comps, phases, {v.Moles('AL'): 0.6, v.Moles('ZN'): 1.4, v.P: 1e5, v.T: 600.0})
+    assert_allclose(np.squeeze(wks_2x.get(v.N)), 2.0, atol=1e-6)
+    assert_allclose(np.squeeze(wks_2x.get('X(AL)')), 0.3, atol=1e-5)
+    assert_allclose(np.squeeze(wks_2x.get('GM')), np.squeeze(wks_ref.get('GM')), atol=1e-4)
+
+
+@select_database("alzn_mey.tdb")
+def test_intensive_only_conditions_raises(load_database):
+    """Specifying only intensive conditions (no extensive system-size condition) raises."""
+    dbf = load_database()
+    wks = Workspace(dbf, ['AL', 'ZN', 'VA'], ['FCC_A1'], {v.X('AL'): 0.3, v.P: 1e5, v.T: 600.0})
+    with pytest.raises(ConditionError):
+        wks.get('GM')

--- a/pycalphad/tests/test_workspace.py
+++ b/pycalphad/tests/test_workspace.py
@@ -241,7 +241,7 @@ def test_mass_fraction_binary_dilute(load_database):
 def test_lincomb_binary_condition(load_database):
     dbf = load_database()
     wks = Workspace(database=dbf, components=['AL', 'ZN', 'VA'], phases=['FCC_A1', 'HCP_A3', 'LIQUID'],
-                    conditions={v.T: 300, v.P: 1e5, 0.5*v.X('ZN') - 7*v.X('AL'): 0.1})
+                    conditions={v.T: 300, v.P: 1e5, v.N: 1, 0.5*v.X('ZN') - 7*v.X('AL'): 0.1})
     result = 0.5 * wks.get('X(ZN)') - 7 * wks.get('X(AL)')
     np.testing.assert_almost_equal(result, 0.1, decimal=8)
     result2 = wks.get(0.5*v.X('ZN') - 7*v.X('AL'))
@@ -251,7 +251,7 @@ def test_lincomb_binary_condition(load_database):
 def test_lincomb_binary_condition_rhs_negative(load_database):
     dbf = load_database()
     wks = Workspace(database=dbf, components=['AL', 'ZN', 'VA'], phases=['FCC_A1', 'HCP_A3', 'LIQUID'],
-                    conditions={v.T: 300, v.P: 1e5, v.X('ZN') - v.X('AL'): -0.5})
+                    conditions={v.T: 300, v.P: 1e5, v.N: 1, v.X('ZN') - v.X('AL'): -0.5})
     result = wks.get('X(ZN)') - wks.get('X(AL)')
     np.testing.assert_almost_equal(result, -0.5, decimal=8)
     result2 = wks.get(v.X('ZN') - v.X('AL'))
@@ -266,7 +266,7 @@ def test_lincomb_binary_condition_rhs_negative(load_database):
 def test_lincomb_ratio_binary_condition(load_database):
     dbf = load_database()
     wks = Workspace(database=dbf, components=['AL', 'ZN', 'VA'], phases=['FCC_A1', 'HCP_A3', 'LIQUID'],
-                    conditions={v.T: 300, v.P: 1e5, v.X('AL')/v.X('ZN'): [0.25, 1, 1.5]})
+                    conditions={v.T: 300, v.P: 1e5, v.N: 1, v.X('AL')/v.X('ZN'): [0.25, 1, 1.5]})
     result = wks.get('X(AL)') / wks.get('X(ZN)')
     np.testing.assert_almost_equal(result, [0.25, 1, 1.5], decimal=8)
 
@@ -387,7 +387,7 @@ def test_issue_503_suspend_phase_infeasible_internal_constraints():
     CONSTITUENT GAS:G :O,ZR :  !
     """
     # SPINEL phase cannot charge balance, so even though it contains ZR, O, and VA, it must be suspended
-    wks = Workspace(TDB, ['O', 'ZR', 'VA'], ['SPINEL', 'GAS'], {v.P: 1e5, v.X('O'): 0.5, v.T: 1000})
+    wks = Workspace(TDB, ['O', 'ZR', 'VA'], ['SPINEL', 'GAS'], {v.P: 1e5, v.N: 1, v.X('O'): 0.5, v.T: 1000})
     wks.verbose = True
     print(wks.get_dict('X(*,*)'))
     print(wks.get_dict('NP(*)'))
@@ -509,7 +509,7 @@ def test_shallow_ternary_with_isolated_phase(load_database):
     dbf = load_database()
     comps = ['CR', 'FE', 'NI', 'VA']
     phases = ['BCC_A2']
-    conditions = {v.T: 1170, v.P:101325, v.X('CR'): 0.638, v.X('NI'): 0.062}
+    conditions = {v.T: 1170, v.P:101325, v.N: 1, v.X('CR'): 0.638, v.X('NI'): 0.062}
     wks = Workspace(dbf, phases=phases, components=comps, conditions=conditions, verbose=True)
 
     # Values confirmed by turning point density up to 1e7

--- a/pycalphad/variables.py
+++ b/pycalphad/variables.py
@@ -939,12 +939,106 @@ class PressureType(IndependentPotential):
     def __reduce__(self):
         return self.__class__, ()
 
-class SystemMolesType(StateVariable):
+class Moles(StateVariable):
+    """
+    Number of moles of atoms in the system.
+
+    Construct via:
+      ``Moles()``                -> total system moles (returns a ``SystemMolesType``)
+      ``Moles('AL')``            -> moles of a component (symbol ``N_AL``)
+      ``Moles('FCC_A1', 'AL')``  -> phase-local moles of a component; valid to construct
+                                    (like ``X('FCC_A1', 'AL')``) but not yet a solver condition
+    """
     implementation_units = 'mol'
     display_units = 'mol'
+
+    def __new__(cls, *args):
+        # Dispatch the no-argument (total) form to the dedicated SystemMolesType so that
+        # ``Moles() is v.N`` and existing ``isinstance(c, SystemMolesType)`` checks keep
+        # identifying total moles. Concrete (component/phase-local) forms construct normally.
+        if cls is Moles and len(args) == 0:
+            return SystemMolesType()
+        return StateVariable.__new__(cls, *args)
+    # StateVariable.__copy__ bypasses the __new__ lru_cache via ``cls.__new__.__wrapped__``;
+    # our override would otherwise hide it, so re-expose the unwrapped constructor.
+    __new__.__wrapped__ = StateVariable.__new__.__wrapped__
+
+    def __init__(self, *args):
+        phase_name = None
+        species = None
+        if len(args) == 1:
+            species = Component(args[0])
+            varname = 'N_' + species.escaped_name.upper()
+        elif len(args) == 2:
+            phase_name = args[0].upper()
+            species = Component(args[1])
+            varname = 'N_' + phase_name + '_' + species.escaped_name.upper()
+        else:
+            raise ValueError(f'Moles is not defined for arguments: {args!r}')
+        super().__init__(varname)
+        self.phase_name = phase_name
+        self.species = species
+
+    @property
+    def display_name(self):
+        if self.phase_name is None:
+            return f'Moles {self.species}'
+        return f'Moles {self.phase_name} {self.species}'
+
+    def expand_wildcard(self, phase_names=None, components=None):
+        if phase_names is not None and self.phase_name is not None:
+            return [self.__class__(phase_name, self.species) for phase_name in phase_names]
+        elif components is not None:
+            if self.phase_name is None:
+                return [self.__class__(comp) for comp in components]
+            return [self.__class__(self.phase_name, comp) for comp in components]
+        raise ValueError('Both phase_names and components are None')
+
+    def compute_property(self, compsets, cur_conds, chemical_potentials):
+        # N(species) = sum_alpha NP_alpha * X_alpha[species]
+        result = np.atleast_1d(np.zeros(self.shape))
+        result[:] = np.nan
+        for _, compset in self.filtered(compsets):
+            if np.isnan(result[0]):
+                result[0] = 0
+            el_idx = compset.phase_record.nonvacant_elements.index(str(self.species))
+            result[0] += compset.NP * compset.X[el_idx]
+        return result
+
+    def __reduce__(self):
+        if self.phase_name is None:
+            return self.__class__, (self.species,)
+        return self.__class__, (self.phase_name, self.species)
+
+
+class SystemMolesType(Moles):
+    """Total number of moles of atoms in the system (the ``N`` condition).
+
+    Note: deliberately does NOT set ``species``/``phase_name`` instance attributes,
+    so ``hasattr(v.N, 'species')`` stays False (preserving the historical duck-typing
+    used across the codebase to discriminate composition vs. non-composition conditions).
+    New code distinguishing total vs. component moles should use
+    ``getattr(cond, 'species', None)``.
+    """
     display_name = 'No. Moles'
+
     def __init__(self):
-        super().__init__('N')
+        # Bypass Moles.__init__ (which expects a species); total moles is unparametrized.
+        StateVariable.__init__(self, 'N')
+
+    def compute_property(self, compsets, cur_conds, chemical_potentials):
+        # total N = sum_alpha NP_alpha * sum_A X_alpha[A]
+        # Returns a scalar (like other state variables T, P), not an array, so callers
+        # that treat N as a state-variable value (e.g. mapping) get a consistent shape.
+        if len(compsets) == 0:
+            return np.nan
+        result = 0.0
+        for compset in compsets:
+            if (compset.NP == 0) and (not compset.fixed):
+                continue
+            result += compset.NP * np.sum(compset.X)
+        return result
+
     def __reduce__(self):
         return self.__class__, ()
 

--- a/pycalphad/variables.py
+++ b/pycalphad/variables.py
@@ -576,6 +576,16 @@ class MoleFraction(StateVariable):
                 result[0] += compset.NP * compset.X[el_idx]
             else:
                 result[0] += compset.X[el_idx]
+        if (self.phase_name is None) and not np.isnan(result[0]):
+            # sum(NP * X) is the number of moles of this component, N(species).
+            # The overall mole fraction is X(species) = N(species) / N, where N is
+            # counted from the elemental amounts in the composition sets; a global
+            # N condition is not required to exist.
+            system_amount = np.sum([compset.NP * np.sum(compset.X) for compset in compsets])
+            if system_amount != 0:
+                result[0] /= system_amount
+            else:
+                raise ValueError(f"The system has zero moles. Got composition sets: {compsets}")
         return result
 
     def compute_per_phase_property(self, compset, cur_conds):
@@ -627,6 +637,16 @@ class MoleFraction(StateVariable):
             else:
                 jansson_derivative += np.dot(deltas.delta_statevars, grad_value[:len(state_variables)])
                 jansson_derivative += np.dot(delta_sitefracs, grad_value[len(state_variables):])
+        if (self.phase_name is None) and not np.isnan(jansson_derivative):
+            # The accumulated value is the derivative of N(species) = sum(NP * X).
+            # N is held fixed by the equilibrium system (dN == 0 along the perturbation),
+            # so the derivative of X(species) = N(species)/N is exactly dN(species) / N.
+            # No quotient rule is needed.
+            system_amount = np.sum([compset.NP * np.sum(compset.X) for compset in compsets])
+            if system_amount != 0:
+                jansson_derivative /= system_amount
+            else:
+                raise ValueError(f"The system has zero moles. Got composition sets: {compsets}")
         return jansson_derivative
 
     def jansson_deltas(self, spec, state) -> JanssonDerivativeDeltas:

--- a/pycalphad/variables.py
+++ b/pycalphad/variables.py
@@ -1011,10 +1011,10 @@ class Moles(StateVariable):
     Number of moles of atoms in the system.
 
     Construct via:
-      ``Moles()``                -> total system moles (returns a ``SystemMolesType``)
-      ``Moles('AL')``            -> moles of a component (symbol ``N_AL``)
-      ``Moles('FCC_A1', 'AL')``  -> phase-local moles of a component; valid to construct
-                                    (like ``X('FCC_A1', 'AL')``) but not yet a solver condition
+
+    * ``Moles()``                -> total system moles (returns a ``SystemMolesType``)
+    * ``Moles('AL')``            -> moles of a component (symbol ``N_AL``)
+    * ``Moles('FCC_A1', 'AL')``  -> phase-local moles of a component; valid to construct (like ``X('FCC_A1', 'AL')``) but not yet a solver condition
     """
     implementation_units = 'mol'
     display_units = 'mol'

--- a/pycalphad/variables.py
+++ b/pycalphad/variables.py
@@ -10,8 +10,39 @@ from pycalphad.io.grammar import parse_chemical_formula
 from pycalphad.property_framework.types import JanssonDerivativeDeltas
 from pycalphad.core.minimizer import site_fraction_differential, state_variable_differential, \
     fixed_component_differential, chemical_potential_differential
+from pycalphad.core.errors import ConditionError
 import numpy as np
 from copy import copy
+
+
+def _element_amounts(compsets):
+    "Total moles of each non-vacant element, N(e) = sum_alpha NP_alpha * X_alpha[e]."
+    nonvacant_elements = compsets[0].phase_record.nonvacant_elements
+    n_elem = np.zeros(len(nonvacant_elements))
+    for compset in compsets:
+        for el_idx in range(len(nonvacant_elements)):
+            n_elem[el_idx] += compset.NP * compset.X[el_idx]
+    return n_elem
+
+
+def _redefined_component_row(species, phase_record):
+    """Row index of ``species`` in the change-of-basis matrix if it is a *redefined*
+    component (non-trivial basis), else None. A name that is a declared basis component
+    takes precedence over a same-named pure element (e.g. ZN in an [ALZN, ZN] basis means
+    the ZN component, not the ZN element). For a trivial (pure-element) basis there are no
+    redefined components, so this returns None and the element paths run.
+    """
+    if phase_record.basis_is_trivial:
+        return None
+    return phase_record.basis_component_index.get(str(species))
+
+
+def _raise_not_in_basis(species, phase_record):
+    "N/X/W of a multi-element component outside the basis is ill-defined."
+    raise ConditionError(
+        f"Component {str(species)!r} is not part of the calculation's component basis "
+        f"{[str(c) for c in phase_record.basis_components]}; only basis components and pure "
+        f"elements can be requested as N/X/W outputs.")
 
 
 class Component(object):
@@ -568,6 +599,24 @@ class MoleFraction(StateVariable):
     def compute_property(self, compsets, cur_conds, chemical_potentials):
         result = np.atleast_1d(np.zeros(self.shape))
         result[:] = np.nan
+        if len(compsets) == 0:
+            return result
+        prf = compsets[0].phase_record
+        row = _redefined_component_row(self.species, prf)
+        if row is not None:
+            # Redefined-component mole fraction: X(c) = n_comp[c] / sum_c' n_comp[c'],
+            # with n_comp = (S^T)^-1 . N(elements).
+            if self.phase_name is not None:
+                raise ConditionError(f"{self}: phase-local component mole fractions are not supported")
+            n_elem = _element_amounts(compsets)
+            inv_T = np.asarray(prf.component_basis_inv_T)
+            total_comp = float(np.dot(inv_T.sum(axis=0), n_elem))
+            if total_comp == 0:
+                raise ValueError(f"The system has zero moles. Got composition sets: {compsets}")
+            result[0] = float(np.dot(inv_T[row], n_elem)) / total_comp
+            return result
+        if str(self.species) not in prf.nonvacant_elements:
+            _raise_not_in_basis(self.species, prf)
         for _, compset in self.filtered(compsets):
             el_idx = compset.phase_record.nonvacant_elements.index(str(self.species))
             if np.isnan(result[0]):
@@ -722,6 +771,24 @@ class MassFraction(StateVariable):
     def compute_property(self, compsets, cur_conds, chemical_potentials):
         result = np.atleast_1d(np.zeros(self.shape))
         result[:] = np.nan
+        if len(compsets) == 0:
+            return result
+        prf = compsets[0].phase_record
+        row = _redefined_component_row(self.species, prf)
+        if row is not None:
+            # Redefined-component mass fraction: W(c) = MW(c)*N(c) / total_mass, where
+            # MW(c) = sum_e S[c,e]*mass_e and total_mass = sum_e mass_e*N(e).
+            if self.phase_name is not None:
+                raise ConditionError(f"{self}: phase-local component mass fractions are not supported")
+            n_elem = _element_amounts(compsets)
+            total_mass = float(np.dot(np.asarray(prf.molar_masses), n_elem))
+            if total_mass == 0:
+                raise ValueError(f"The system has zero mass. Got composition sets: {compsets}")
+            n_comp = float(np.dot(np.asarray(prf.component_basis_inv_T)[row], n_elem))
+            result[0] = np.asarray(prf.component_molar_masses)[row] * n_comp / total_mass
+            return result
+        if str(self.species) not in prf.nonvacant_elements:
+            _raise_not_in_basis(self.species, prf)
         normalizer = 0.
         for _, compset in self.filtered(compsets):
             el_idx = compset.phase_record.nonvacant_elements.index(str(self.species))
@@ -998,6 +1065,16 @@ class Moles(StateVariable):
         # N(species) = sum_alpha NP_alpha * X_alpha[species]
         result = np.atleast_1d(np.zeros(self.shape))
         result[:] = np.nan
+        if len(compsets) == 0:
+            return result
+        prf = compsets[0].phase_record
+        row = _redefined_component_row(self.species, prf)
+        if row is not None:
+            # Redefined-component amount: N(component) = (S^T)^-1[c, :] . N(elements).
+            result[0] = float(np.dot(np.asarray(prf.component_basis_inv_T)[row], _element_amounts(compsets)))
+            return result
+        if str(self.species) not in prf.nonvacant_elements:
+            _raise_not_in_basis(self.species, prf)
         for _, compset in self.filtered(compsets):
             if np.isnan(result[0]):
                 result[0] = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,3 +135,10 @@ ignore_errors = true # workaround for https://github.com/cython/cython/issues/55
 # '[tool.setuptools.scm]' needs to be the last line because
 # we do an append operation in the deploy.yaml GitHub Actions workflow
 [tool.setuptools_scm]
+
+[tool.uv]
+cache-keys = [
+    { file = "pyproject.toml" },
+    { file = "pycalphad/**/*.pyx" },
+    { file = "pycalphad/**/*.pxd" }
+    ]


### PR DESCRIPTION
**This is a draft PR.** 

This PR:
- Removes the requirement to have a total `N` condition and only support for `N=1`. This is a breaking change because we remove the default `N=1` condition. Any legacy code that did not explicitly include `v.N: 1` conditions will break. 
  - Consequently, `v.N` is removed as a "state variable" in the sense of being built into phase records and composition sets. `N` is never an input to a `Model` callable and only current potentials `P`, `T` and any new user-defined state variables that are part of `Model` objects make sense to be in there. We always derive `N` from the moles of elements computed by callables.
- Adds support for `N(i)` conditions
- Adds support to take in a set of `v.Component` objects (or strings that parse into components) to define a new component basis. Similar to the `DEFINE_COMPONENTS` feature found in other software.

The new component basis is intended to be completely general for the conditions and the property framework.

This would close #692 and #695.


--- 

I realized after some discussions, re-reading how we do linear combination conditions and drafting up `N(i)` conditions (which we implement a sum of all elements) that user-defined components are just a change of basis in that requires a linear combination of pure element conditions in the same way that we do explicit linear combination conditions, but general to `v.W`, `v.B`, `v.X(Component)` (and the `W(Component)`, `B(Component)`, `N(Component)` variants), the explicit linear combination conditions of those, as well as `MU(Component)`. 

We're actually not far from supporting that and I threw an LLM at the last part, which introduced the ability to provide a set of `v.Component` objects to `Workspace` and the functions it calls that construct the new components basis and store it in the `PhaseRecordFactory`. I am not completely happy with the implementation yet, but I think the implementation is correct at first glance and the external API changes (i.e. the only change being that we now support providing non-pure element `v.Component` objects to `components` arguments) should be stable such that we can test this branch as I evaluate the code.

Before merging, I'd like to
- Rewrite/simplify the implementation of how we track and use the basis
- As a stretch goal, I'd like to unify better how we handle explicit linear combination conditions and generalize those beyond the current `v.X` conditions. Maybe they get implemented as a condition-local change of basis?

Adding support for more conditions greatly increases the different ways parts of the code can be composed and cause breakages. I think this will need a good deal of manual testing to try to uncover unforeseen edge and corner cases. I'm particularly concerned about how support for more types of conditions affects starting point selection.

Extending Component support to `mapping` is not in scope for this PR, but I expect that we can work on it on top of this branch since the external-facing API changes relevant to mapping should be stable with respect to the implementation details that may change. 

I expect this to be a key feature for pseudobinary and pseudoternary support. Although as these changes are simply a linear combination of conditions, it will not resolve issues with convergence in the solver when the solutions are in subspaces of the component space. The thermodynamically correct thing to do is to set the chemical potentials of one of the components, but observations in issues elsewhere indicate that may be flaky.