### PR TITLE
Handle plotting without tieline data

### DIFF
--- a/pycalphad/mapping/plotting.py
+++ b/pycalphad/mapping/plotting.py
@@ -156,7 +156,7 @@ def plot_tielines(ax, strategy: Union[BinaryStrategy, TernaryStrategy], x: v.Sta
     tieline_color : color
     """
     tieline_data = strategy.get_tieline_data(x, y)
-    if not tieline_data:
+    if len(tieline_data) == 0:
         return
     x_all = np.concatenate([st.x for st in tieline_data], axis=1)
     y_all = np.concatenate([st.y for st in tieline_data], axis=1)

--- a/pycalphad/mapping/plotting.py
+++ b/pycalphad/mapping/plotting.py
@@ -156,6 +156,8 @@ def plot_tielines(ax, strategy: Union[BinaryStrategy, TernaryStrategy], x: v.Sta
     tieline_color : color
     """
     tieline_data = strategy.get_tieline_data(x, y)
+    if not tieline_data:
+        return
     x_all = np.concatenate([st.x for st in tieline_data], axis=1)
     y_all = np.concatenate([st.y for st in tieline_data], axis=1)
     min_x_range = PLOT_TIELINE_AS_NODE_THRESHOLD * np.ptp(x_all)

--- a/pycalphad/tests/test_mapping_strategy.py
+++ b/pycalphad/tests/test_mapping_strategy.py
@@ -106,6 +106,26 @@ def test_ternary_strategy(load_database):
     new_num_nodes = len(strategy.node_queue.nodes)
     assert new_num_nodes == num_nodes + 1
 
+
+@select_database("crtiv_ghosh.tdb")
+def test_plot_ternary_without_tielines(load_database):
+    dbf = load_database()
+    comps = ["CR", "TI", "V", "VA"]
+    phases = ["BCC_A2", "HCP_A3", "LAVES_C15"]
+    conds = {
+        v.X("V"): (0, 0.2, 0.05),
+        v.X("TI"): (0, 1, 0.05),
+        v.T: 923,
+        v.P: 101325,
+    }
+    strategy = TernaryStrategy(dbf, comps, phases, conds)
+
+    assert strategy.get_tieline_data(v.X("V"), v.X("TI")) == []
+    ax = plot_ternary(strategy)
+    assert ax.name == "triangular"
+    plt.close(ax.figure)
+
+
 @select_database("alcocrni.tdb")
 def test_step_strategy_through_single_phase(load_database):
     dbf = load_database()

--- a/pycalphad/tests/test_mapping_strategy.py
+++ b/pycalphad/tests/test_mapping_strategy.py
@@ -111,11 +111,11 @@ def test_ternary_strategy(load_database):
 def test_plot_ternary_without_tielines(load_database):
     dbf = load_database()
     comps = ["CR", "TI", "V", "VA"]
-    phases = ["BCC_A2", "HCP_A3", "LAVES_C15"]
+    phases = ["LIQUID"]
     conds = {
-        v.X("V"): (0, 0.2, 0.05),
-        v.X("TI"): (0, 1, 0.05),
-        v.T: 923,
+        v.X("V"): (0, 1, 0.2),
+        v.X("TI"): (0, 1, 0.2),
+        v.T: 2000,
         v.P: 101325,
     }
     strategy = TernaryStrategy(dbf, comps, phases, conds)


### PR DESCRIPTION
## Summary

- return early from `plot_tielines` when a mapping strategy has no tieline data
- allow binary and ternary plotting to continue with axes, labels, limits, and legends for single-phase or not-yet-mapped strategies
- add a regression test that plots a real `TernaryStrategy` before `do_map()` has produced any tielines

## Testing

- `pytest pycalphad/tests/test_mapping_strategy.py::test_ternary_strategy pycalphad/tests/test_mapping_strategy.py::test_plot_ternary_without_tielines -q` (`2 passed`)
- `pytest pycalphad/tests/test_plot.py -q` (`3 passed`)

Closes #717
