### PR TITLE
ENH: Rank deficiency diagnostics for Solver(debugging_output=True)

### DIFF
--- a/pycalphad/core/constants.py
+++ b/pycalphad/core/constants.py
@@ -13,6 +13,16 @@ COMP_DIFFERENCE_TOL = 1e-4
 # Constraint scaling factors, for numerical stability
 INTERNAL_CONSTRAINT_SCALING = 1.0
 
+# Singular values at or below this fraction of the largest are treated as zero
+# when diagnosing rank deficiency under Solver(debugging_output=True).
+# Deliberately looser than the rcond=1e-16 that lstsq passes to dgelsd, which
+# only catches exact deficiency.
+RANK_DEFICIENCY_RTOL = 1e-12
+# Full-rank matrices with s_min/s_max below this get a softer "ill-conditioned" note
+ILL_CONDITIONED_RATIO = 1e-8
+# Null space components smaller than this (after normalization) are omitted from diagnostics
+NULLSPACE_SIGNIFICANCE = 0.1
+
 # Prevent excessive sampling for very complex phase models
 # This avoids running out of RAM
 MAX_ENDMEMBER_PAIRS = 5000 # ~100 endmembers

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -3,6 +3,7 @@ import numpy as np
 cimport numpy as np
 from pycalphad.core.composition_set cimport CompositionSet
 from pycalphad.core.constants import MIN_SITE_FRACTION
+from pycalphad.core.rank_diagnostics import analyze_rank
 cimport scipy.linalg.cython_lapack as cython_lapack
 from libc.stdlib cimport malloc, free
 from libc.math cimport isnan
