### PR TITLE
Ignore extra tokens on the ChemSage header line

### DIFF
--- a/pycalphad/io/cs_dat.py
+++ b/pycalphad/io/cs_dat.py
@@ -801,7 +801,7 @@ def parse_header(toks: TokenParser) -> Header:
     num_soln_phases = toks.parse(int)
     list_soln_species_count = toks.parseN(num_soln_phases, int)
     num_stoich_phases = toks.parse(int)
-    toks._discard_remaining_tokens()
+    toks._discard_remaining_tokens()  # drop remainder of this line
     pure_elements = toks.parseN(num_pure_elements, str)
     pure_elements_mass = toks.parseN(num_pure_elements, float)
     num_gibbs_coeffs = toks.parse(int)

--- a/pycalphad/io/cs_dat.py
+++ b/pycalphad/io/cs_dat.py
@@ -84,6 +84,9 @@ class TokenParser():
             raise ValueError(f'N must be >=1, got {N}')
         return [self.parse(cls) for _ in range(N)]
 
+    def _discard_remaining_tokens(self):
+        self._tokens_deque.clear()
+
 
 @dataclass
 class Header:
@@ -798,6 +801,7 @@ def parse_header(toks: TokenParser) -> Header:
     num_soln_phases = toks.parse(int)
     list_soln_species_count = toks.parseN(num_soln_phases, int)
     num_stoich_phases = toks.parse(int)
+    toks._discard_remaining_tokens()
     pure_elements = toks.parseN(num_pure_elements, str)
     pure_elements_mass = toks.parseN(num_pure_elements, float)
     num_gibbs_coeffs = toks.parse(int)

--- a/pycalphad/tests/test_cs_dat.py
+++ b/pycalphad/tests/test_cs_dat.py
@@ -1,0 +1,36 @@
+import pytest
+
+from pycalphad.io.cs_dat import TokenParser, TokenParserError, parse_header
+
+
+@pytest.mark.parametrize(
+    ("extras", "blank_lines"),
+    [("", ""), ("  7  8", ""), ("\t7   8  9   ", "\n  \t")],
+)
+def test_parse_header_discards_only_second_line_extra_tokens(extras, blank_lines):
+    toks = TokenParser(
+        "title\n"
+        f"2 1 1 0{extras}\n"
+        f"{blank_lines}AL NI\n"
+        "26.9815 58.6934\n"
+        "2 1 2\n"
+        "2 3 4\n"
+    )
+
+    assert toks.parse(str) == "title"
+    header = parse_header(toks)
+
+    assert header.list_soln_species_count == [1]
+    assert header.num_stoich_phases == 0
+    assert header.pure_elements == ["AL", "NI"]
+    assert header.pure_elements_mass == [26.9815, 58.6934]
+    assert header.gibbs_coefficient_idxs == [1, 2]
+    assert header.excess_coefficient_idxs == [3, 4]
+
+
+def test_parse_header_extras_do_not_hide_later_malformed_line():
+    toks = TokenParser("title\n1 1 1 0 7 8\nAL\nnot-a-mass\n")
+
+    assert toks.parse(str) == "title"
+    with pytest.raises(TokenParserError, match="not-a-mass"):
+        parse_header(toks)


### PR DESCRIPTION
## Summary

- discard only the surplus tokens already buffered from the second ChemSage header line
- keep element names, masses, and later coefficient fields aligned to their physical lines
- add regression coverage for extra tokens, tabs/blank lines, the no-extra control, and a malformed following mass

Fixes #542.

## Validation

- dependency-free focused harness: 4 regression cases passed
- both changed Python files parse successfully
- `git diff --check`
- preserved evidence for this exact base and patch: focused 4 passed; existing DAT integrations 32 passed; adjacent database I/O 54 passed; full suite 314 passed, 2 skipped, 1 xfailed

The current system environment does not have `symengine`, so pytest cannot collect the package here; no dependencies were installed. The full-suite figures above are from the preserved, hash-matched work package rather than a new run in this checkout.

## Checklist

- [x] Plain-language description included
- [x] Regression tests added
- [x] No dependency changes
- [x] GitHub Actions CI and maintainer review

## AI assistance disclosure

This patch, tests, and pull request text were developed and checked with OpenAI Codex assistance. No independent human self-review is claimed; maintainer review is requested before merge.