@@ -839,6 +840,51 @@ cpdef site_fraction_differential(CompsetState csst, double[::1] delta_chempots, 
             delta_y[i] += csst.c_component[chempot_idx, i] * delta_chempots[chempot_idx]
     return np.asarray(delta_y)
 
+cdef equilibrium_system_labels(SystemSpecification spec, SystemState state):
+    """Return (row_labels, col_labels) for the global equilibrium matrix.
+
+    This lives in minimizer.pyx (rather than alongside the analysis in
+    rank_diagnostics.py) because SystemSpecification's index arrays are cdef with no
+    .pxd visibility; it reads them here and hands plain Python strings to the analyzer.
+    The row and column order must follow fill_equilibrium_system and
+    construct_equilibrium_system exactly. Only used under debugging_output.
+    """
+    cdef CompositionSet compset
+    cdef int i, idx
+    # Every name is sourced from the first composition set; all of them share a
+    # component list and state variable list
+    phase_record = state.compsets[0].phase_record
+    nonvacant_elements = list(phase_record.nonvacant_elements)
+    state_variables = list(phase_record.state_variables)
+
+    row_labels = []
+    # The composition set index disambiguates miscibility-gap duplicates of a phase
+    for i in range(state.free_stable_compset_indices.shape[0]):
+        idx = state.free_stable_compset_indices[i]
+        compset = state.compsets[idx]
+        row_labels.append(f"stable_phase[{compset.phase_record.phase_name}:cs{idx}]")
+    for i in range(spec.fixed_stable_compset_indices.shape[0]):
+        idx = spec.fixed_stable_compset_indices[i]
+        compset = state.compsets[idx]
+        row_labels.append(f"fixed_phase[{compset.phase_record.phase_name}:cs{idx}]")
+    for i in range(spec.prescribed_mole_fraction_rhs.shape[0]):
+        row_labels.append(f"X_condition[{i}]")
+    row_labels.append("N_condition")
+
+    col_labels = []
+    for i in range(spec.free_chemical_potential_indices.shape[0]):
+        idx = spec.free_chemical_potential_indices[i]
+        col_labels.append(f"MU({nonvacant_elements[idx]})")
+    for i in range(state.free_stable_compset_indices.shape[0]):
+        idx = state.free_stable_compset_indices[i]
+        compset = state.compsets[idx]
+        col_labels.append(f"NP({compset.phase_record.phase_name}:cs{idx})")
+    for i in range(spec.free_statevar_indices.shape[0]):
+        idx = spec.free_statevar_indices[i]
+        col_labels.append(f"d({state_variables[idx]})")
+    return row_labels, col_labels
+
+
 cpdef solve_state(SystemSpecification spec, SystemState state):
     cdef double[::1,:] equilibrium_matrix  # Fortran ordering required by call into lapack
     cdef double[::1] equilibrium_soln
@@ -862,6 +908,12 @@ cpdef solve_state(SystemSpecification spec, SystemState state):
     if spec.debugging_output:
         print(f"equilibrium matrix:\n{np.asarray(equilibrium_matrix)}")
         print(f"equilibrium rhs: {np.asarray(equilibrium_soln)}")
+        # The matrix is still intact here; lstsq destroys it below
+        if len(state.compsets) > 0:
+            row_labels, col_labels = equilibrium_system_labels(spec, state)
+            report = analyze_rank(np.asarray(equilibrium_matrix), row_labels, col_labels)
+            if report is not None:
+                print(report.format("equilibrium matrix"))
 
     lstsq(&equilibrium_matrix[0,0], equilibrium_matrix.shape[0], equilibrium_matrix.shape[1],
           &equilibrium_soln[0], 1e-16)

--- a/pycalphad/core/minimizer.pyx
+++ b/pycalphad/core/minimizer.pyx
@@ -885,11 +885,46 @@ cdef equilibrium_system_labels(SystemSpecification spec, SystemState state):
     return row_labels, col_labels
 
 
+cdef site_fraction_label(var):
+    """Render one entry of PhaseRecord.variables as a short site fraction label.
+
+    The phase name is already carried by the report title, so it is dropped here:
+    ``Y(RUTILE,0,TI+2)`` becomes ``y[0:TI+2]``. Falls back to the variable's own
+    string form for anything that is not a SiteFraction.
+    """
+    try:
+        return f"y[{var.sublattice_index}:{var.species.name}]"
+    except AttributeError:
+        return f"y[{var}]"
+
+
+cdef phase_constraint_labels(CompositionSet compset):
+    """Return (constraint_row_labels, site_fraction_col_labels) for one compset.
+
+    Rows follow the order in which compute_phase_matrix borders the phase matrix:
+    the internal constraints first, then the phase-local conditions. Columns are the
+    phase_dof site fractions, which are the columns of both constraint Jacobians
+    after the num_statevars offset. Only used under debugging_output.
+    """
+    cdef int k
+    phase_record = compset.phase_record
+    row_labels = []
+    for k in range(phase_record.num_internal_cons):
+        row_labels.append(f"internal_cons[{k}]")
+    for k in range(compset.num_phase_local_conditions):
+        row_labels.append(f"phase_local_cons[{k}]")
+    col_labels = []
+    for var in phase_record.variables:
+        col_labels.append(site_fraction_label(var))
+    return row_labels, col_labels
+
+
 cpdef solve_state(SystemSpecification spec, SystemState state):
     cdef double[::1,:] equilibrium_matrix  # Fortran ordering required by call into lapack
     cdef double[::1] equilibrium_soln
     cdef int chempot_idx, comp_idx, i, cs_idx
     cdef CompsetState csst
+    cdef CompositionSet compset
 
     state.previous_chemical_potentials[:] = state.chemical_potentials[:]
     state.recompute(spec)
@@ -898,9 +933,29 @@ cpdef solve_state(SystemSpecification spec, SystemState state):
         for i in range(state.free_stable_compset_indices.shape[0]):
             cs_idx = state.free_stable_compset_indices[i]
             csst = state.cs_states[cs_idx]
+            compset = state.compsets[cs_idx]
             print(state.compsets[cs_idx])
             print(f"phase matrix:\n{np.asarray(csst.phase_matrix)}")
             print(f"inv phase matrix:\n{np.asarray(csst.full_e_matrix)}")
+            # If the constraint Jacobians that border the phase matrix are not full
+            # row rank, the bordered matrix is structurally singular no matter what the
+            # Hessian block looks like -- and invert_matrix will not notice, because
+            # dgetrf only reports an exactly zero pivot. This is the PR #710 failure
+            # mode, and the numeric twin of the symbolic matrix_rank assertion in
+            # test_model.py. The Jacobians were filled by compute_phase_matrix during
+            # recompute; only their site fraction columns border the phase matrix.
+            cons_jac = np.asarray(csst.cons_jac_tmp)[:, spec.num_statevars:]
+            if compset.num_phase_local_conditions > 0:
+                cons_jac = np.vstack([cons_jac,
+                                      np.asarray(csst.phase_local_jac_tmp)[:, spec.num_statevars:]])
+            if cons_jac.shape[0] > 0:
+                row_labels, col_labels = phase_constraint_labels(compset)
+                # Only the row null space is interesting here: for a wide
+                # (n_cons x phase_dof) block, the question is which constraints are
+                # redundant, not which site fractions are unconstrained (many always are)
+                report = analyze_rank(cons_jac, row_labels, col_labels, want_col_nullspace=False)
+                if report is not None:
+                    print(report.format(f"phase matrix constraints: {compset.phase_record.phase_name}"))
 
 
     equilibrium_matrix, equilibrium_soln = construct_equilibrium_system(spec, state, 0)

--- a/pycalphad/core/rank_diagnostics.py
+++ b/pycalphad/core/rank_diagnostics.py
@@ -1,0 +1,170 @@
+"""
+Rank and conditioning diagnostics for the energy minimizer.
+
+Everything in this module is called only from inside the ``if spec.debugging_output:``
+blocks of :func:`pycalphad.core.minimizer.solve_state`, so it has no effect on the
+normal solve path. It is kept in pure Python (rather than in ``minimizer.pyx``) so
+the report wording and thresholds can be tuned without a Cython rebuild, and so the
+analysis can be inspected on its own.
+
+The entry point is :func:`analyze_rank`, which runs one SVD on a matrix and returns
+either ``None`` (the matrix is healthy and nothing should be printed), an
+:class:`IllConditioned` note, or a :class:`RankDeficiency` report naming the redundant
+equations (left null space) and the undetermined unknowns (right null space).
+"""
+
+import numpy as np
+
+from pycalphad.core.constants import (ILL_CONDITIONED_RATIO, NULLSPACE_SIGNIFICANCE,
+                                      RANK_DEFICIENCY_RTOL)
+
+__all__ = ["RankDeficiency", "IllConditioned", "analyze_rank"]
+
+
+def _significant_terms(v, labels, threshold=NULLSPACE_SIGNIFICANCE):
+    """
+    Render a null space vector as a short, readable sum of labeled terms.
+
+    The vector is normalized, given a deterministic sign (the largest-magnitude
+    component is made positive), stripped of components at or below ``threshold``,
+    and sorted by descending magnitude, e.g.::
+
+        +0.707*stable_phase[TIO_ALPHA] -0.707*stable_phase[TI3O2]
+
+    Structural degeneracies produce sparse, near-canonical null vectors, so this is
+    typically two or three terms.
+    """
+    v = np.asarray(v, dtype=np.float64).ravel()
+    norm = np.linalg.norm(v)
+    if norm > 0:
+        v = v / norm
+    magnitudes = np.abs(v)
+    # Compare magnitudes at the precision we print them, so that components which are
+    # equal in exact arithmetic (the +/-1/sqrt(2) pair a structural degeneracy
+    # produces) do not order or sign themselves off a last-bit difference
+    ranking = np.round(magnitudes, 3)
+    largest = int(np.argmax(ranking))
+    # Deterministic sign convention: the largest component is positive. Otherwise the
+    # printed signs would flip with the LAPACK driver, since -w is as valid as w.
+    if v[largest] < 0:
+        v = -v
+    significant = np.flatnonzero(magnitudes > threshold)
+    if significant.shape[0] == 0:
+        # Every component is diffuse; report the largest one rather than nothing
+        significant = np.array([largest])
+    # Stable sort, so ties fall back to the natural (matrix index) order
+    order = significant[np.argsort(-ranking[significant], kind="stable")]
+    return " ".join(f"{v[i]:+.3f}*{labels[i]}" for i in order)
+
+
+class RankDeficiency:
+    """A matrix with at least one singular value at or below ``RANK_DEFICIENCY_RTOL * s_max``."""
+
+    def __init__(self, rank, shape, s_max, s_min, ratio, dependent_rows, undetermined):
+        self.rank = rank
+        self.shape = shape
+        self.s_max = s_max
+        self.s_min = s_min
+        self.ratio = ratio
+        #: Left null space, rendered: which equations are redundant
+        self.dependent_rows = dependent_rows
+        #: Right null space, rendered: which unknowns are undetermined
+        self.undetermined = undetermined
+
+    def format(self, title):
+        lines = [f"!! RANK DEFICIENT {title}  rank {self.rank}/{min(self.shape)}  "
+                 f"(s_min/s_max = {self.ratio:.1e})"]
+        for terms in self.dependent_rows:
+            lines.append(f"   dependent rows:        {terms}")
+        for terms in self.undetermined:
+            lines.append(f"   undetermined unknowns: {terms}")
+        return "\n".join(lines)
+
+    def __repr__(self):
+        return (f"RankDeficiency(rank={self.rank}, shape={self.shape}, "
+                f"ratio={self.ratio:.3e})")
+
+
+class IllConditioned:
+    """A full-rank matrix whose smallest singular value is below ``ILL_CONDITIONED_RATIO * s_max``."""
+
+    def __init__(self, ratio, s_max, s_min):
+        self.ratio = ratio
+        self.s_max = s_max
+        self.s_min = s_min
+
+    def format(self, title):
+        return (f"!  ill-conditioned {title}  (s_min/s_max = {self.ratio:.1e}, "
+                f"s_max = {self.s_max:.3e}, s_min = {self.s_min:.3e})")
+
+    def __repr__(self):
+        return f"IllConditioned(ratio={self.ratio:.3e})"
+
+
+def analyze_rank(A, row_labels, col_labels, rtol=RANK_DEFICIENCY_RTOL,
+                 cond_tol=ILL_CONDITIONED_RATIO,
+                 want_row_nullspace=True, want_col_nullspace=True):
+    """
+    Diagnose the rank and conditioning of ``A``.
+
+    Parameters
+    ----------
+    A : array-like
+        The matrix to analyze. It is not modified.
+    row_labels : Sequence[str]
+        One label per row of ``A``, e.g. ``stable_phase[FCC_A1:cs0]``.
+    col_labels : Sequence[str]
+        One label per column of ``A``, e.g. ``MU(AL)``.
+    rtol : float
+        Singular values at or below ``rtol * s_max`` are treated as zero.
+    cond_tol : float
+        Full-rank matrices with ``s_min/s_max`` below this get an ill-conditioned note.
+    want_row_nullspace : bool
+        Report the left null space (which equations are redundant).
+    want_col_nullspace : bool
+        Report the right null space (which unknowns are undetermined). Set this to
+        False for a symmetric matrix, where the two null spaces coincide, or where
+        the interesting answer is only about the rows.
+
+    Returns
+    -------
+    RankDeficiency, IllConditioned, or None
+        ``None`` means the matrix is healthy and nothing should be printed.
+    """
+    A = np.asarray(A, dtype=np.float64)
+    if A.ndim != 2 or A.size == 0:
+        return None
+    if not np.all(np.isfinite(A)):
+        # NaN or +/-1e19 sentinels from a failed lstsq/invert_matrix. SVD would raise
+        # on these, and the raw values are already visible in the surrounding dump.
+        return None
+    try:
+        U, s, Vt = np.linalg.svd(A)
+    except np.linalg.LinAlgError:
+        # A diagnostic must never break the run it is diagnosing
+        return None
+    s_max = float(s[0])
+    s_min = float(s[-1])
+    if s_max > 0:
+        ratio = s_min / s_max
+        rank = int(np.count_nonzero(s > rtol * s_max))
+    else:
+        ratio = 0.0
+        rank = 0
+    if rank == min(A.shape):
+        if ratio < cond_tol:
+            return IllConditioned(ratio=ratio, s_max=s_max, s_min=s_min)
+        # Healthy: emit nothing, so the diagnostic is signal rather than more firehose
+        return None
+    dependent_rows = []
+    if want_row_nullspace:
+        # Left null space: w.T @ A == 0, i.e. sum_i w_i * row_i == 0
+        for k in range(rank, A.shape[0]):
+            dependent_rows.append(_significant_terms(U[:, k], row_labels))
+    undetermined = []
+    if want_col_nullspace:
+        # Right null space: A @ v == 0, the direction the solution is arbitrary along
+        for k in range(rank, A.shape[1]):
+            undetermined.append(_significant_terms(Vt[k, :], col_labels))
+    return RankDeficiency(rank=rank, shape=A.shape, s_max=s_max, s_min=s_min, ratio=ratio,
+                          dependent_rows=dependent_rows, undetermined=undetermined)

--- a/pycalphad/tests/test_workspace.py
+++ b/pycalphad/tests/test_workspace.py
@@ -539,3 +539,21 @@ def test_solver_with_debugging_output_is_successful(load_database):
         solver=Solver(debugging_output=True)
         )
     result = wks.get("GM")
+
+
+@pytest.mark.solver
+@select_database("TiO-17Yan.tdb")
+def test_solver_with_debugging_output_charged_phases(load_database):
+    """Solver(debugging_output=True) runs successfully for phases with charge balance"""
+    # Charged phases carry internal constraints beyond the sublattice site fraction
+    # sums, so this drives the constraint Jacobian rank check of the debugging output,
+    # which the neutral alzn_mey.tdb smoke test above does not reach.
+    dbf = load_database()
+    wks = Workspace(
+        database=dbf,
+        components=["TI", "O", "VA"],
+        phases=["TI3O2", "TIO_ALPHA"],
+        conditions={v.N: 1, v.P: 1e5, v.T: 620.0, v.X("O"): 0.41},
+        solver=Solver(debugging_output=True)
+        )
+    result = wks.get("GM")

--- a/pycalphad/tests/test_workspace.py
+++ b/pycalphad/tests/test_workspace.py
@@ -525,6 +525,7 @@ def test_get_dict_phase_specific_unit_conversion_uses_phase_molar_mass(load_data
     assert_allclose(get_dict_value, expected)
 
 
+@pytest.mark.solver
 @select_database("alzn_mey.tdb")
 def test_solver_with_debugging_output_is_successful(load_database):
     """Solver(debugging_output=True) runs successfully"""


### PR DESCRIPTION
[Artifacts](https://cloud.humanlayer.com/tasks/019fd330-291f-70ec-995f-002ad8799256/artifacts) | [Task](https://cloud.humanlayer.com/deep/tasks/019fd330-291f-70ec-995f-002ad8799256)

Checklist
* [x] Include a plain language description of your changes.
* [x] Any dependency changes are reflected in the `pyproject.toml` — no dependency changes (NumPy only).

## What problems was I solving

When a matrix in the Newton loop goes singular, the solver gives no signal. Two failure modes are equally invisible today:

- The **per-phase matrix** is rank deficient — e.g. a redundant charge-balance constraint. `dgetrf`/`dgetri` only report an *exactly* zero pivot, so LAPACK returns `info == 0`, the inverse is numerical garbage, and that garbage propagates silently into every row of the global system. This is the failure mode #710 fixed for one specific case; other user-authored internal constraints can still do it.
- The **global equilibrium matrix** is rank deficient — `dgelsd` returns a minimum-norm solution, which is a well-defined but *different* answer than the intended Newton step. Its effective-rank output is computed and then thrown away.

The only tool available is `Solver(debugging_output=True)`, which dumps every raw matrix every iteration. Finding the singular one means visually scanning hundreds of printed arrays and mentally computing their rank.

After this PR, a degenerate matrix announces itself in the debug stream with a labeled block naming *which* equations are redundant and *which* unknowns are undetermined, in CALPHAD vocabulary:

```text
!! RANK DEFICIENT equilibrium matrix  rank 4/5  (s_min/s_max = 8.4e-18)
   dependent rows:        +0.707*stable_phase[TIO_ALPHA:cs1] -0.707*stable_phase[TI3O2:cs0]
   undetermined unknowns: +0.707*NP(TIO_ALPHA:cs1) +0.707*NP(TI3O2:cs0)
```

```text
!! RANK DEFICIENT phase matrix constraints: FCC_A1  rank 1/2  (s_min/s_max = 4.5e-17)
   dependent rows:        +0.894*internal_cons[0] -0.447*internal_cons[1]
```

Success criteria: the diagnostic is **silent on healthy matrices** (it adds 0.00% to the debug stream for the `alzn_mey.tdb` and `TiO-17Yan.tdb` smoke-test conditions, rising to at most 4.65% on a hard all-phases `TiO-17Yan.tdb` run at `X(O) = 0.5`, where the global system genuinely *is* degenerate), and the normal solve path is unchanged.

## What user-facing changes did I ship

- [`pycalphad/core/rank_diagnostics.py`](https://github.com/pycalphad/pycalphad/pull/713/files#diff-1c33cb97541fa0c0e8d9fe064d20ed54f66787106bf217936891b36f68c41619) — new pure-Python module: one SVD per matrix, returning `RankDeficiency`, `IllConditioned`, or `None` (healthy → print nothing).
- [`pycalphad/core/minimizer.pyx`](https://github.com/pycalphad/pycalphad/pull/713/files#diff-a6c6b39719ed149e93ff2289892e639c8cb43e178de4cf1956cd6a7b7fd95457) — two new checks wired into the two *existing* `if spec.debugging_output:` blocks in `solve_state`, plus the labeling helpers that turn matrix indices into `MU(AL)` / `NP(FCC_A1:cs0)` / `internal_cons[2]` / `y[0:TI+2]`.
- [`pycalphad/core/constants.py`](https://github.com/pycalphad/pycalphad/pull/713/files#diff-21dec5cd5784758948daeae38c16d61ba70491ee769a46f2c82d7c51a76cd0ce) — three named, commented thresholds.
- [`pycalphad/tests/test_workspace.py`](https://github.com/pycalphad/pycalphad/pull/713/files#diff-31e23fd0f866a3d4f331e4bd2bfa4840923e1f047fb204497622e549367b0cbc) — a second `debugging_output` smoke test on charged phases, and `@pytest.mark.solver` on both.

No public API change. `SolverResult`, `Workspace`, and `equilibrium()` are untouched, there is no `.pxd` change, and no `nogil` function was modified — so nothing runs unless you opt into `Solver(debugging_output=True)`.

## How I implemented it

### The analysis module (pure Python)

[`rank_diagnostics.py:104`](https://github.com/pycalphad/pycalphad/pull/713/files#diff-1c33cb97541fa0c0e8d9fe064d20ed54f66787106bf217936891b36f68c41619R104) — `analyze_rank(A, row_labels, col_labels, ...)` runs a single `np.linalg.svd`, derives rank from `s > rtol * s[0]`, and returns one of three things:

- `None` when the matrix is full rank and well conditioned — the important case, since it keeps the diagnostic signal rather than more firehose.
- [`IllConditioned`](https://github.com/pycalphad/pycalphad/pull/713/files#diff-1c33cb97541fa0c0e8d9fe064d20ed54f66787106bf217936891b36f68c41619R88) — full rank, but `s_min/s_max < ILL_CONDITIONED_RATIO`. A one-line softer note.
- [`RankDeficiency`](https://github.com/pycalphad/pycalphad/pull/713/files#diff-1c33cb97541fa0c0e8d9fe064d20ed54f66787106bf217936891b36f68c41619R60) — carries the left null space (`U[:, rank:]`, redundant *equations*) and the right null space (`Vt[rank:, :]`, undetermined *unknowns*).

[`_significant_terms`](https://github.com/pycalphad/pycalphad/pull/713/files#diff-1c33cb97541fa0c0e8d9fe064d20ed54f66787106bf217936891b36f68c41619R24) renders a null vector as a short labeled sum. Two details matter for output that is stable across runs: the largest-magnitude component is forced positive (otherwise printed signs flip with the LAPACK driver, since `-w` is as valid as `w`), and magnitudes are compared at the precision they are printed (`np.round(..., 3)`), so the ±1/√2 pair a structural degeneracy produces does not order or sign itself off a last-bit difference.

The module is defensive by construction — it is a diagnostic, and a diagnostic must never break the run it is diagnosing. Non-finite input (the NaN / ±1e19 sentinels a failed `lstsq` leaves behind) and `LinAlgError` both return `None` rather than raising; the raw values are already visible in the surrounding dump.

It is kept out of `minimizer.pyx` deliberately: report wording and thresholds can be tuned without a Cython rebuild, and the analysis is importable and inspectable on its own.

### Check 1 — global equilibrium matrix

[`minimizer.pyx:969`](https://github.com/pycalphad/pycalphad/pull/713/files#diff-a6c6b39719ed149e93ff2289892e639c8cb43e178de4cf1956cd6a7b7fd95457R969), inside the block that already prints `equilibrium matrix` and `equilibrium rhs`. Placement is load-bearing: the matrix is still intact here, and `lstsq` destroys it two lines later. It is square and O(1)-scaled, so no copy and no extra LAPACK call is needed. Both null spaces are reported — rows and columns say different things for this non-symmetric system.

[`equilibrium_system_labels`](https://github.com/pycalphad/pycalphad/pull/713/files#diff-a6c6b39719ed149e93ff2289892e639c8cb43e178de4cf1956cd6a7b7fd95457R843) reproduces the row/column order of `fill_equilibrium_system` and `construct_equilibrium_system` exactly: `stable_phase[...]` → `fixed_phase[...]` → `X_condition[k]` → `N_condition` for rows, `MU(EL)` → `NP(PHASE:csN)` → `d(T)`/`d(P)` for columns. Phase labels carry the composition set index so miscibility-gap duplicates of the same phase are distinguishable. This helper has to live in Cython because `SystemSpecification`'s index arrays are `cdef` with no `.pxd` visibility — it reads them and hands plain Python strings to the analyzer.

### Check 2 — per-phase constraint Jacobian

[`minimizer.pyx:956`](https://github.com/pycalphad/pycalphad/pull/713/files#diff-a6c6b39719ed149e93ff2289892e639c8cb43e178de4cf1956cd6a7b7fd95457R956), inside the existing per-compset debug loop. This is the check the work exists for: if the constraint Jacobians that border the phase matrix are not full *row* rank, the bordered matrix is structurally singular no matter what the Hessian block looks like — and `invert_matrix` will not notice. It is the numeric twin of the symbolic `matrix_rank` assertion in `test_model.py`.

The Jacobians are already materialized in `csst.cons_jac_tmp` / `csst.phase_local_jac_tmp` by `compute_phase_matrix` during `recompute`, so no recomputation is needed. Two details: the `spec.num_statevars` column offset (only the site-fraction columns border the phase matrix), and `want_col_nullspace=False` — for a wide `(n_cons × phase_dof)` block the interesting question is which *constraints* are redundant, not which site fractions are unconstrained, since many always are. Constraint rows are O(1)-scaled, so this check needs no equilibration and produces no false positives from clamped site fractions.

[`phase_constraint_labels`](https://github.com/pycalphad/pycalphad/pull/713/files#diff-a6c6b39719ed149e93ff2289892e639c8cb43e178de4cf1956cd6a7b7fd95457R901) and [`site_fraction_label`](https://github.com/pycalphad/pycalphad/pull/713/files#diff-a6c6b39719ed149e93ff2289892e639c8cb43e178de4cf1956cd6a7b7fd95457R888) name the rows `internal_cons[k]` / `phase_local_cons[k]` and shorten `Y(RUTILE,0,TI+2)` to `y[0:TI+2]`, since the phase name is already in the report title.

### Tests

[`test_workspace.py:546`](https://github.com/pycalphad/pycalphad/pull/713/files#diff-31e23fd0f866a3d4f331e4bd2bfa4840923e1f047fb204497622e549367b0cbcR546) adds `test_solver_with_debugging_output_charged_phases` on `TiO-17Yan.tdb` — the fixture #710 added. Charged phases carry internal constraints beyond the sublattice site-fraction sums, so this drives the constraint-Jacobian labeling and check, which the neutral `alzn_mey.tdb` smoke test does not reach. Both tests are marked `@pytest.mark.solver` per `docs/developer/contributing.rst`.

## Deviations from the plan

The plan is the [structure outline](https://cloud.humanlayer.com/artifacts/019fd3b5-7728-7a8f-bc84-e7f61134fb19), which specified three phases.

### Implemented as planned

- **Phase 1** (global equilibrium matrix) and **Phase 2** (per-phase constraint Jacobian) shipped exactly as written — same module layout, same function signatures, same call sites, same label vocabulary, same thresholds.

### Deviations/surprises

- **Phase 3 was implemented in full, evaluated, and then reverted by decision.** It would have added an ill-conditioning note on the *equilibrated* bordered phase matrix, to catch a singular Hessian block rather than a singular constraint border. It passed every automated check, but the evidence killed it:
  - Forcing `debugging_output=True` across the whole `-m solver` suite (all 38 tests passing, so every firing is a false positive by construction) gave **60 reports out of 11,167 checks** on healthy phases — 38 hard `RANK DEFICIENT`, 22 soft `ill-conditioned` — on `alfeo.tdb`'s `HALITE` and a Cu-Mg phase with a phase-local condition.
  - **All 60** had their null direction supported entirely on the constraint border (border weight > 0.95, zero on the Hessian block). Phase 3 exists to catch a singular Hessian, and across the entire suite it caught that **zero times**.
  - Mechanism: symmetric Jacobi equilibration scales column `j` by `1/sqrt(|H_jj|)`, and a site fraction pinned at `MIN_SITE_FRACTION = 1e-14` gives `H_jj ~ 8e17`, crushing that column by 1e-9. Those are exactly the columns distinguishing a charge-balance row from the sublattice-sum rows. Scaling cannot restore information a frozen site fraction has removed.
  - No threshold separates the false positives from real degeneracies — `HALITE`'s equilibrated ratio is 4.0e-18, below even the hard `RANK_DEFICIENCY_RTOL`.

  The equilibration *was* doing real work (unscaled, 90% of matrices would have reported `RANK DEFICIENT`) — it removes most of the artifact, not all of it. The outline anticipated this in an Open Question, whose stated fallback is the design discussion's "Option C — constraint block only". That fallback was taken. The working-tree changes were discarded with `git restore`, the extension rebuilt, and the suite re-verified.

### Additions not in plan

- None. `site_fraction_label` is a small extraction out of `phase_constraint_labels`, not new behavior.

### Items planned but not implemented

- **Phase 3**, as above. The Phase 3 section is retained in the outline as the record of what was tried and why it was dropped.
- **No committed unit tests for `analyze_rank`.** The design discussion chose smoke-tests-only and explicitly rejected committing unit tests of the analysis functions; each phase verified the math with a throwaway script instead. This is called out as the outline's first remaining Open Question — `_significant_terms` is a pure function on NumPy arrays with no solver dependency, so committing a small `test_rank_diagnostics.py` would cost a few dozen lines. Reviewer's call.

### Known follow-up, out of scope here

The one way to check a singular *Hessian* block without the constraint-border artifact is to project the Hessian onto the null space of the constraint Jacobian and test the reduced Hessian's rank. That sidesteps the frozen-site-fraction scaling problem entirely, but it is a different design from the equilibration approach and wants its own plan.

## How to verify it

```bash
git fetch origin add-rank-deficiency-detection-to-solver-debugging
git worktree add ../pycalphad-rank-diagnostics add-rank-deficiency-detection-to-solver-debugging
cd ../pycalphad-rank-diagnostics
uv sync   # rebuilds the Cython extension
```

### Automated Tests

```bash
uv run pytest pycalphad/tests/test_workspace.py -k debugging_output
uv run pytest pycalphad/tests/test_model.py -k charge_balance   # the model-level fix this mirrors
uv run pytest pycalphad                                          # full suite
```

Last local run: **315 passed, 2 skipped, 1 xfailed** (`filterwarnings = ["error"]` is active).

### Manual Testing

- [ ] **Healthy path stays silent.** A debug solve on `alzn_mey.tdb` prints no new lines:
  ```python
  from pycalphad import Database, Workspace, variables as v
  from pycalphad.core.solver import Solver
  wks = Workspace(database=Database("pycalphad/tests/databases/alzn_mey.tdb"),
                  components=["AL", "ZN", "VA"], phases=["FCC_A1", "HCP_A3", "LIQUID"],
                  conditions={v.N: 1, v.P: 1e5, v.T: 600, v.X("ZN"): 0.3},
                  solver=Solver(debugging_output=True))
  wks.get("GM")
  ```
- [ ] **The constraint check fires on a genuinely dependent constraint.** Subclass `Model` to append `2 * cons[0]` as an extra internal constraint on `alzn_mey.tdb`'s `FCC_A1` and rerun the above; it should print
  ```text
  !! RANK DEFICIENT phase matrix constraints: FCC_A1  rank 1/2  (s_min/s_max = 4.5e-17)
     dependent rows:        +0.894*internal_cons[0] -0.447*internal_cons[1]
  ```
  The 2:1 coefficient ratio is the expected null vector for a doubled row.
- [ ] **#710's pruning holds at runtime.** The `TiO-17Yan.tdb` debug run prints no constraint-rank block.
- [ ] **Output stays bounded.** Added output should be a small fraction of the existing matrix dumps on a hard run.

Note: the `(LA+3)2(O-2)6` phase from `test_inconsistent_charge_balance_constraint_is_kept` cannot be used for the second check — it is infeasible, so no composition set is ever created and `add_nearly_stable` raises `IndexError` before `solve_state` runs.

## Description for the changelog

`Solver(debugging_output=True)` now reports rank-deficient and ill-conditioned matrices in the Newton loop, naming the redundant equations and undetermined unknowns in CALPHAD terms instead of matrix indices.
